### PR TITLE
feat: use mui collapse for collapse

### DIFF
--- a/licenses/README.md
+++ b/licenses/README.md
@@ -1,0 +1,3 @@
+I don't know how MIT licenses work with NPM packages. It might only be for if this software is distributed, which because it is publicly available, could happen.
+
+Here are some licenses just in case.

--- a/licenses/license-dnd-kit.md
+++ b/licenses/license-dnd-kit.md
@@ -1,0 +1,23 @@
+https://github.com/clauderic/dnd-kit/blob/master/LICENSE
+
+MIT License
+
+Copyright (c) 2021, Claudéric Demers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/licenses/license-mui.md
+++ b/licenses/license-mui.md
@@ -1,0 +1,23 @@
+https://github.com/mui/material-ui/blob/master/LICENSE
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Call-Em-All
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/licenses/license-react-select.md
+++ b/licenses/license-react-select.md
@@ -1,0 +1,23 @@
+https://github.com/JedWatson/react-select/blob/master/LICENSE
+
+The MIT License (MIT)
+
+Copyright (c) 2022 Jed Watson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/collapse/Collapse.tsx
+++ b/src/components/collapse/Collapse.tsx
@@ -1,23 +1,11 @@
-import { type ReactNode, useEffect, useRef, useState } from 'react';
+import { type ReactNode } from 'react';
 
-import styled from 'styled-components';
+import {
+  type CollapseProps as MuiCollapseProps,
+  Collapse as MuiCollapse,
+} from '@mui/material';
 
-type StyledCollapseProps = {
-  $height?: number;
-  collapseSize: number;
-  completelyCollapsed: boolean;
-  currentlyCollapsed: boolean;
-  hideOverflow: boolean;
-};
-
-const StyledCollapseWrapper = styled.div<StyledCollapseProps>`
-  position: relative;
-  transition: height 0.3s cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-  overflow: ${p => (p.hideOverflow ? 'hidden' : undefined)};
-  visibility: ${p => (p.completelyCollapsed ? 'hidden' : undefined)};
-  height: ${p =>
-    p.currentlyCollapsed ? `${p.collapseSize}px` : `${p.$height}px`};
-`;
+// https://mui.com/material-ui/api/collapse
 
 export type CollapseProps = {
   children: ReactNode;
@@ -32,90 +20,21 @@ export type CollapseProps = {
    * @default false
    */
   collapsed?: boolean;
-};
+} & Pick<MuiCollapseProps, 'orientation'>;
+
 export const Collapse = ({
   children,
   className,
   collapsed = false,
   collapseSize = 0,
-}: CollapseProps) => {
-  const [completelyCollapsed, setCompletelyCollapsed] = useState(collapsed);
-  const [hideOverflow, setHideOverflow] = useState(collapsed);
-  const [contentHeight, setContentHeight] = useState<number | undefined>();
-
-  const contentWrapperRef = useRef<HTMLDivElement>(null);
-
-  const getComputedHeight = () => {
-    if (contentWrapperRef.current === null) {
-      return undefined;
-    }
-    const computedStyle = window.getComputedStyle(contentWrapperRef.current);
-    // Height already contains padding
-    const height = parseFloat(computedStyle.height);
-    const borderTop = parseFloat(computedStyle.borderTopWidth);
-    const borderBottom = parseFloat(computedStyle.borderBottomWidth);
-    const marginTop = parseFloat(computedStyle.marginTop);
-    const marginBottom = parseFloat(computedStyle.marginBottom);
-    const total = height + borderTop + borderBottom + marginTop + marginBottom;
-    return total;
-  };
-
-  useEffect(() => {
-    setContentHeight(getComputedHeight());
-    let resizeObserver: ResizeObserver | null = null;
-    if (contentWrapperRef.current) {
-      // change size when content changes
-      resizeObserver = new ResizeObserver(() => {
-        setContentHeight(getComputedHeight());
-      });
-      resizeObserver.observe(contentWrapperRef.current);
-    }
-
-    return () => {
-      resizeObserver?.disconnect();
-    };
-  }, []);
-
-  useEffect(() => {
-    setHideOverflow(true);
-    if (!collapsed) {
-      setCompletelyCollapsed(false);
-    }
-  }, [collapsed]);
-
-  const handleTransitionEnd = () => {
-    if (collapsed) {
-      setHideOverflow(true);
-      setCompletelyCollapsed(true);
-    } else {
-      // Done expanding so safe to show overflow
-      setHideOverflow(false);
-      setCompletelyCollapsed(false);
-      setContentHeight(getComputedHeight());
-    }
-  };
-
-  return (
-    <StyledCollapseWrapper
-      $height={contentHeight}
-      className={className}
-      collapseSize={collapseSize}
-      completelyCollapsed={completelyCollapsed}
-      currentlyCollapsed={collapsed}
-      hideOverflow={hideOverflow}
-      onTransitionEnd={handleTransitionEnd}
-    >
-      <div
-        ref={contentWrapperRef}
-        style={{
-          // if the child  component that has margin-top or the last component has margin-bottom. The child component will be collapsed with the parent component, which causing unexpected cut off
-          // and "overflow: auto", or some "padding" value (at least 1px) or "border" will make the margin will not be collapsed
-          overflow: 'auto',
-          position: 'relative',
-        }}
-      >
-        {children}
-      </div>
-    </StyledCollapseWrapper>
-  );
-};
+  orientation,
+}: CollapseProps) => (
+  <MuiCollapse
+    className={className}
+    collapsedSize={collapseSize}
+    in={!collapsed}
+    orientation={orientation}
+  >
+    {children}
+  </MuiCollapse>
+);

