### PR TITLE
refactor: update size when content change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "4.4.20",
+  "version": "4.4.21",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/collapse/Collapse.tsx
+++ b/src/components/collapse/Collapse.tsx
@@ -62,6 +62,18 @@ export const Collapse = ({
 
   useEffect(() => {
     setContentHeight(getComputedHeight());
+    let resizeObserver: ResizeObserver | null = null;
+    if (contentWrapperRef.current) {
+      // change size when content changes
+      resizeObserver = new ResizeObserver(() => {
+        setContentHeight(getComputedHeight());
+      });
+      resizeObserver.observe(contentWrapperRef.current);
+    }
+
+    return () => {
+      resizeObserver?.disconnect();
+    };
   }, []);
 
   useEffect(() => {

--- a/src/components/collapse/__stories__/Collapse.stories.tsx
+++ b/src/components/collapse/__stories__/Collapse.stories.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import type { Meta, StoryFn } from '@storybook/react';
 import { Button } from 'src/components/button/Button';
@@ -42,6 +42,11 @@ const StyledCollapseComponent = styled(CollapseComponent)`
   border-radius: 6px;
 `;
 
+const ActionWrapper = styled.div`
+  display: inline-flex;
+  gap: 20px;
+`;
+
 const Template: StoryFn<CollapseProps> = ({
   children,
   className,
@@ -49,17 +54,46 @@ const Template: StoryFn<CollapseProps> = ({
 }) => {
   const [open1, setOpen1] = useState(true);
   const [open2, setOpen2] = useState(false);
+  const [moreItems, setMoreItems] = useState(false);
+
+  useEffect(() => {
+    setTimeout(() => {
+      setMoreItems(true);
+    }, 2000);
+
+    setTimeout(() => {
+      setMoreItems(false);
+    }, 4000);
+  }, []);
+
+  useEffect(() => {
+    if (moreItems) {
+      setTimeout(() => {
+        setMoreItems(false);
+      }, 2000);
+    }
+  }, [moreItems]);
 
   return (
     <>
-      <Button
-        onClick={() => {
-          setOpen1(!open1);
-          setOpen2(!open2);
-        }}
-      >
-        Toggle
-      </Button>
+      <ActionWrapper>
+        <Button
+          onClick={() => {
+            setOpen1(!open1);
+            setOpen2(!open2);
+          }}
+        >
+          Toggle
+        </Button>
+
+        <Button
+          onClick={() => {
+            setMoreItems(true);
+          }}
+        >
+          Add more items
+        </Button>
+      </ActionWrapper>
       <CollapseContainer>
         <p>Collapse size: {collapseSize ? `${collapseSize}px` : '0px'}</p>
         <div>
@@ -70,6 +104,13 @@ const Template: StoryFn<CollapseProps> = ({
             collapseSize={collapseSize}
           >
             {children}
+            {moreItems && (
+              <>
+                <NavigationItem content="Item 4" />
+                <NavigationItem content="Item 5" />
+                <NavigationItem content="Item 6" />
+              </>
+            )}
           </StyledCollapseComponent>
         </div>
         <div>
@@ -80,6 +121,13 @@ const Template: StoryFn<CollapseProps> = ({
             collapseSize={collapseSize}
           >
             {children}
+            {moreItems && (
+              <>
+                <NavigationItem content="Item 4" />
+                <NavigationItem content="Item 5" />
+                <NavigationItem content="Item 6" />
+              </>
+            )}
           </StyledCollapseComponent>
         </div>
       </CollapseContainer>


### PR DESCRIPTION
## Issue
Collapse doesn't detect when content height change which leads to part of item cut off in label creation.
<img width="823" alt="image" src="https://github.com/Zonos/amino/assets/17950626/81baac8e-0b29-435c-9b34-5f0ec8d4d160">

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->
This PR adds resizeObserver to detect height change and a story for the fix (when open the story, it will add 2 more items to the list after 2 seconds, and those 2 will be removed after 2 seconds later), you can also add more items manually.
https://amino-ov78kk3t6-zonos.vercel.app/?path=/story/amino-collapse--collapse

`ResizeObserver` browser compatibility looks really good:
<img width="800" alt="image" src="https://github.com/Zonos/amino/assets/17950626/1a1f3679-4614-4682-a180-3b3e85843ba6">


## Todo

- [ ] Bump version and add tag
