### PR TITLE
Fix/dialog click event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "4.4.24",
+  "version": "5.0.0",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.0.0",
+  "version": "4.4.24",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "4.4.24",
+  "version": "4.4.25",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/all.ts
+++ b/src/all.ts
@@ -692,6 +692,7 @@ import './utils/hooks/action-pivot-table/useHasuraGqlPagination';
 import './utils/hooks/useAminoTheme';
 import './utils/hooks/useCurrentShema';
 import './utils/hooks/useDropdown';
+import './utils/hooks/useHeightAdjustTextarea';
 import './utils/hooks/useNotify';
 import './utils/hooks/useStorage';
 import './utils/hooks/useSwr';

--- a/src/components/textarea/Textarea.tsx
+++ b/src/components/textarea/Textarea.tsx
@@ -2,7 +2,6 @@ import {
   type ReactNode,
   type TextareaHTMLAttributes,
   forwardRef,
-  useEffect,
   useRef,
 } from 'react';
 
@@ -182,11 +181,6 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
   ) => {
     const hasValue = !!value;
     const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-    useEffect(() => {
-      if (ref && typeof ref !== 'function') {
-        textareaRef.current = ref.current;
-      }
-    }, [ref]);
 
     useHeightAdjustTextarea({
       maxRows,
@@ -202,9 +196,17 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
         }`}
         width={width}
       >
-        <Fields onClick={() => textareaRef.current?.focus()}>
+        <Fields onClick={() => textareaRef?.current?.focus()}>
           <StyledTextarea
-            ref={textareaRef}
+            ref={node => {
+              if (ref && typeof ref === 'function') {
+                ref(node);
+              } else if (ref) {
+                // eslint-disable-next-line no-param-reassign
+                ref.current = node;
+              }
+              textareaRef.current = node;
+            }}
             className={[
               error ? 'has-error' : '',
               label ? 'has-label' : '',
@@ -218,7 +220,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
           />
           <StyledLabelInput
             data-label={label}
-            onClick={() => textareaRef.current?.focus()}
+            onClick={() => textareaRef?.current?.focus()}
           >
             {label}
           </StyledLabelInput>

--- a/src/components/textarea/__stories__/Textarea.stories.tsx
+++ b/src/components/textarea/__stories__/Textarea.stories.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import type { Meta, StoryFn } from '@storybook/react';
 import { Input } from 'src/components/input/Input';
@@ -20,6 +20,9 @@ const TextAreaMeta: Meta = {
   component: Textarea,
 };
 
+const longContent = `lorem ipsum dolor sit amet consectetur adipisicing elit. Repellat id iure amet accusantium ea consequuntur eaque animi fugiat iusto similique, vero velit distinctio sequi nesciunt odit nobis consequatur nihil sunt. Lorem ipsum dolor sit amet consectetur adipisicing elit. Repellat id iure amet accusantium ea consequuntur eaque animi fugiat iusto similique, vero velit distinctio sequi nesciunt odit nobis consequatur nihil sunt. Lorem ipsum dolor sit amet consectetur adipisicing elit. Repellat id iure amet accusantium ea consequuntur eaque animi fugiat iusto similique, vero velit distinctio sequi nesciunt odit nobis consequatur nihil sunt.`;
+const shortContent = `lorem ipsum dolor sit amet consectetur adipisicing elit. Repellat id iure amet accusantium ea consequuntur eaque animi fugiat iusto similique`;
+
 export default TextAreaMeta;
 
 const Template: StoryFn<TextareaProps> = ({
@@ -30,9 +33,17 @@ const Template: StoryFn<TextareaProps> = ({
   value: _value,
 }: TextareaProps) => {
   const [value, setValue] = useState(_value);
-  const [longContent, setLongContent] = useState(
-    `lorem ipsum dolor sit amet consectetur adipisicing elit. Repellat id iure amet accusantium ea consequuntur eaque animi fugiat iusto similique, vero velit distinctio sequi nesciunt odit nobis consequatur nihil sunt. Lorem ipsum dolor sit amet consectetur adipisicing elit. Repellat id iure amet accusantium ea consequuntur eaque animi fugiat iusto similique, vero velit distinctio sequi nesciunt odit nobis consequatur nihil sunt. Lorem ipsum dolor sit amet consectetur adipisicing elit. Repellat id iure amet accusantium ea consequuntur eaque animi fugiat iusto similique, vero velit distinctio sequi nesciunt odit nobis consequatur nihil sunt.`
-  );
+  const [autoAdjustContent, setAutoAdjustContent] = useState(longContent);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      // toggle between long and short content every 3 seconds
+      setAutoAdjustContent(content =>
+        longContent === content ? shortContent : longContent
+      );
+    }, 3000);
+    return () => clearInterval(interval);
+  }, []);
   return (
     <div
       style={{
@@ -95,16 +106,7 @@ const Template: StoryFn<TextareaProps> = ({
             label={label}
             onChange={() => {}}
             placeholder={placeholder}
-            value={`Lorem ipsum dolor sit amet consectetur adipisicing elit. Repellat id
-            iure amet accusantium ea consequuntur eaque animi fugiat iusto
-            similique, vero velit distinctio sequi nesciunt odit nobis
-            consequatur nihil sunt. Lorem ipsum dolor sit amet consectetur
-            adipisicing elit. Repellat id iure amet accusantium ea consequuntur
-            eaque animi fugiat iusto similique, vero velit distinctio sequi
-            nesciunt odit nobis consequatur nihil sunt. Lorem ipsum dolor sit
-            amet consectetur adipisicing elit. Repellat id iure amet accusantium
-            ea consequuntur eaque animi fugiat iusto similique, vero velit
-            distinctio sequi nesciunt odit nobis consequatur nihil sunt.`}
+            value={longContent}
           />
           <Input label={label} onChange={() => {}} value="" />
         </StyledGroup>
@@ -154,9 +156,9 @@ const Template: StoryFn<TextareaProps> = ({
             expandable
             helpText={helpText}
             label={label}
-            onChange={e => setLongContent(e.target.value)}
+            onChange={e => setAutoAdjustContent(e.target.value)}
             placeholder={placeholder}
-            value={longContent}
+            value={autoAdjustContent}
           />
           <Textarea
             error={error}
@@ -164,9 +166,9 @@ const Template: StoryFn<TextareaProps> = ({
             helpText={helpText}
             label={label}
             maxRows={3}
-            onChange={e => setLongContent(e.target.value)}
+            onChange={e => setAutoAdjustContent(e.target.value)}
             placeholder={placeholder}
-            value={longContent}
+            value={autoAdjustContent}
           />
         </StyledGroup>
       </div>

--- a/src/components/textarea/__stories__/Textarea.stories.tsx
+++ b/src/components/textarea/__stories__/Textarea.stories.tsx
@@ -30,6 +30,9 @@ const Template: StoryFn<TextareaProps> = ({
   value: _value,
 }: TextareaProps) => {
   const [value, setValue] = useState(_value);
+  const [longContent, setLongContent] = useState(
+    `lorem ipsum dolor sit amet consectetur adipisicing elit. Repellat id iure amet accusantium ea consequuntur eaque animi fugiat iusto similique, vero velit distinctio sequi nesciunt odit nobis consequatur nihil sunt. Lorem ipsum dolor sit amet consectetur adipisicing elit. Repellat id iure amet accusantium ea consequuntur eaque animi fugiat iusto similique, vero velit distinctio sequi nesciunt odit nobis consequatur nihil sunt. Lorem ipsum dolor sit amet consectetur adipisicing elit. Repellat id iure amet accusantium ea consequuntur eaque animi fugiat iusto similique, vero velit distinctio sequi nesciunt odit nobis consequatur nihil sunt.`
+  );
   return (
     <div
       style={{
@@ -140,6 +143,30 @@ const Template: StoryFn<TextareaProps> = ({
             label={label}
             onChange={e => setValue(e.target.value)}
             value={value?.toString() || ''}
+          />
+        </StyledGroup>
+      </div>
+      <div>
+        <Text type="bold-label">Expandable (maxRow 5 | maxRow 3):</Text>
+        <StyledGroup style={{ display: 'flex', gap: '10px' }}>
+          <Textarea
+            error={error}
+            expandable
+            helpText={helpText}
+            label={label}
+            onChange={e => setLongContent(e.target.value)}
+            placeholder={placeholder}
+            value={longContent}
+          />
+          <Textarea
+            error={error}
+            expandable
+            helpText={helpText}
+            label={label}
+            maxRows={3}
+            onChange={e => setLongContent(e.target.value)}
+            placeholder={placeholder}
+            value={longContent}
           />
         </StyledGroup>
       </div>

--- a/src/components/textarea/__stories__/Textarea.stories.tsx
+++ b/src/components/textarea/__stories__/Textarea.stories.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import type { Meta, StoryFn } from '@storybook/react';
 import { Input } from 'src/components/input/Input';
@@ -34,6 +34,12 @@ const Template: StoryFn<TextareaProps> = ({
 }: TextareaProps) => {
   const [value, setValue] = useState(_value);
   const [autoAdjustContent, setAutoAdjustContent] = useState(longContent);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    // focus the first input on mount (ref works)
+    textareaRef.current?.focus();
+  }, []);
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -58,6 +64,7 @@ const Template: StoryFn<TextareaProps> = ({
 
         <StyledGroup style={{ display: 'flex', gap: '10px' }}>
           <Textarea
+            ref={textareaRef}
             error={error}
             helpText={helpText}
             onChange={() => {}}

--- a/src/utils/hooks/useHeightAdjustTextarea.ts
+++ b/src/utils/hooks/useHeightAdjustTextarea.ts
@@ -1,0 +1,65 @@
+import { type MutableRefObject, useEffect, useState } from 'react';
+
+/** @desc Get the computed style of a component */
+const getComputedStyle = (
+  element: HTMLTextAreaElement,
+  property: keyof CSSStyleDeclaration
+) => window.getComputedStyle(element)[property] as string;
+
+type TextareaParams = {
+  initialRows?: number;
+  // when expanding textarea, it will expand up to maxRows
+  maxRows?: number;
+  ref: MutableRefObject<HTMLTextAreaElement | null>;
+  shouldExpand: boolean;
+  textareaValue: string;
+};
+
+/**
+ * This hook is used to adjust the height of textarea to the defined `maxRows`. It will
+ * expand the height of textarea up to `maxRows` and then it will add scroll bar.
+ */
+export const useHeightAdjustTextarea = ({
+  initialRows = 2,
+  maxRows = 5,
+  ref,
+  shouldExpand,
+  textareaValue,
+}: TextareaParams) => {
+  const [originalHeight, setOriginalHeight] = useState(0);
+
+  useEffect(() => {
+    const textarea = ref.current;
+    if (!textarea || !shouldExpand) {
+      return;
+    }
+
+    const height = parseFloat(getComputedStyle(textarea, 'height'));
+    const lineHeight = parseFloat(getComputedStyle(textarea, 'lineHeight'));
+    const paddingTop =
+      parseFloat(getComputedStyle(textarea, 'paddingTop')) || 0;
+    const paddingBottom =
+      parseFloat(getComputedStyle(textarea, 'paddingBottom')) || 0;
+
+    if (!originalHeight) {
+      setOriginalHeight(height);
+    }
+
+    // max rows converted to px
+    const maxHeightToScroll = lineHeight * maxRows + paddingTop + paddingBottom;
+
+    // shrink it to zero in case the content shrink
+    textarea.style.height = '0';
+
+    // raise the textarea height when it's less max number of rows height
+    if (textarea.scrollHeight <= maxHeightToScroll) {
+      const adjustedHeight = Math.max(originalHeight, textarea.scrollHeight);
+
+      textarea.style.height = `${adjustedHeight}px`;
+      textarea.style.overflow = 'hidden';
+    } else {
+      textarea.style.height = `${maxHeightToScroll}px`;
+      textarea.style.overflow = 'auto';
+    }
+  }, [ref, maxRows, textareaValue, shouldExpand, originalHeight, initialRows]);
+};


### PR DESCRIPTION
## Issue

<!-- [Jira issue description](url) -->
<!-- Example:
[3106 - Loup Charmant - Need dashboard switched from Hello](https://myzonos.atlassian.net/browse/DM-550)
-->
- Designer wants textarea to be able to adjust height to fit the content automatically.
- She also found the bug that the dialog will be closed if the mouse up or down is triggered on the dialog overlay.

https://github.com/Zonos/amino/assets/17950626/97cb66eb-7cfc-4898-9ea7-3581500415fd



## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR:
- add expandable feature for textarea [story url](https://amino-8pijpwbdn-zonos.vercel.app/?path=/docs/amino-textarea--docs) 
<img width="1268" alt="image" src="https://github.com/Zonos/amino/assets/17950626/be538bd5-7087-4cdb-a708-c6724bcf6e27">

- fixes the bug on the dialog described above [story url](https://amino-8pijpwbdn-zonos.vercel.app/?path=/docs/amino-dialog--docs)

## Todo

- [ ] Bump version and add tag
