### PR TITLE
Refactor/make select option more flexible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ __diff_output__
 /playwright-report/
 /playwright/.cache/
 snapshots
+
+# Ignore _private_* folders (for some scratchpad scripts)
+_private_*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/radio/RadioGroup.tsx
+++ b/src/components/radio/RadioGroup.tsx
@@ -6,13 +6,8 @@ import styled from 'styled-components';
 import { Radio } from './Radio';
 
 const RadioContainer = styled.div`
-  * {
-    margin-bottom: ${theme.space16};
-  }
-
-  *:last-of-type {
-    margin-bottom: 0;
-  }
+  display: flex;
+  gap: ${theme.space8};
 `;
 
 export type RadioGroupItem<T extends string = string> = {
@@ -21,17 +16,19 @@ export type RadioGroupItem<T extends string = string> = {
 };
 
 export type RadioGroupProps<T extends string = string> = {
+  className?: string;
+  disabled?: boolean;
   initialValue?: string;
   items: RadioGroupItem<T>[];
-  disabled?: boolean;
   onChange: (newValue: T) => void;
 };
 
 export const RadioGroup = <T extends string = string>({
-  items,
+  className,
   disabled,
-  onChange,
   initialValue,
+  items,
+  onChange,
 }: RadioGroupProps<T>) => {
   const [activeIndex, setActiveIndex] = useState(-1);
 
@@ -60,5 +57,5 @@ export const RadioGroup = <T extends string = string>({
     />
   ));
 
-  return <RadioContainer>{radios}</RadioContainer>;
+  return <RadioContainer className={className}>{radios}</RadioContainer>;
 };

--- a/src/components/select/CountryMultiSelect.tsx
+++ b/src/components/select/CountryMultiSelect.tsx
@@ -59,7 +59,7 @@ export const MenuList = <
 };
 
 export interface CountryMultiSelectProps<
-  Option extends IOption = IOption,
+  Option extends IOption<string> = IOption<string>,
   IsMulti extends true = true,
   Group extends GroupBase<Option> = GroupBase<Option>
 > extends Omit<

--- a/src/components/select/__stories__/Select.stories.tsx
+++ b/src/components/select/__stories__/Select.stories.tsx
@@ -250,3 +250,31 @@ export const ScrollableDialogSelect = () => {
     </CenteredDiv>
   );
 };
+
+export const SelectWithNumberOptions = () => {
+  const [value, setValue] = useState<number>(1);
+  const options = [
+    {
+      label: 'US Dollar (USD)',
+      icon: <FileIcon size={14} />,
+      value: 1,
+    },
+    {
+      icon: <FileIcon size={14} />,
+      label: 'European Euro (EUR)',
+      value: 2,
+    },
+  ];
+  return (
+    <div>
+      <Select
+        icon={<FileIcon size={20} />}
+        onChange={item => item?.value && setValue(item.value)}
+        label="Currencies"
+        value={options.find(option => option.value === value) || null}
+        options={options}
+      />
+      Selected value: {value} (typeof value: {typeof value})
+    </div>
+  );
+};

--- a/src/types/IOption.ts
+++ b/src/types/IOption.ts
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 
-export interface IOption<V extends string = string> {
+export interface IOption<V extends string | number = string | number> {
   icon?: ReactNode;
   isDisabled?: boolean;
   label: string;


### PR DESCRIPTION
## Issue

<!-- [Jira issue description](url) -->
<!-- Example:
[3106 - Loup Charmant - Need dashboard switched from Hello](https://myzonos.atlassian.net/browse/DM-550)
-->
- Select component current state only allow `options` with value `string` to be passed in, and in some scenarios, we have `options` with value is `id`, which is `number`. We need to make it to allow that.

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR refactors to make the select `options` to allow value with `number` type and a story for that in `Select` section
<img width="1261" alt="image" src="https://github.com/Zonos/amino/assets/17950626/aceb0f1e-9c46-4415-a3b0-82be27ddb1d7">


## Todo

- [ ] Bump version and add tag
