### PR TITLE
Fix (theme): Dialog and Coversheet revert to use createPortal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "4.4.9",
+  "version": "4.4.10",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/cover-sheet/CoverSheet.tsx
+++ b/src/components/cover-sheet/CoverSheet.tsx
@@ -98,11 +98,7 @@ export const CoverSheet = ({
     if (!document?.body) {
       return;
     }
-    if (open) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = 'auto';
-    }
+    document.body.style.overflow = open ? 'hidden' : 'auto';
   }, [open]);
 
   if (typeof document !== 'undefined') {

--- a/src/components/cover-sheet/CoverSheet.tsx
+++ b/src/components/cover-sheet/CoverSheet.tsx
@@ -1,9 +1,12 @@
-import { type ReactNode, useEffect, useState } from 'react';
+import { type ReactNode, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 
 import { AnimatePresence, motion } from 'framer-motion';
 import { Text } from 'src/components/text/Text';
 import { RemoveIcon } from 'src/icons/RemoveIcon';
 import { theme } from 'src/styles/constants/theme';
+import type { Theme } from 'src/types';
+import { useAminoTheme } from 'src/utils/hooks/useAminoTheme';
 import styled from 'styled-components';
 
 import { Button } from '../button/Button';
@@ -21,6 +24,7 @@ const StyledDialog = styled(motion.div)`
   top: 0;
   width: 100vw;
   height: 100vh;
+  color: ${theme.textColor};
 
   @media print {
     height: unset;
@@ -65,6 +69,7 @@ export type CoverSheetProps = {
   /** used for setting id of the wrapper of where the action will be located */
   actionWrapperId?: string;
   actions?: ReactNode;
+  themeOverride?: Theme;
 };
 
 export const CoverSheet = ({
@@ -75,12 +80,9 @@ export const CoverSheet = ({
   children,
   actionWrapperId = '__cover-sheet-actions',
   actions,
+  themeOverride,
 }: CoverSheetProps) => {
-  const [isMounted, setIsMounted] = useState(false);
-
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
+  const { aminoTheme } = useAminoTheme();
 
   useEffect(() => {
     if (typeof document === 'undefined') {
@@ -94,37 +96,41 @@ export const CoverSheet = ({
     }
   }, [actionWrapperId]);
 
-  if (!isMounted) {
-    return null;
+  if (typeof document !== 'undefined') {
+    const body = document.querySelector('body');
+    if (body) {
+      return createPortal(
+        <AnimatePresence>
+          {open && (
+            <StyledDialog
+              className={className}
+              data-theme={themeOverride || aminoTheme}
+              transition={{ ease: [0.4, 0, 0.2, 1], duration: 0.35 }}
+              initial={{ opacity: 0, translateY: 10 }}
+              animate={{ opacity: 1, translateY: 0 }}
+              exit={{ opacity: 0, translateY: 5 }}
+            >
+              <Header>
+                <StyledCloseButton
+                  icon={<RemoveIcon size={20} />}
+                  onClick={onClose}
+                />
+                <StyledHeader type="header">{label}</StyledHeader>
+                <div id={actionWrapperId}>
+                  {actions && (
+                    <CoverSheetActions coverSheetActionId={actionWrapperId}>
+                      {actions}
+                    </CoverSheetActions>
+                  )}
+                </div>
+              </Header>
+              <Content>{children}</Content>
+            </StyledDialog>
+          )}
+        </AnimatePresence>,
+        body
+      );
+    }
   }
-
-  return (
-    <AnimatePresence>
-      {open && (
-        <StyledDialog
-          className={className}
-          transition={{ ease: [0.4, 0, 0.2, 1], duration: 0.35 }}
-          initial={{ opacity: 0, translateY: 10 }}
-          animate={{ opacity: 1, translateY: 0 }}
-          exit={{ opacity: 0, translateY: 5 }}
-        >
-          <Header>
-            <StyledCloseButton
-              icon={<RemoveIcon size={20} />}
-              onClick={onClose}
-            />
-            <StyledHeader type="header">{label}</StyledHeader>
-            <div id={actionWrapperId}>
-              {actions && (
-                <CoverSheetActions coverSheetActionId={actionWrapperId}>
-                  {actions}
-                </CoverSheetActions>
-              )}
-            </div>
-          </Header>
-          <Content>{children}</Content>
-        </StyledDialog>
-      )}
-    </AnimatePresence>
-  );
+  return null;
 };

--- a/src/components/cover-sheet/CoverSheet.tsx
+++ b/src/components/cover-sheet/CoverSheet.tsx
@@ -94,6 +94,17 @@ export const CoverSheet = ({
     }
   }, [actionWrapperId]);
 
+  useEffect(() => {
+    if (!document?.body) {
+      return;
+    }
+    if (open) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'auto';
+    }
+  }, [open]);
+
   if (typeof document !== 'undefined') {
     const body = document.querySelector('body');
     if (body) {

--- a/src/components/cover-sheet/CoverSheet.tsx
+++ b/src/components/cover-sheet/CoverSheet.tsx
@@ -40,9 +40,7 @@ const StyledHeader = styled(Text)`
   flex-grow: 1;
 `;
 const Header = styled.header`
-  background: ${theme.surfaceColor};
   border-bottom: ${theme.border};
-
   padding: ${theme.space16} ${theme.space24};
   display: flex;
   align-items: center;

--- a/src/components/dialog/_BaseDialog.tsx
+++ b/src/components/dialog/_BaseDialog.tsx
@@ -1,9 +1,11 @@
-import React, { type ReactNode, useEffect, useState } from 'react';
+import React, { type ReactNode, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 
 import { AnimatePresence, motion } from 'framer-motion';
 import { Backdrop } from 'src/components/backdrop/Backdrop';
 import { theme } from 'src/styles/constants/theme';
 import type { Theme } from 'src/types/Theme';
+import { useAminoTheme } from 'src/utils/hooks/useAminoTheme';
 import styled from 'styled-components';
 
 const DialogLayout = styled.div`
@@ -20,7 +22,7 @@ const DialogLayout = styled.div`
 `;
 
 const Popup = styled(motion.div)<{ width: number; noBorder?: boolean }>`
-  position: fixed;
+  position: relative;
   z-index: 1001;
   background: ${theme.surfaceColor};
   width: ${p => p.width}px;
@@ -57,11 +59,7 @@ export const BaseDialog = ({
   closeOnEsc = true,
   noBorder = false,
 }: BaseDialogProps) => {
-  const [isMounted, setIsMounted] = useState(false);
-
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
+  const { aminoTheme } = useAminoTheme();
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
     if (onClose && closeOnEsc && event.key === 'Escape') {
@@ -69,47 +67,56 @@ export const BaseDialog = ({
     }
   };
 
-  if (!isMounted) {
-    return null;
-  }
+  const dialogBackdrop = useRef<HTMLDivElement>(null);
 
-  return (
-    <AnimatePresence>
-      {open && (
-        <Backdrop
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 0.65 }}
-          exit={{ opacity: 0 }}
-          transition={{ duration: 0.3 }}
-          key="dialog-backdrop"
-          data-theme={themeOverride}
-        />
-      )}
-      {open && (
-        <DialogLayout
-          data-theme={themeOverride}
-          onClick={() => onClose && closeOnBlur && onClose()}
-          onKeyDown={handleKeyDown}
-          tabIndex={-1}
-        >
-          <Popup
-            className={className}
-            transition={{ ease: [0.4, 0, 0.2, 1], duration: 0.3 }}
-            initial={{ opacity: 0, scale: 0.95 }}
-            animate={{ opacity: 1, scale: 1 }}
-            exit={{ opacity: 0, scale: 0.95 }}
-            key="dialog"
-            width={width || 444}
-            noBorder={noBorder}
-            onClick={e => {
-              // Prevent dialog from closing when clicking in the dialog
-              e.stopPropagation();
-            }}
+  // Focus the backdrop so we can listen for keypresses ('escape' to close)
+  useEffect(() => {
+    if (!dialogBackdrop.current?.contains(document.activeElement)) {
+      dialogBackdrop.current?.focus();
+    }
+  }, [open]);
+
+  if (typeof document !== 'undefined') {
+    return createPortal(
+      <AnimatePresence>
+        {open && (
+          <Backdrop
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 0.65 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.3 }}
+            key="dialog-backdrop"
+            data-theme={themeOverride || aminoTheme}
+          />
+        )}
+        {open && (
+          <DialogLayout
+            data-theme={themeOverride || aminoTheme}
+            onClick={() => onClose && closeOnBlur && onClose()}
+            onKeyDown={handleKeyDown}
+            tabIndex={-1}
           >
-            {children}
-          </Popup>
-        </DialogLayout>
-      )}
-    </AnimatePresence>
-  );
+            <Popup
+              className={className}
+              transition={{ ease: [0.4, 0, 0.2, 1], duration: 0.3 }}
+              initial={{ opacity: 0, scale: 0.95 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.95 }}
+              key="dialog"
+              width={width || 444}
+              noBorder={noBorder}
+              onClick={e => {
+                // Prevent dialog from closing when clicking in the dialog
+                e.stopPropagation();
+              }}
+            >
+              {children}
+            </Popup>
+          </DialogLayout>
+        )}
+      </AnimatePresence>,
+      document.querySelector('body')!
+    );
+  }
+  return null;
 };

