### PR TITLE
Refactor/storage hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.1.14",
+  "version": "5.1.15",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/__stories__/Storage.stories.tsx
+++ b/src/__stories__/Storage.stories.tsx
@@ -35,7 +35,6 @@ export const Storage = () => {
 
   const { setValue, value } = useStorage({
     defaultValue: defaultPerson,
-    json: true,
     key: 'amino:story:storage:test',
     schema,
     type: storageType,
@@ -46,10 +45,6 @@ export const Storage = () => {
   const rawValue = localStorage.getItem('amino:story:storage:test');
 
   const submit = () => {
-    setValue(input as unknown as Person);
-  };
-
-  const submitAsJson = () => {
     try {
       setValue(JSON.parse(input) as Person);
     } catch (error) {
@@ -77,13 +72,12 @@ export const Storage = () => {
       </div>
       <Input
         onChange={e => setInput(e.target.value)}
-        placeholder="Enter a value to set"
+        placeholder="Enter a JSON value to set"
         type="text"
         value={input}
       />
       <HStack>
-        <LegacyButton onClick={submit}>Set Value</LegacyButton>
-        <LegacyButton onClick={submitAsJson}>Set Value as JSON</LegacyButton>
+        <LegacyButton onClick={submit}>Set Value as JSON</LegacyButton>
       </HStack>
     </VStack>
   );

--- a/src/__stories__/Storage.stories.tsx
+++ b/src/__stories__/Storage.stories.tsx
@@ -8,6 +8,7 @@ import { Input } from 'src/components/input/Input';
 import { HStack } from 'src/components/stack/HStack';
 import { VStack } from 'src/components/stack/VStack';
 import { useStorage } from 'src/utils/hooks/useStorage';
+import type { StorageType } from 'src/utils/storage';
 
 const meta: Meta = {
   title: 'Storage',
@@ -30,12 +31,14 @@ const defaultPerson: Person = {
 };
 
 export const Storage = () => {
+  const [storageType, setStorageType] = useState<StorageType>('local');
+
   const { setValue, value } = useStorage({
     defaultValue: defaultPerson,
     json: true,
     key: 'amino:story:storage:test',
     schema,
-    type: 'local',
+    type: storageType,
   });
 
   const [input, setInput] = useState('');
@@ -47,11 +50,25 @@ export const Storage = () => {
   };
 
   const submitAsJson = () => {
-    setValue(JSON.parse(input) as Person);
+    try {
+      setValue(JSON.parse(input) as Person);
+    } catch (error) {
+      // eslint-disable-next-line no-alert
+      alert('Invalid JSON');
+    }
   };
 
   return (
     <VStack>
+      <div>
+        <select
+          onChange={e => setStorageType(e.target.value as StorageType)}
+          value={storageType}
+        >
+          <option value="local">Local Storage</option>
+          <option value="session">Session Storage</option>
+        </select>
+      </div>
       <div>
         Raw local storage value: <strong>{rawValue}</strong>
       </div>

--- a/src/components/announcement-dialog/AnnouncementDialog.tsx
+++ b/src/components/announcement-dialog/AnnouncementDialog.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, forwardRef } from 'react';
 
 import styled from 'styled-components';
+import { z } from 'zod';
 
 import {
   type BaseDialogProps,
@@ -55,6 +56,7 @@ export const AnnouncementDialog = forwardRef<
       useStorage<'seen' | '', string>({
         defaultValue: '',
         key: `announcement:${announcementId}`,
+        schema: z.enum(['seen', '']),
         type: 'local',
       });
 

--- a/src/components/filter/useFilterWrapper.tsx
+++ b/src/components/filter/useFilterWrapper.tsx
@@ -119,9 +119,19 @@ export const useFilterWrapper = ({
   const dropdownRef = useRef<HTMLDivElement>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
 
+  const handleApply = () => {
+    setActive(true);
+    onApply();
+    setDropDownOpen(false);
+  };
+
   const handleKeyDown = (event: KeyboardEvent) => {
     if (event.key === 'Escape') {
       setDropDownOpen(false);
+    }
+
+    if (event.key === 'Enter') {
+      handleApply();
     }
   };
 
@@ -157,12 +167,6 @@ export const useFilterWrapper = ({
   const handleOpenDropdown = (e: ReactMouseEvent) => {
     e.stopPropagation();
     setDropDownOpen(true);
-  };
-
-  const handleApply = () => {
-    setActive(true);
-    onApply();
-    setDropDownOpen(false);
   };
 
   const handleToggle = () => {
@@ -220,6 +224,7 @@ export const useFilterWrapper = ({
   );
 
   return {
+    handleApplyFilter: handleApply,
     renderWrapper,
     setFilterText,
   };

--- a/src/utils/__tests__/storage.test.ts
+++ b/src/utils/__tests__/storage.test.ts
@@ -17,7 +17,6 @@ describe('storage tests', () => {
 
   test(`Value doesn't exist`, () => {
     const result = getStorageItem({
-      json: true,
       key: 'person',
       schema,
       type: 'local',
@@ -35,7 +34,6 @@ describe('storage tests', () => {
     localStorage.setItem('person', JSON.stringify(p));
 
     const result = getStorageItem({
-      json: true,
       key: 'person',
       schema,
       type: 'local',
@@ -53,7 +51,6 @@ describe('storage tests', () => {
     localStorage.setItem('person', JSON.stringify(almostAPerson));
 
     const result = getStorageItem({
-      json: true,
       key: 'person',
       schema,
       type: 'local',
@@ -92,5 +89,25 @@ describe('storage tests', () => {
     });
 
     expect(result).toBeNull();
+  });
+
+  test(`String enum is not JSON stringified`, () => {
+    const value = 'day';
+
+    const stringSchema = z.enum(['day', 'night', 'midnight']);
+
+    localStorage.setItem('theme', value);
+
+    const rawValue = localStorage.getItem('theme');
+
+    expect(rawValue).toBe('day');
+
+    const result = getStorageItem({
+      key: 'theme',
+      schema: stringSchema,
+      type: 'local',
+    });
+
+    expect(result).toBe('day');
   });
 });

--- a/src/utils/hooks/__tests__/useStorage.test.ts
+++ b/src/utils/hooks/__tests__/useStorage.test.ts
@@ -6,6 +6,7 @@ import { useStorage } from 'src/utils/hooks/useStorage';
 describe('useStorage', () => {
   afterEach(() => {
     localStorage.clear();
+    sessionStorage.clear();
   });
 
   test('should set an array of strings', async () => {
@@ -53,7 +54,7 @@ describe('useStorage', () => {
         json: true,
         key: 'people-array',
         schema: person,
-        type: 'local',
+        type: 'session',
       }),
     );
 

--- a/src/utils/hooks/__tests__/useStorage.test.ts
+++ b/src/utils/hooks/__tests__/useStorage.test.ts
@@ -13,7 +13,6 @@ describe('useStorage', () => {
     const { result } = renderHook(() =>
       useStorage({
         defaultValue: [],
-        json: true,
         key: 'people-array',
         schema: z.array(z.string()),
         type: 'local',
@@ -51,7 +50,6 @@ describe('useStorage', () => {
     const { result } = renderHook(() =>
       useStorage({
         defaultValue: null,
-        json: true,
         key: 'people-array',
         schema: person,
         type: 'session',
@@ -121,11 +119,13 @@ describe('useStorage', () => {
   });
 
   test('Should parse a boolean without a schema', async () => {
+    const boolean = z.boolean();
+
     const { result } = renderHook(() =>
       useStorage({
         defaultValue: false,
-        json: true,
         key: 'boolean',
+        schema: boolean,
         type: 'session',
       }),
     );
@@ -149,8 +149,6 @@ describe('useStorage', () => {
       await setValue('ooga-booga' as unknown as boolean);
     });
 
-    // We have no schema, so it should just return the raw JSON parsed value
-    // Not sure why anyone would want this...
-    expect(getCurrentValue()).toBe('ooga-booga');
+    expect(getCurrentValue()).toBe(false);
   });
 });

--- a/src/utils/hooks/__tests__/useStorage.test.ts
+++ b/src/utils/hooks/__tests__/useStorage.test.ts
@@ -85,4 +85,72 @@ describe('useStorage', () => {
 
     expect(getCurrentValue()).toBeNull();
   });
+
+  test('Should validate a string union without a json parse', async () => {
+    const fruit = z.enum(['apple', 'orange', 'banana']);
+
+    const { result } = renderHook(() =>
+      useStorage({
+        defaultValue: 'apple',
+        key: 'people-array',
+        schema: fruit,
+        type: 'local',
+      }),
+    );
+
+    const getCurrentValue = () => result.current.value;
+
+    // Assert initial state
+    const { setValue, value: initialValue } = result.current;
+
+    expect(initialValue).toBe('apple');
+
+    await act(async () => {
+      await setValue('banana');
+    });
+
+    // Assert the updated state
+    expect(getCurrentValue()).toBe('banana');
+
+    // Manually mangle local storage
+    await act(async () => {
+      await setValue('ooga-booga' as unknown as z.infer<typeof fruit>);
+    });
+
+    expect(getCurrentValue()).toBe('apple');
+  });
+
+  test('Should parse a boolean without a schema', async () => {
+    const { result } = renderHook(() =>
+      useStorage({
+        defaultValue: false,
+        json: true,
+        key: 'boolean',
+        type: 'session',
+      }),
+    );
+
+    const getCurrentValue = () => result.current.value;
+
+    // Assert initial state
+    const { setValue, value: initialValue } = result.current;
+
+    expect(initialValue).toBe(false);
+
+    await act(async () => {
+      await setValue(true);
+    });
+
+    // Assert the updated state
+    expect(getCurrentValue()).toBe(true);
+
+    // Manually mangle local storage
+    await act(async () => {
+      await setValue('ooga-booga' as unknown as boolean);
+    });
+
+    // We have no schema, so it should just return the raw JSON parsed value
+    // Not sure why anyone would want this...
+    expect(getCurrentValue()).toBe('ooga-booga');
+  });
 });

--- a/src/utils/hooks/useAminoTheme.ts
+++ b/src/utils/hooks/useAminoTheme.ts
@@ -3,7 +3,6 @@ import { useEffect } from 'react';
 import type { Theme } from 'src/types';
 import { themeSchema } from 'src/types/Theme';
 import { useStorage } from 'src/utils/hooks/useStorage';
-import { getStorageItem } from 'src/utils/storage';
 
 type Params = {
   /** Use with root to override a theme in localStorage */
@@ -14,27 +13,14 @@ type Params = {
 
 export const useAminoTheme = (params?: Params) => {
   const { override, root } = params ?? {};
-  // SWR cache is not initialized at first, so it would default to 'day' instead of the localStorage value.
-  const getDefaultValue = () => {
-    if (typeof window === 'undefined') {
-      return 'day';
-    }
-
-    const storedValue = getStorageItem<Theme>({
-      key: 'amino:theme',
-      schema: themeSchema,
-      type: 'local',
-    });
-
-    return storedValue ?? 'day';
-  };
 
   const { setValue: setAminoTheme, value: aminoTheme } = useStorage<
     Theme,
     'amino:theme'
   >({
-    defaultValue: getDefaultValue(),
+    defaultValue: 'day',
     key: 'amino:theme',
+    schema: themeSchema,
     type: 'local',
   });
 

--- a/src/utils/hooks/useCurrentShema.ts
+++ b/src/utils/hooks/useCurrentShema.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 import { useStorage } from 'src/utils/hooks/useStorage';
 
 export const useCurrentSchema = <TValue extends string>(
@@ -6,5 +8,6 @@ export const useCurrentSchema = <TValue extends string>(
   useStorage({
     defaultValue: defaultSchema,
     key: 'amino:current-schema',
+    schema: z.string(),
     type: 'session',
   });

--- a/src/utils/hooks/useStorage.ts
+++ b/src/utils/hooks/useStorage.ts
@@ -1,6 +1,8 @@
-import { useSwr } from 'src/utils/hooks/useSwr';
+import { useMemo, useSyncExternalStore } from 'react';
+
 import {
   type StorageParams,
+  type StorageType,
   getStorageItem,
   setStorageItem,
 } from 'src/utils/storage';
@@ -12,13 +14,37 @@ export type AminoStorageKey =
   | `amino:${AminoLocalStorageKey}`
   | (string & Record<never, never>);
 
+const getStorageSubscription = (type: StorageType) => {
+  const subscribe = (callback: () => void) => {
+    /**
+     * For external documents
+     * @link https://developer.mozilla.org/en-US/docs/Web/API/Window/storage_event
+     *
+     * Session storage is not shared between tabs, so we don't need to worry about that
+     */
+    if (type === 'local') {
+      window.addEventListener('storage', callback);
+    }
+    // Our internal event naming
+    window.addEventListener(`amino:storage-${type}`, callback);
+    return () => {
+      if (type === 'local') {
+        window.removeEventListener('storage', callback);
+      }
+
+      window.removeEventListener(`amino:storage-${type}`, callback);
+    };
+  };
+
+  return subscribe;
+};
+
 export type UseStorageParams<
   TValue extends unknown,
   TKey extends AminoStorageKey,
 > = StorageParams<TValue, TKey> & {
   defaultValue: TValue;
 };
-
 export const useStorage = <
   TValue extends unknown,
   TKey extends AminoStorageKey = AminoStorageKey,
@@ -29,14 +55,18 @@ export const useStorage = <
   schema,
   type,
 }: UseStorageParams<TValue, TKey>) => {
-  // we don't need useSwrt here since we only use swr for caching the storage value
-  const { data, ...swrProps } = useSwr<TValue | null>(
-    key,
-    () => getStorageItem<TValue>({ json, key, schema, type }) || null,
+  const subscribe = useMemo(() => getStorageSubscription(type), [type]);
+
+  // The snapshot function is only used to trigger re-renders, so we need simple string equality comparison
+  useSyncExternalStore(subscribe, () =>
+    type === 'local' ? localStorage.getItem(key) : sessionStorage.getItem(key),
   );
+
+  const currentValue =
+    getStorageItem<TValue>({ json, key, schema, type }) || null;
 
   const setValue = (value: TValue) =>
     setStorageItem({ json, key, type, value });
 
-  return { setValue, value: data ?? defaultValue, ...swrProps };
+  return { setValue, value: currentValue ?? defaultValue };
 };

--- a/src/utils/hooks/useStorage.ts
+++ b/src/utils/hooks/useStorage.ts
@@ -50,7 +50,6 @@ export const useStorage = <
   TKey extends AminoStorageKey = AminoStorageKey,
 >({
   defaultValue,
-  json,
   key,
   schema,
   type,
@@ -58,15 +57,18 @@ export const useStorage = <
   const subscribe = useMemo(() => getStorageSubscription(type), [type]);
 
   // The snapshot function is only used to trigger re-renders, so we need simple string equality comparison
-  useSyncExternalStore(subscribe, () =>
-    type === 'local' ? localStorage.getItem(key) : sessionStorage.getItem(key),
+  useSyncExternalStore(
+    subscribe,
+    () =>
+      type === 'local'
+        ? localStorage.getItem(key)
+        : sessionStorage.getItem(key),
+    () => JSON.stringify(defaultValue),
   );
 
-  const currentValue =
-    getStorageItem<TValue>({ json, key, schema, type }) || null;
+  const currentValue = getStorageItem<TValue>({ key, schema, type }) || null;
 
-  const setValue = (value: TValue) =>
-    setStorageItem({ json, key, type, value });
+  const setValue = (value: TValue) => setStorageItem({ key, type, value });
 
   return { setValue, value: currentValue ?? defaultValue };
 };

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -28,7 +28,10 @@ export const getStorageItem = <Value extends unknown>({
   schema,
   type,
 }: StorageParams<Value>): Value | null => {
-  const storage = type === 'session' ? sessionStorage : localStorage;
+  if (typeof window === 'undefined') return null;
+
+  const storage =
+    type === 'local' ? window.localStorage : window.sessionStorage;
   const rawValue = storage.getItem(key);
 
   if (!rawValue) return null;
@@ -75,11 +78,15 @@ export const setStorageItem = async <Value extends unknown>({
   type,
   value,
 }: SetParams<Value>) => {
-  const storage = type === 'session' ? sessionStorage : localStorage;
+  const storage =
+    type === 'session' ? window.sessionStorage : window.localStorage;
 
   const setValue = json ? JSON.stringify(value) : String(value);
 
   storage.setItem(key, setValue);
+
+  // Dispatch our internal event
+  window.dispatchEvent(new Event(`amino:storage-${type}`));
 
   await mutate(key, value);
 };

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -33,18 +33,31 @@ export const getStorageItem = <Value extends unknown>({
 
   if (!rawValue) return null;
 
-  let parsedJson: unknown;
-
   if (json) {
+    let parsedJson: unknown;
+
     try {
       parsedJson = JSON.parse(rawValue);
     } catch {
       return null;
     }
+
+    if (schema) {
+      const parsed = schema.safeParse(parsedJson);
+
+      if (!parsed.success) {
+        return null;
+      }
+
+      return parsed.data;
+    }
+
+    return parsedJson as Value;
   }
 
+  // Could be a string union, in which case JSON parsing is unnecessary
   if (schema) {
-    const parsed = schema.safeParse(parsedJson || rawValue);
+    const parsed = schema.safeParse(rawValue);
 
     if (!parsed.success) {
       return null;

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -58,7 +58,7 @@ export const getStorageItem = <Value extends unknown>({
     return parsedJson as Value;
   }
 
-  // Could be a string union, in which case JSON parsing is unnecessary
+  // Could be something like a string union, in which case JSON parsing is unnecessary
   if (schema) {
     const parsed = schema.safeParse(rawValue);
 


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR refactors the `useStorage` hook to use new react hooks instead of swr. swr was really just an unnecessary layer which added extra latency to a native browser capability.

Also fixes a bug where if `json` was true but there was no `schema`, then it would not return the parsed value.

Should also be SSR safe. There is support inside the hook https://react.dev/reference/react/useSyncExternalStore#adding-support-for-server-rendering

However, the snapshot value does shallow comparison (doesn't work for objects), therefore I opted to just use it for render comparison, and get the parsed value separately anyways. The getter is server safe as well and defaults to the `defaultValue`

EDIT: disregard the above, it appears `getServerSnapshot` is required regardless...


- Filters now get applied when pressing enter

## Todo

- [ ] Bump version and add tag