--- a/src/components/collapse/__stories__/Collapse.stories.tsx
+++ b/src/components/collapse/__stories__/Collapse.stories.tsx
@@ -1,15 +1,16 @@
+/* eslint-disable react/no-array-index-key */
 import { useEffect, useState } from 'react';
 
 import type { Meta, StoryFn } from '@storybook/react';
 import styled from 'styled-components';
 
 import { Banner } from 'src/components/banner/Banner';
+import { Button } from 'src/components/button/Button';
 import { LegacyButton } from 'src/components/button/LegacyButton';
-import {
-  type CollapseProps,
-  Collapse as CollapseComponent,
-} from 'src/components/collapse/Collapse';
+import { type CollapseProps, Collapse } from 'src/components/collapse/Collapse';
 import { NavigationItem } from 'src/components/layout/NavigationGroup';
+import { Text } from 'src/components/text/Text';
+import { ChevronRightIcon } from 'src/icons/ChevronRightIcon';
 import { theme } from 'src/styles/constants/theme';
 
 const CollapseMeta: Meta = {
@@ -25,7 +26,7 @@ const CollapseMeta: Meta = {
       },
     },
   },
-  component: CollapseComponent,
+  component: Collapse,
   parameters: {
     docs: { source: { type: 'code' } },
   },