--- a/src/components/dialog/_BaseDialog.tsx
+++ b/src/components/dialog/_BaseDialog.tsx
@@ -69,10 +69,19 @@ export const BaseDialog = ({
 
   const dialogBackdrop = useRef<HTMLDivElement>(null);
 
-  // Focus the backdrop so we can listen for keypresses ('escape' to close)
+  // Focus the backdrop so we can listen for keypress ('escape' to close)
   useEffect(() => {
     if (!dialogBackdrop.current?.contains(document.activeElement)) {
       dialogBackdrop.current?.focus();
+    }
+
+    if (!document?.body) {
+      return;
+    }
+    if (open) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'auto';
     }
   }, [open]);
 

--- a/src/components/dialog/_BaseDialog.tsx
+++ b/src/components/dialog/_BaseDialog.tsx
@@ -78,11 +78,7 @@ export const BaseDialog = ({
     if (!document?.body) {
       return;
     }
-    if (open) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = 'auto';
-    }
+    document.body.style.overflow = open ? 'hidden' : 'auto';
   }, [open]);
 
   if (typeof document !== 'undefined') {


### PR DESCRIPTION
## Jira issue

[Dialog backdrop position](https://myzonos.atlassian.net/jira/software/projects/FE/boards/145?selectedIssue=FE-273)
[Theme bug fixes](https://myzonos.atlassian.net/jira/software/projects/FE/boards/145?selectedIssue=FE-270)

## Description

This PR brings back the react portal to the dialog and coversheet components. To get the data-theme to apply, we are using the useAminoTheme hook to get the theme if there is no `themeOverride` present. Scrolling is also disabled when the dialog or coversheet is open.

## Todo

- [x] Bump version and add tag
