### PR TITLE
fix(GraphMatrix): workaround for cursor jumping

### DIFF
--- a/src/components/graph-matrix/GraphMatrix.tsx
+++ b/src/components/graph-matrix/GraphMatrix.tsx
@@ -106,6 +106,7 @@ export const GraphMatrix = ({
   const [cachingKey] = useState('first-time');
   const [showTable, setShowTable] = useState(false);
   const [splitPanelSizes, setSplitPanelSizes] = useState([1, 0]);
+  const [isClientRendering, setIsClientRendering] = useState(false);
 
   const [operationName, setOperationName] = useState('');
   const { graphiqlFetcher, resultData, isLoading } = useGraphiqlFetcher({
@@ -119,6 +120,10 @@ export const GraphMatrix = ({
   const storage = useGraphiqlStorage({
     defaultSchema: schemaName,
   });
+
+  useEffect(() => {
+    setIsClientRendering(true);
+  }, []);
 
   useEffect(() => {
     /** Detect if is fetching data in graphiql explorer when hitting "Play" button  */
@@ -176,41 +181,43 @@ export const GraphMatrix = ({
         collapseAll={!showTable}
       >
         <StyleTableWrap>
-          <GraphiQL
-            fetcher={graphiqlFetcher}
-            onEditOperationName={setOperationName}
-            onEditQuery={onEditQuery}
-            onEditVariables={onEditVariables}
-            plugins={[graphMatrixPlugin]}
-            query={query}
-            variables={variables}
-            schema={schema}
-            toolbar={{
-              additionalContent: (
-                <>
-                  <ToolbarButton
-                    label={showTable ? 'Hide table' : 'Show table'}
-                    onClick={() => setShowTable(!showTable)}
-                  >
-                    {showTable ? (
-                      <EyeOffIcon color="red600" />
-                    ) : (
-                      <EyeIcon color="gray400" />
-                    )}
-                  </ToolbarButton>
-                  {customToolbar}
-                </>
-              ),
-            }}
-            storage={storage}
-          >
-            <GraphiqlContextWrapper
-              setExecutionContext={setExecutionContext}
-              setResponseEditorContext={setResponseEditorContext}
+          {isClientRendering && (
+            <GraphiQL
+              fetcher={graphiqlFetcher}
+              onEditOperationName={setOperationName}
+              onEditQuery={onEditQuery}
+              onEditVariables={onEditVariables}
+              plugins={[graphMatrixPlugin]}
+              query={query}
+              variables={variables}
+              schema={schema}
+              toolbar={{
+                additionalContent: (
+                  <>
+                    <ToolbarButton
+                      label={showTable ? 'Hide table' : 'Show table'}
+                      onClick={() => setShowTable(!showTable)}
+                    >
+                      {showTable ? (
+                        <EyeOffIcon color="red600" />
+                      ) : (
+                        <EyeIcon color="gray400" />
+                      )}
+                    </ToolbarButton>
+                    {customToolbar}
+                  </>
+                ),
+              }}
+              storage={storage}
             >
-              <GraphiQL.Footer />
-            </GraphiqlContextWrapper>
-          </GraphiQL>
+              <GraphiqlContextWrapper
+                setExecutionContext={setExecutionContext}
+                setResponseEditorContext={setResponseEditorContext}
+              >
+                <GraphiQL.Footer />
+              </GraphiqlContextWrapper>
+            </GraphiQL>
+          )}
         </StyleTableWrap>
         {renderTableData()}
       </SplitPanel>


### PR DESCRIPTION
## Jira issue

[FE-221 - Amino: GraphMatrix - Graphiql cursor jump when typing fast](https://myzonos.atlassian.net/browse/FE-221)


## Description

This PR implements a workaround to prevent the cursor from jumping to the beginning of the query window when typing quickly
this fix comes from:
https://github.com/graphql/graphiql/issues/2368#issuecomment-1176119332 possibly doesn't work all the time, GitHub issue is not being worked on as GraphiQL is looking to reimplement the Explorer plugin soon

## Todo

- [ ] Bump version and add tag
