### PR TITLE
fix: text area cursor got covered by the label placeholder when has no label

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/textarea/Textarea.tsx
+++ b/src/components/textarea/Textarea.tsx
@@ -52,6 +52,7 @@ const StyledTextarea = styled.textarea<TextareaType>`
   box-sizing: border-box;
   position: relative;
   padding: 0 ${theme.space16};
+  padding-top: ${theme.space8};
   transition: ${theme.transition};
   outline: none;
   order: 2;
@@ -71,6 +72,30 @@ const StyledTextarea = styled.textarea<TextareaType>`
   }
   &.has-label {
     padding: ${theme.space24} 4px ${theme.space8} ${theme.space16};
+
+    &.has-content,
+    &:focus {
+      &::placeholder {
+        opacity: 0.6;
+      }
+      & + ${StyledLabelInput} {
+        top: 11px;
+        transform: scale(0.8);
+        & + ${StyledBorder} {
+          &::before {
+            content: '';
+            position: absolute;
+            z-index: 2;
+            left: 0;
+            top: 0;
+            height: 25px;
+            right: 0;
+            background: white;
+            border-radius: ${theme.radius6};
+          }
+        }
+      }
+    }
   }
 
   ::placeholder {
@@ -78,29 +103,6 @@ const StyledTextarea = styled.textarea<TextareaType>`
     opacity: 0;
     color: ${theme.gray400};
     font-weight: 400;
-  }
-  &.has-content,
-  &:focus {
-    &::placeholder {
-      opacity: 0.6;
-    }
-    & + ${StyledLabelInput} {
-      top: 11px;
-      transform: scale(0.8);
-      & + ${StyledBorder} {
-        &::before {
-          content: '';
-          position: absolute;
-          z-index: 2;
-          left: 0;
-          top: 0;
-          height: 25px;
-          right: 0;
-          background: white;
-          border-radius: ${theme.radius6};
-        }
-      }
-    }
   }
 
   :focus {

--- a/src/components/textarea/__stories__/Textarea.stories.tsx
+++ b/src/components/textarea/__stories__/Textarea.stories.tsx
@@ -40,6 +40,35 @@ const Template: Story<TextareaProps> = ({
       }}
     >
       <div>
+        <Text type="bold-label">No label:</Text>
+
+        <StyledGroup style={{ display: 'flex', gap: '10px' }}>
+          <Textarea
+            error={error}
+            helpText={helpText}
+            value=""
+            onChange={() => {}}
+          />
+          <Input value="" onChange={() => {}} />
+        </StyledGroup>
+      </div>
+      <div>
+        <Text type="bold-label">No label, has content:</Text>
+
+        <StyledGroup style={{ display: 'flex', gap: '10px' }}>
+          <Textarea
+            error={error}
+            helpText={helpText}
+            value={value}
+            onChange={e => setValue(e.target.value)}
+          />
+          <Input
+            value={value?.toString() || ''}
+            onChange={e => setValue(e.target.value)}
+          />
+        </StyledGroup>
+      </div>
+      <div>
         <Text type="bold-label">No placeholder:</Text>
 
         <StyledGroup style={{ display: 'flex', gap: '10px' }}>


### PR DESCRIPTION
## Issue

<!-- [Jira issue description](url) -->
<!-- Example:
[3106 - Loup Charmant - Need dashboard switched from Hello](https://myzonos.atlassian.net/browse/DM-550)
-->
- `Textarea` component when no label specified, the cursor will not appear even when the component is focus

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR fixes the issue by showing the label cover only when there is a `label` prop in `Textarea` component.
<img width="1272" alt="image" src="https://user-images.githubusercontent.com/17950626/235235709-e47f2596-afc9-49a6-ba10-4d6e849e7e6b.png">

## Todo

- [ ] Bump version and add tag
