### PR TITLE
Refactor/amino design for single classification

### DIFF
--- a/src/components/drop-zone/DropZone.tsx
+++ b/src/components/drop-zone/DropZone.tsx
@@ -7,6 +7,7 @@ import { theme } from 'src/styles/constants/theme';
 import { type UploadedFile } from 'src/types/UploadedFile';
 import styled from 'styled-components';
 
+import { ImageAvatar } from '../avatar/ImageAvatar';
 import { Button } from '../button/Button';
 import { Spinner } from '../spinner/Spinner';
 import { Text } from '../text/Text';
@@ -183,7 +184,11 @@ export const DropZone = ({
   const renderFiles = () =>
     uploadedFiles.map((file, index) => (
       <UploadedFileRow key={file.name}>
-        <FileDuotoneIcon />
+        {file.imageUrl ? (
+          <ImageAvatar imageUrl={file.imageUrl} shape="rounded" />
+        ) : (
+          <FileDuotoneIcon />
+        )}
         <UploadedFileInfoWrapper>
           <Text color="gray1200" type="label">
             {file.name}

--- a/src/components/drop-zone/__stories__/DropZone.stories.tsx
+++ b/src/components/drop-zone/__stories__/DropZone.stories.tsx
@@ -73,6 +73,8 @@ export const DropZone: StoryFn<typeof DropZoneComponent> = props => {
       instructionText="Drop your files here"
       onRemoveFile={index => handleRemoveFile(index)}
       uploadedFiles={files.map(f => ({
+        // get preview image from localfile or remote url
+        imageUrl: URL.createObjectURL(f),
         name: f.name,
         size: `${f.size} bytes`,
       }))}

--- a/src/components/file-upload/FileUpload.tsx
+++ b/src/components/file-upload/FileUpload.tsx
@@ -3,7 +3,6 @@ import { type DropzoneOptions, useDropzone } from 'react-dropzone';
 import { Text } from 'src/components/text/Text';
 import { RemoveCircleDuotoneIcon } from 'src/icons/RemoveCircleDuotoneIcon';
 import { theme } from 'src/styles/constants/theme';
-import type { UploadedFile } from 'src/types/UploadedFile';
 import styled from 'styled-components';
 
 import { Button } from '../button/Button';
@@ -82,6 +81,11 @@ const RemoveFileButton = styled(Button)`
   }
 `;
 
+type UploadFileNoImage = {
+  name: string;
+  size: string;
+};
+
 export type FileUploadProps = {
   className?: string;
   /**
@@ -104,7 +108,7 @@ export type FileUploadProps = {
    */
   loadingText?: string;
   /** Display file info if uploaded file property has data */
-  uploadedFile: UploadedFile | null;
+  uploadedFile: UploadFileNoImage | null;
   onRemoveFile?: () => void;
 };
 

--- a/src/components/tag/Tag.tsx
+++ b/src/components/tag/Tag.tsx
@@ -4,54 +4,90 @@ import { RemoveIcon } from 'src/icons/RemoveIcon';
 import { theme } from 'src/styles/constants/theme';
 import styled from 'styled-components';
 
+type TagSize = 'base' | 'lg';
+
 export interface TagProps {
   children?: ReactNode | string;
   className?: string;
   icon?: ReactNode;
   iconRight?: boolean;
+  size?: TagSize;
+  onClick?: () => void;
   onClose: () => void;
 }
 
-const TagWrapper = styled.div`
-  display: inline-block;
-`;
-const StyledTag = styled.button<Omit<TagProps, 'onClose'>>`
-  display: flex;
-  gap: ${theme.space8};
-  font-size: ${theme.typeScaleBase};
-  font-weight: normal;
-  padding: 3px ${theme.space16};
-  text-align: center;
-  font-weight: 500;
+const TagWrapper = styled.div<{ $size: TagSize }>`
+  display: inline-flex;
   // default background color (gray)
   background-color: ${theme.gray200};
-  color: ${theme.gray800};
   border-radius: ${theme.radius6};
+
+  height: ${p => (p.$size === 'base' ? theme.space20 : theme.space24)};
+`;
+
+const StyledTagLeft = styled.button<Omit<TagProps, 'onClose'>>`
+  display: inline-flex;
+  font-size: ${p => (p.size === 'base' ? theme.fontSizeS : theme.fontSizeBase)};
+  background-color: ${theme.gray200};
+  border-radius: ${theme.radius6} 0 0 ${theme.radius6};
+  gap: ${theme.space8};
+  font-weight: normal;
+  padding: 0 ${theme.space8};
+
+  color: ${theme.gray800};
   align-items: center;
-  &:hover {
-    background-color: ${theme.gray300};
+  text-align: center;
+  font-weight: 500;
+  &:focus {
+    outline: none;
   }
   p {
     margin: 0;
-    font-weight: 700;
+    font-weight: 600;
   }
+
   svg {
     order: ${({ iconRight }) => (iconRight ? '2' : '')};
   }
 `;
+const StyledTagRight = styled.button`
+  border-radius: 0 ${theme.radius6} ${theme.radius6} 0;
+  display: inline-flex;
+  align-items: center;
+  padding: ${theme.space4};
+`;
 
+const StyledRemoveBtn = styled.div`
+  display: flex;
+
+  ${StyledTagRight}:hover & {
+    background-color: ${theme.gray300};
+    border-radius: 50%;
+  }
+`;
 export const Tag = ({
   children,
   className,
   icon,
   iconRight,
+  onClick,
   onClose,
+  size = 'base',
 }: TagProps) => (
-  <TagWrapper className={className}>
-    <StyledTag iconRight={iconRight} onClick={onClose} type="button">
+  <TagWrapper $size={size} className={className}>
+    <StyledTagLeft
+      iconRight={iconRight}
+      onClick={onClick}
+      size={size}
+      type="button"
+    >
       {icon}
       <p>{children}</p>
-      <RemoveIcon size={16} />
-    </StyledTag>
+    </StyledTagLeft>
+    <StyledTagRight onClick={onClose} type="button">
+      <StyledRemoveBtn>
+        <RemoveIcon size={14} />
+      </StyledRemoveBtn>
+    </StyledTagRight>
   </TagWrapper>
 );

--- a/src/components/tag/__stories__/Tag.stories.tsx
+++ b/src/components/tag/__stories__/Tag.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryFn } from '@storybook/react';
+import { VStack } from 'src/components/stack/VStack';
 import { type TagProps, Tag } from 'src/components/tag/Tag';
 import { CubeIcon } from 'src/icons/CubeIcon';
 
@@ -19,9 +20,24 @@ const Template: StoryFn<TagProps> = ({
   iconRight,
   onClose,
 }: TagProps) => (
-  <Tag icon={icon} iconRight={iconRight} onClose={onClose}>
-    {children}
-  </Tag>
+  <VStack>
+    <div>
+      <p>
+        Size: <b>base</b>
+      </p>
+      <Tag icon={icon} iconRight={iconRight} onClose={onClose} size="base">
+        {children}
+      </Tag>
+    </div>
+    <div>
+      <p>
+        Size: <b>lg</b>
+      </p>
+      <Tag icon={icon} iconRight={iconRight} onClose={onClose} size="lg">
+        {children}
+      </Tag>
+    </div>
+  </VStack>
 );
 
 export const Default = Template.bind({});
@@ -38,7 +54,7 @@ Default.parameters = {
 export const WithIcon = Template.bind({});
 WithIcon.args = {
   children: <span>HS code for Brazil</span>,
-  icon: <CubeIcon size={20} />,
+  icon: <CubeIcon size={16} />,
 };
 WithIcon.parameters = {
   design: {

--- a/src/components/tag/__stories__/Tag.stories.tsx
+++ b/src/components/tag/__stories__/Tag.stories.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import type { Meta, StoryFn } from '@storybook/react';
 import { VStack } from 'src/components/stack/VStack';
 import { type TagProps, Tag } from 'src/components/tag/Tag';
@@ -19,26 +21,59 @@ const Template: StoryFn<TagProps> = ({
   icon,
   iconRight,
   onClose,
-}: TagProps) => (
-  <VStack>
-    <div>
-      <p>
-        Size: <b>base</b>
-      </p>
-      <Tag icon={icon} iconRight={iconRight} onClose={onClose} size="base">
-        {children}
-      </Tag>
-    </div>
-    <div>
-      <p>
-        Size: <b>lg</b>
-      </p>
-      <Tag icon={icon} iconRight={iconRight} onClose={onClose} size="lg">
-        {children}
-      </Tag>
-    </div>
-  </VStack>
-);
+}: TagProps) => {
+  const [tagSectionClicked, settagSectionClicked] = useState<
+    'whole' | 'close' | null
+  >(null);
+  useEffect(() => {
+    if (tagSectionClicked) {
+      // reset after 5 seconds
+      setTimeout(() => {
+        settagSectionClicked(null);
+      }, 2000);
+    }
+  }, [tagSectionClicked]);
+
+  return (
+    <VStack>
+      <p>Tag section clicked: {tagSectionClicked || 'None'}</p>
+      <div>
+        <p>
+          Size: <b>base</b>
+        </p>
+        <Tag
+          icon={icon}
+          iconRight={iconRight}
+          onClick={() => settagSectionClicked('whole')}
+          onClose={() => {
+            settagSectionClicked('close');
+            onClose();
+          }}
+          size="base"
+        >
+          {children}
+        </Tag>
+      </div>
+      <div>
+        <p>
+          Size: <b>lg</b>
+        </p>
+        <Tag
+          icon={icon}
+          iconRight={iconRight}
+          onClick={() => settagSectionClicked('whole')}
+          onClose={() => {
+            settagSectionClicked('close');
+            onClose();
+          }}
+          size="lg"
+        >
+          {children}
+        </Tag>
+      </div>
+    </VStack>
+  );
+};
 
 export const Default = Template.bind({});
 Default.args = {

--- a/src/types/UploadedFile.ts
+++ b/src/types/UploadedFile.ts
@@ -1,4 +1,5 @@
 export type UploadedFile = {
+  imageUrl?: string;
   name: string;
   size?: string;
 };


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR:
- Dropzone:
  - add `imageUrl` to uploaded file prop in Dropzone (show `imageUrl` if provided, otherwise use default file icon
- Tag
  - add size to tag component
    <img width="235" alt="image" src="https://github.com/Zonos/amino/assets/17950626/b8183216-f7ce-4d27-8172-8f84c256033f">

  - adjust style, separate close button and whole tag click event, be able to trigger left and right section (close) of the tag
     <img width="181" alt="image" src="https://github.com/Zonos/amino/assets/17950626/5bb97634-d868-49cb-bff2-c81021b9553f">
     <img width="212" alt="image" src="https://github.com/Zonos/amino/assets/17950626/f3dad140-1600-4791-af8c-e962eda45e41">



## Todo

- [ ] Bump version and add tag
