### PR TITLE
Fix/select stylnig

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.0.8",
+  "version": "5.0.9",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -35,6 +35,10 @@ export interface SelectProps<
    */
   value: Option[] | Option | null;
   /**
+   * An easier way to override the option rendering without having to use the typical component props and recreating all the styles.
+   */
+  customOption?: (value: Option['value']) => ReactNode;
+  /**
    * @example
    * onChange={changed => setExampleValue(changed?.value || null)}
    */

--- a/src/components/select/_StyledReactSelect.tsx
+++ b/src/components/select/_StyledReactSelect.tsx
@@ -345,7 +345,7 @@ export const CheckboxOptionComponent = <
 const localStyles: StylesConfig<IOption, boolean, GroupBase<IOption>> = {
   clearIndicator: provided => ({
     ...provided,
-    color: `${theme.gray700}`,
+    color: theme.gray700,
     paddingLeft: 14,
     paddingRight: 4,
   }),
@@ -368,7 +368,7 @@ const localStyles: StylesConfig<IOption, boolean, GroupBase<IOption>> = {
   },
   dropdownIndicator: provided => ({
     ...provided,
-    color: `${theme.gray900}`,
+    color: theme.gray900,
     paddingLeft: 4,
     paddingRight: 10,
   }),
@@ -380,7 +380,11 @@ const localStyles: StylesConfig<IOption, boolean, GroupBase<IOption>> = {
   // groupHeading
   // indicatorsContainer
   indicatorSeparator: provided => ({ ...provided, width: 0 }),
-  // input
+  input: provided => ({
+    ...provided,
+    color: theme.textColor,
+    opacity: 0.8,
+  }),
   // loadingIndicator
   // loadingMessage
   menu: provided => ({

--- a/src/components/select/_StyledReactSelect.tsx
+++ b/src/components/select/_StyledReactSelect.tsx
@@ -30,11 +30,12 @@ import type { IOption } from 'src/types/IOption';
 import type { Size } from 'src/types/Size';
 import { getTestId } from 'src/utils/getTestId';
 
-type AdditionalProps = {
+type AdditionalProps<Value> = {
   hasGroups?: boolean;
   icon?: ReactNode;
   label?: string;
   size?: Size;
+  customOption?: (value: Value) => ReactNode;
 };
 
 const ClearIndicator = <
@@ -179,7 +180,8 @@ const Control = <
     selectProps,
   } = props;
   const { icon, label, size, value } =
-    selectProps as (typeof props)['selectProps'] & AdditionalProps;
+    selectProps as (typeof props)['selectProps'] &
+      AdditionalProps<Option['value']>;
   return (
     <div
       ref={innerRef}
@@ -303,13 +305,30 @@ export const CheckboxOptionComponent = <
     isSelected,
     selectProps,
   } = props;
-  const { hasGroups } = selectProps as (typeof props)['selectProps'] &
-    AdditionalProps;
+  const { customOption, hasGroups } =
+    selectProps as (typeof props)['selectProps'] &
+      AdditionalProps<Option['value']>;
 
   const { color, ...style } = getStyles('option', props) as CSSProperties;
   if (hasGroups) {
     style.paddingLeft = 48;
   }
+
+  const renderContent = () => {
+    if (customOption) {
+      return customOption(data.value);
+    }
+
+    return (
+      <SelectedSingleOptionWrapper>
+        <IconLabel color={color} icon={data.icon}>
+          {children}
+        </IconLabel>
+        {isSelected && <CheckCircleIcon color="blue600" size={16} />}
+      </SelectedSingleOptionWrapper>
+    );
+  };
+
   return (
     <div ref={innerRef} {...innerProps}>
       <StyledSelectOptionWrapper
@@ -330,12 +349,7 @@ export const CheckboxOptionComponent = <
             onChange={() => {}}
           />
         ) : (
-          <SelectedSingleOptionWrapper>
-            <IconLabel color={color} icon={data.icon}>
-              {children}
-            </IconLabel>
-            {isSelected && <CheckCircleIcon color="blue600" size={16} />}
-          </SelectedSingleOptionWrapper>
+          renderContent()
         )}
       </StyledSelectOptionWrapper>
     </div>
@@ -352,7 +366,7 @@ const localStyles: StylesConfig<IOption, boolean, GroupBase<IOption>> = {
   // container
   control: (provided, state) => {
     const { size } = state.selectProps as (typeof state)['selectProps'] &
-      AdditionalProps;
+      AdditionalProps<IOption['value']>;
     return {
       ...provided,
       background: theme.inputBackground,
@@ -452,7 +466,7 @@ export interface StyledReactSelectProps<
   Group extends GroupBase<Option>,
 > extends Props<Option, IsMulti, Group>,
     HelpTextProps,
-    AdditionalProps {
+    AdditionalProps<Option['value']> {
   closeOnOutsideScroll?: boolean;
   components?: SelectComponentsConfig<Option, IsMulti, Group>;
   size?: Size;
@@ -466,6 +480,7 @@ export const StyledReactSelect = <
 >({
   closeOnOutsideScroll = false,
   components,
+  customOption,
   error,
   hasGroups,
   helpText,
@@ -477,7 +492,8 @@ export const StyledReactSelect = <
   styles,
   ...props
 }: StyledReactSelectProps<Option, IsMulti, Group>) => {
-  const additionalProps: AdditionalProps = {
+  const additionalProps: AdditionalProps<Option['value']> = {
+    customOption,
     hasGroups,
     icon,
     label,

--- a/src/components/select/__stories__/Select.stories.tsx
+++ b/src/components/select/__stories__/Select.stories.tsx
@@ -7,6 +7,7 @@ import { Button } from 'src/components/button/Button';
 import { Dialog } from 'src/components/dialog/Dialog';
 import { type SelectProps, Select } from 'src/components/select/Select';
 import { VStack } from 'src/components/stack/VStack';
+import { Text } from 'src/components/text/Text';
 import { FileIcon } from 'src/icons/FileIcon';
 import { FlagIcon } from 'src/icons/flag-icon/FlagIcon';
 import { type IOption } from 'src/types/IOption';
@@ -169,6 +170,47 @@ SelectWithDeveloperException.parameters = {
     type: 'figma',
     url: 'https://www.figma.com/file/dKbMcUDxYQ8INw5cUdvXLI/amino-tokens-2021?node-id=79%3A135',
   },
+};
+
+export const Customized = SelectTemplate.bind({});
+
+const customOption: SelectProps['customOption'] = (value: string | number) => (
+  <div
+    style={{
+      display: 'flex',
+      justifyContent: 'space-between',
+    }}
+  >
+    <Text color="blue500" fontWeight={800}>
+      {value}
+    </Text>
+    <Text color="red500">{value}</Text>
+  </div>
+);
+
+Customized.args = {
+  customOption,
+  icon: <FileIcon size={20} />,
+  label: 'Currencies',
+  options: [
+    {
+      icon: <FileIcon size={14} />,
+      label: 'US Dollar (USD)',
+      value: 'USD',
+    },
+    {
+      icon: <FileIcon size={14} />,
+      label: 'European Euro (EUR)',
+      value: 'EUR',
+    },
+  ],
+  value: [
+    {
+      icon: <FileIcon size={14} />,
+      label: 'US Dollar (USD)',
+      value: 'USD',
+    },
+  ],
 };
 
 const CenteredDiv = styled.div`


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR fixes dark mode styling for Select and adds a `customOption` prop to create more complex designs easier.

Admin design: 
<img width="392" alt="image" src="https://github.com/Zonos/amino/assets/50718218/6a1f9e48-1768-44d2-86c1-45226b9b4797">


## Todo

- [ ] Bump version and add tag
