### PR TITLE
stories: mdx doc stories for theme usage

### DIFF
--- a/.storybook/buildStories.ts
+++ b/.storybook/buildStories.ts
@@ -1,3 +1,4 @@
+import { glob } from 'glob';
 import { capitalize } from '../build-utils/css/utils/capitalize';
 
 // https://storybook.js.org/docs/react/configure/overview#with-a-configuration-object
@@ -26,7 +27,7 @@ type StoryEntry = StorySpecifier & {
 const removedPrefixes = /(components|icons|styles)\//;
 
 const pathRegex =
-  /(?<fullFolder>..\/src(\/(?<folder>.*))?\/__stories__)\/(?<fileName>.*)\.stories\.tsx/i;
+  /(?<fullFolder>..\/src(\/(?<folder>.*))?\/__stories__)\/(?<fullFileName>(?<fileName>.*)\.stories\.(tsx|mdx))/i;
 
 // The titlePrefix defines the folder structure in the sidebar
 const getTitlePrefix = ({
@@ -60,7 +61,7 @@ const getTitlePrefix = ({
 const getStoryEntry = (storyPath: string): StoryEntry => {
   const matched = storyPath.match(pathRegex);
 
-  const { fullFolder, folder, fileName } = matched?.groups || {};
+  const { fullFolder, folder, fileName, fullFileName } = matched?.groups || {};
 
   const titlePrefix = getTitlePrefix({ folder, fileName });
 
@@ -68,7 +69,7 @@ const getStoryEntry = (storyPath: string): StoryEntry => {
     directory: fullFolder,
     fileName,
     titlePrefix,
-    files: `${fileName}.stories.tsx`,
+    files: fullFileName,
   };
 };
 
@@ -85,3 +86,11 @@ export const buildStories = (stories: string[]) =>
       const storyNameB = getTitle(b);
       return storyNameA.localeCompare(storyNameB);
     });
+
+export const getStories = () => {
+  const stories = glob.sync('../src/**/__stories__/*.stories.{tsx,mdx}', {
+    cwd: __dirname,
+  });
+  const storyPaths = buildStories(stories);
+  return storyPaths;
+};

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,16 +1,9 @@
 import type { StorybookConfig } from '@storybook/react-webpack5';
-import { glob } from 'glob';
 import path from 'path';
-import { buildStories } from './buildStories';
+import { getStories } from './buildStories';
 
-const findStories = () => {
-  const stories = glob.sync('../src/**/__stories__/*.stories.tsx', {
-    cwd: __dirname,
-  });
-  return buildStories(stories);
-};
 const config: StorybookConfig = {
-  stories: findStories(),
+  stories: getStories(),
   framework: {
     name: '@storybook/react-webpack5',
     options: {},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "4.4.11",
+  "version": "4.4.12",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/theme-select/__stories__/ThemeSelect.stories.mdx
+++ b/src/components/theme-select/__stories__/ThemeSelect.stories.mdx
@@ -5,18 +5,15 @@ import { ThemeSelect } from '../ThemeSelect';
 
 # Theme
 
-At the root of your app, use the current theme and wrap all contents in a node with `data-theme={aminoTheme}`.
-
-Due to some components that use portals (dialogs...), the theme should also be applied to the whole document body.
-
+At the root of your app, all you need to do is call `useAminoTheme({ root: true })`. This will automatically set a data attribute on the HTML body that matches the current theme. All children will inherit the theme.
 
 ```typescript
-export const Layout = () => {
-  const { aminoTheme } = useAminoTheme();
-  useEffect(() => {
-    document.body.dataset.theme = aminoTheme;
-  }, [aminoTheme]);
+import { useAminoTheme } from "@zonos/amino/utils/hooks/useAminoTheme";
 
-  return <div data-theme={aminoTheme}>YOUR CONTENT HERE</div>;
+
+export const Layout = () => {
+  useAminoTheme({ root: true });
+
+  return <div>{YOUR_CONTENT_HERE}</div>;
 };
 ```

--- a/src/components/theme-select/__stories__/ThemeSelect.stories.mdx
+++ b/src/components/theme-select/__stories__/ThemeSelect.stories.mdx
@@ -1,0 +1,22 @@
+import { Meta } from '@storybook/blocks';
+import { ThemeSelect } from '../ThemeSelect';
+
+<Meta title="ThemeSelect/Usage" component={ThemeSelect} />
+
+# Theme
+
+At the root of your app, use the current theme and wrap all contents in a node with `data-theme={aminoTheme}`.
+
+Due to some components that use portals (dialogs...), the theme should also be applied to the whole document body.
+
+
+```typescript
+export const Layout = () => {
+  const { aminoTheme } = useAminoTheme();
+  useEffect(() => {
+    document.body.dataset.theme = aminoTheme;
+  }, [aminoTheme]);
+
+  return <div data-theme={aminoTheme}>YOUR CONTENT HERE</div>;
+};
+```

--- a/src/components/theme-select/__stories__/ThemeSelect.stories.tsx
+++ b/src/components/theme-select/__stories__/ThemeSelect.stories.tsx
@@ -24,10 +24,10 @@ const Template: StoryFn = ({ type }: Props) => (
   </Wrapper>
 );
 
-export const ThemeSelect = Template.bind({});
+export const Default = Template.bind({});
 
-export const ThemeSelectCards = Template.bind({});
-ThemeSelectCards.args = { type: 'cards' };
+export const Cards = Template.bind({});
+Cards.args = { type: 'cards' };
 
-export const ThemeSelectToggle = Template.bind({});
-ThemeSelectToggle.args = { type: 'toggle' };
+export const Toggle = Template.bind({});
+Toggle.args = { type: 'toggle' };

--- a/src/utils/hooks/useAminoTheme.ts
+++ b/src/utils/hooks/useAminoTheme.ts
@@ -1,12 +1,27 @@
+import { useEffect } from 'react';
+
 import type { Theme } from 'src/types';
 
 import { useStorage } from './useStorage';
 
-export const useAminoTheme = () => {
+type Params = {
+  /** Whether to modify the HTML body */
+  root: boolean;
+};
+
+export const useAminoTheme = (props?: Params) => {
+  const isRoot = !!props?.root;
   const [aminoTheme, setAminoTheme] = useStorage<Theme, 'amino:theme'>({
     defaultValue: 'day',
     key: 'amino:theme',
     type: 'local',
   });
+
+  useEffect(() => {
+    if (isRoot) {
+      document.body.dataset.theme = aminoTheme;
+    }
+  }, [aminoTheme, isRoot]);
+
   return { aminoTheme, setAminoTheme };
 };


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR adds a doc story for theme usage.

~No version bump as these are internal story only changes.~ Hook has an added optional prop to modify the root.

Link: https://amino-git-feat-theme-usage-docs-zonos.vercel.app/?path=/docs/amino-themeselect-usage--docs

I went back and forth on the doc (mdx) story loading, but I figured it would be too specific and rare to have custom logic for finding those stories. As a result, if you want to add a doc story, then you will have to manually set the title.