@@ -33,13 +34,36 @@ const CollapseMeta: Meta = {
 
 export default CollapseMeta;
 
+const BasicWrapper = styled.div`
+  border: ${theme.border};
+  background: ${theme.gray100};
+  margin: 20px;
+  padding: 20px;
+  display: flex;
+`;
+
+export const Basic: StoryFn<CollapseProps> = props => {
+  const [collapsed, setCollapsed] = useState(false);
+
+  return (
+    <>
+      <Button onClick={() => setCollapsed(!collapsed)}>Toggle</Button>
+      <Collapse collapsed={collapsed} {...props}>
+        <BasicWrapper>
+          <Text>Some text</Text>
+        </BasicWrapper>
+      </Collapse>
+    </>
+  );
+};
+
 const CollapseContainer = styled.div`
   margin: 20px;
   display: flex;
   gap: 40px;
 `;
 
-const StyledCollapseComponent = styled(CollapseComponent)`
+const RandomCollapseWrapper = styled.div`
   border: 1px solid gray;
   border-radius: 6px;
 `;
@@ -53,11 +77,7 @@ const StyledBanner = styled(Banner)`
   margin: ${theme.space16};
 `;
 
-const Template: StoryFn<CollapseProps> = ({
-  children,
-  className,
-  collapseSize,
-}) => {
+export const Random: StoryFn<CollapseProps> = ({ collapseSize }) => {
   const [open1, setOpen1] = useState(true);
   const [open2, setOpen2] = useState(false);
   const [moreItems, setMoreItems] = useState(false);
@@ -79,6 +99,15 @@ const Template: StoryFn<CollapseProps> = ({
       }, 2000);
     }
   }, [moreItems]);
+
+  const children = (
+    <>
+      <StyledBanner>Component has margin top & bottom</StyledBanner>
+      <NavigationItem content="Item 1" isActive />
+      <NavigationItem content="Item 2" />
+      <NavigationItem content="Item 3" />
+    </>
+  );
 
   return (
     <>
@@ -105,11 +134,7 @@ const Template: StoryFn<CollapseProps> = ({
         <div>
           Open by default (no border) - to test if the the `Collapse` will
           collapse the margin with its children
-          <CollapseComponent
-            className={className}
-            collapsed={!open1}
-            collapseSize={collapseSize}
-          >
+          <Collapse collapsed={!open1} collapseSize={collapseSize}>
             {children}
             {moreItems && (
               <>
@@ -119,55 +144,124 @@ const Template: StoryFn<CollapseProps> = ({
                 <StyledBanner>Component has margin top & bottom</StyledBanner>
               </>
             )}
-          </CollapseComponent>
+          </Collapse>
         </div>
         <div>
           Open by default
-          <StyledCollapseComponent
-            className={className}
-            collapsed={!open1}
-            collapseSize={collapseSize}
-          >
-            {children}
-            {moreItems && (
-              <>
-                <NavigationItem content="Item 4" />
-                <NavigationItem content="Item 5" />
-                <NavigationItem content="Item 6" />
-                <StyledBanner>Component has margin top & bottom</StyledBanner>
-              </>
-            )}
-          </StyledCollapseComponent>
+          <Collapse collapsed={!open1} collapseSize={collapseSize}>
+            <RandomCollapseWrapper>
+              {children}
+              {moreItems && (
+                <>
+                  <NavigationItem content="Item 4" />
+                  <NavigationItem content="Item 5" />
+                  <NavigationItem content="Item 6" />
+                  <StyledBanner>Component has margin top & bottom</StyledBanner>
+                </>
+              )}
+            </RandomCollapseWrapper>
+          </Collapse>
         </div>
         <div>
           Closed by default
-          <StyledCollapseComponent
-            className={className}
-            collapsed={!open2}
-            collapseSize={collapseSize}
-          >
-            {children}
-            {moreItems && (
-              <>
-                <NavigationItem content="Item 4" />
-                <NavigationItem content="Item 5" />
-                <NavigationItem content="Item 6" />
-              </>
-            )}
-          </StyledCollapseComponent>
+          <Collapse collapsed={!open2} collapseSize={collapseSize}>
+            <RandomCollapseWrapper>
+              {children}
+              {moreItems && (
+                <>
+                  <NavigationItem content="Item 4" />
+                  <NavigationItem content="Item 5" />
+                  <NavigationItem content="Item 6" />
+                </>
+              )}
+            </RandomCollapseWrapper>
+          </Collapse>
         </div>
       </CollapseContainer>
     </>
   );
 };
-export const Collapse = Template.bind({});
-Collapse.args = {
-  children: (
+
+const StyledChevronRightIcon = styled(ChevronRightIcon)<{
+  collapsed: boolean;
+}>`
+  color: ${theme.gray600};
+  transition: ${theme.transition};
+
+  transform: ${({ collapsed }) => (collapsed ? 'rotate(0)' : 'rotate(-90deg)')};
+`;
+
+const Container = styled.div`
+  width: 500px;
+  height: 300px;
+  border: ${theme.border};
+  overflow-y: auto;
+  overscroll-behavior-y: contain;
+`;
+
+const ItemWrapper = styled.div`
+  padding-left: 16px;
+`;
+
+const ItemLabel = styled.div`
+  cursor: pointer;
+  display: flex;
+  gap: 8px;
+`;
+
+type Item = Item[] | null;
+
+const DropdownNavItem = ({ items }: { items: Item[] | null }) => {
+  const [collapsed, setCollapsed] = useState<boolean[]>(
+    items?.map(() => true) || [],
+  );
+
+  if (!items) {
+    return <Text>Leaf</Text>;
+  }
+
+  return (
     <>
-      <StyledBanner>Component has margin top & bottom</StyledBanner>
-      <NavigationItem content="Item 1" isActive />
-      <NavigationItem content="Item 2" />
-      <NavigationItem content="Item 3" />
+      {items.map((item, index) => (
+        <ItemWrapper>
+          <ItemLabel
+            key={index}
+            onClick={() =>
+              setCollapsed(prev => {
+                const next = [...prev];
+                next[index] = !next[index];
+                return next;
+              })
+            }
+          >
+            <StyledChevronRightIcon collapsed={collapsed[index]!} />
+            <Text>Item {index + 1}</Text>
+          </ItemLabel>
+          <Collapse collapsed={collapsed[index]!}>
+            <DropdownNavItem items={item} />
+          </Collapse>
+        </ItemWrapper>
+      ))}
     </>
-  ),
+  );
 };
+
+// A lot of nested items
+const items: Item[] = [
+  [[[[[null]]]]],
+  null,
+  [[[[null]]]],
+  null,
+  [[[null]]],
+  null,
+  [[null]],
+  null,
+  [null],
+  null,
+];
+
+export const DropdownNav: StoryFn<CollapseProps> = () => (
+  <Container>
+    <DropdownNavItem items={items} />
+  </Container>
+);


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR swaps out the Collapse implementation with material-ui's Collapse because theirs is 🔥 . Tweaked the Collapse stories to more accurately reflect our use cases.

Originally needed fixing because it did not behave well when nested.

Adds some licenses as an afterthought.

## Todo

- [x] Bump version and add tag
