### PR TITLE
FEAT: Switch with icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@mui/material": "^5.14.0",
     "@radix-ui/react-slider": "^1.1.2",
     "@types/topojson-client": "^3.1.1",
+    "clsx": "^2.0.0",
     "d3-geo": "^2.0.2",
     "fuse.js": "^6.6.2",
     "highlight.js": "^11.8.0",
@@ -184,6 +185,7 @@
     "@emotion/styled": "^11.x",
     "@graphiql/plugin-explorer": "^0.3",
     "@graphiql/react": "^0.19",
+    "dayjs": "*",
     "framer-motion": "^10.x",
     "graphiql": "^3.0.1",
     "graphql": "^16.x",
@@ -193,7 +195,6 @@
     "react-dom": "^17.x || ^18.x",
     "react-tooltip": "^4.x",
     "styled-components": "^5.x",
-    "swr": "2.x",
-    "dayjs": "*"
+    "swr": "2.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.1.15",
+  "version": "5.1.16",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -29,6 +29,9 @@ dependencies:
   '@types/topojson-client':
     specifier: ^3.1.1
     version: 3.1.1
+  clsx:
+    specifier: ^2.0.0
+    version: 2.0.0
   d3-geo:
     specifier: ^2.0.2
     version: 2.0.2
@@ -7403,6 +7406,11 @@ packages:
   /clsx@1.2.1:
     resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
     engines: {node: '>=6'}
+
+  /clsx@2.0.0:
+    resolution: {integrity: sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==}
+    engines: {node: '>=6'}
+    dev: false
 
   /co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}

--- a/src/components/switch/Switch.tsx
+++ b/src/components/switch/Switch.tsx
@@ -23,6 +23,16 @@ const AminoSwitch = styled.div<{ checked: boolean }>`
   }
 `;
 
+const AminoSwitchWithIcons = styled(AminoSwitch)<{ checked: boolean }>`
+  height: 28px;
+  width: 28px;
+  top: 2px;
+  left: ${p => (p.checked ? 'calc(100% - 30px)' : '2px')};
+  box-shadow:
+    0px -1px 1px 0px rgba(0, 0, 0, 0.2) inset,
+    0px 1px 3px 0px rgba(0, 0, 0, 0.4);
+`;
+
 const AminoSwitchWrapper = styled.div<{
   checked: boolean;
 }>`
@@ -33,12 +43,18 @@ const AminoSwitchWrapper = styled.div<{
   min-height: 16px;
   line-height: 16px;
   border-radius: 20px;
-  background: ${p => (p.checked ? theme.primary : theme.gray100)};
+  background: ${p => (p.checked ? theme.gray0 : theme.gray100)};
   box-shadow: ${theme.v3ShadowInset};
   display: block;
   user-select: none;
-  margin-right: ${theme.space16};
   position: relative;
+`;
+
+const AminoSwitchWrapperWithIcons = styled(AminoSwitchWrapper)`
+  width: 62px;
+  height: 32px;
+  min-width: 24px;
+  background: ${theme.gray50};
 `;
 
 const StyledLabel = styled(Text)`
@@ -87,26 +103,42 @@ const SwitchContainer = styled.label<{
   }
 `;
 
+const SwitchIcon = styled.div<{ left?: boolean }>`
+  position: absolute;
+  top: 6px;
+  left: ${p => (p.left ? '5.8px' : 'auto')};
+  right: ${p => (p.left ? 'auto' : '5.6px')};
+  svg {
+    height: 20px;
+    width: 20px;
+  }
+`;
+
 export type SwitchProps = {
   checked: boolean;
   disabled?: boolean;
-  icon?: ReactNode;
   label?: string;
   labelDescription?: string;
+  labelIcon?: ReactNode;
   subtitle?: string;
+  switchIconLeft?: ReactNode;
+  switchIconRight?: ReactNode;
   onChange: (checked: boolean) => void;
 };
 
 export const Switch = ({
   checked,
   disabled,
-  icon,
   label,
   labelDescription,
+  labelIcon,
   onChange,
   subtitle,
+  switchIconLeft,
+  switchIconRight,
 }: SwitchProps) => {
   const labelAsHtmlAttribute = label?.replace(/\s/g, '-').toLowerCase();
+  const hasIcons = Boolean(switchIconLeft || switchIconRight);
 
   return (
     <SwitchContainer
@@ -115,13 +147,20 @@ export const Switch = ({
       htmlFor={labelAsHtmlAttribute}
       onClick={() => !disabled && onChange(!checked)}
     >
-      <AminoSwitchWrapper checked={checked}>
-        <AminoSwitch checked={checked} id={labelAsHtmlAttribute} />
-      </AminoSwitchWrapper>
-
+      {hasIcons ? (
+        <AminoSwitchWrapperWithIcons checked={checked}>
+          <AminoSwitchWithIcons checked={checked} id={labelAsHtmlAttribute} />
+          <SwitchIcon left>{switchIconLeft}</SwitchIcon>
+          <SwitchIcon>{switchIconRight}</SwitchIcon>
+        </AminoSwitchWrapperWithIcons>
+      ) : (
+        <AminoSwitchWrapper checked={checked}>
+          <AminoSwitch checked={checked} id={labelAsHtmlAttribute} />
+        </AminoSwitchWrapper>
+      )}
       <div>
         <LabelWrapper>
-          {icon}
+          {labelIcon}
           <StyledLabel type="input-label">
             {label}
             {labelDescription && (

--- a/src/components/switch/Switch.tsx
+++ b/src/components/switch/Switch.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 
+import clsx from 'clsx';
 import styled from 'styled-components';
 
 import { Text } from 'src/components/text/Text';
@@ -19,7 +20,7 @@ const AminoSwitch = styled.div<{ checked: boolean }>`
   top: 1px;
   left: ${p => (p.checked ? 'calc(100% - 15px)' : '1px')};
   [data-theme='night'] & {
-    background: ${theme.gray1200};
+    background: ${theme.gray200};
   }
 `;
 
@@ -116,6 +117,7 @@ const SwitchIcon = styled.div<{ left?: boolean }>`
 
 export type SwitchProps = {
   checked: boolean;
+  className?: string;
   disabled?: boolean;
   label?: string;
   labelDescription?: string;
@@ -128,6 +130,7 @@ export type SwitchProps = {
 
 export const Switch = ({
   checked,
+  className,
   disabled,
   label,
   labelDescription,
@@ -143,7 +146,7 @@ export const Switch = ({
   return (
     <SwitchContainer
       checked={checked}
-      className={disabled ? 'disabled' : ''}
+      className={clsx(className, { disabled })}
       htmlFor={labelAsHtmlAttribute}
       onClick={() => !disabled && onChange(!checked)}
     >

--- a/src/components/switch/__stories__/Switch.stories.tsx
+++ b/src/components/switch/__stories__/Switch.stories.tsx
@@ -4,10 +4,12 @@ import type { Meta, StoryFn } from '@storybook/react';
 
 import { type SwitchProps, Switch } from 'src/components/switch/Switch';
 import { Default } from 'src/icons/flags/Default';
+import { LaptopIcon } from 'src/icons/LaptopIcon';
+import { MobileIcon } from 'src/icons/MobileIcon';
 
 const SwitchMeta: Meta = {
   argTypes: {
-    icon: {
+    labelIcon: {
       table: {
         disable: true,
       },
@@ -32,8 +34,8 @@ const Template: StoryFn<SwitchProps> = ({ checked, ...props }: SwitchProps) => {
 
 export const BasicSwitch = Template.bind({});
 BasicSwitch.args = {
-  icon: <Default height={12} width={16} />,
   label: 'Input label',
+  labelIcon: <Default height={12} width={16} />,
   subtitle: 'Subtitle here',
 };
 BasicSwitch.parameters = {
@@ -46,8 +48,8 @@ BasicSwitch.parameters = {
 export const DisabledBasicSwitch = Template.bind({});
 DisabledBasicSwitch.args = {
   disabled: true,
-  icon: <Default height={16} width={16} />,
   label: 'Input label',
+  labelIcon: <Default height={16} width={16} />,
   subtitle: 'Subtitle here',
 };
 DisabledBasicSwitch.parameters = {
@@ -68,14 +70,21 @@ BasicSwitchWithoutIcon.parameters = {
     url: 'https://www.figma.com/file/dKbMcUDxYQ8INw5cUdvXLI/amino-tokens-2021?node-id=79%3A49',
   },
 };
+
 export const BasicSwitchWithoutSubtitle = Template.bind({});
 BasicSwitchWithoutSubtitle.args = {
-  icon: <Default height={16} width={16} />,
   label: 'Input label',
+  labelIcon: <Default height={16} width={16} />,
 };
 BasicSwitchWithoutSubtitle.parameters = {
   design: {
     type: 'figma',
     url: 'https://www.figma.com/file/dKbMcUDxYQ8INw5cUdvXLI/amino-tokens-2021?node-id=79%3A49',
   },
+};
+
+export const SwitchWithIcons = Template.bind({});
+SwitchWithIcons.args = {
+  switchIconLeft: <MobileIcon />,
+  switchIconRight: <LaptopIcon />,
 };

--- a/src/components/theme-select/ThemeSelect.tsx
+++ b/src/components/theme-select/ThemeSelect.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { Card } from 'src/components/card/Card';
 import { Select } from 'src/components/select/Select';
 import { HStack } from 'src/components/stack/HStack';
+import { Switch } from 'src/components/switch/Switch';
 import { Text } from 'src/components/text/Text';
 import { ThemeDarkIcon } from 'src/icons/custom/theme/ThemeDarkIcon';
 import { ThemeLightIcon } from 'src/icons/custom/theme/ThemeLightIcon';
@@ -38,64 +39,6 @@ const ThemeCard = styled(Card)`
     width: 110px;
     box-shadow: ${theme.v3ShadowLarge};
     margin-bottom: ${theme.space16};
-  }
-`;
-
-// Switch style
-const AminoSwitch = styled.div<{ checked: boolean }>`
-  background: ${theme.primary};
-  height: 28px;
-  width: 28px;
-  border-radius: 50%;
-  transition: ${theme.transition};
-  position: absolute;
-  top: 2px;
-  left: ${p => (p.checked ? 'calc(100% - 30px)' : '2px')};
-`;
-
-const SunnyIconStyled = styled(SunnyIcon)<{ isActive: boolean }>`
-  position: absolute;
-  top: 6px;
-  right: 5.8px;
-  color: ${p => (p.isActive ? theme.gray0 : theme.gray1200)};
-`;
-
-const NightIconStyled = styled(NightIcon)<{ isActive: boolean }>`
-  position: absolute;
-  top: 6px;
-  left: 6px;
-  color: ${p => (p.isActive ? theme.gray0 : theme.gray1200)};
-`;
-
-const AminoSwitchWrapper = styled.div<{
-  checked: boolean;
-}>`
-  margin-right: ${theme.space16};
-  width: 62px;
-  height: 32px;
-  min-width: 24px;
-  min-height: 16px;
-  line-height: 16px;
-  border-radius: 20px;
-  background: ${theme.gray50};
-  box-shadow: ${theme.v3ShadowInset};
-  display: block;
-  user-select: none;
-  position: relative;
-`;
-
-const SwitchContainer = styled.label<{
-  checked: boolean;
-}>`
-  display: flex;
-  flex-direction: row;
-  cursor: pointer;
-
-  &.disabled {
-    ${AminoSwitchWrapper} {
-      background: ${p => (p.checked ? theme.gray300 : '')};
-    }
-    cursor: not-allowed;
   }
 `;
 
@@ -179,19 +122,16 @@ export const ThemeSelect = ({
       )}
 
       {type === 'toggle' && (
-        <SwitchContainer
+        <Switch
           checked={checked}
-          className={`${className} ${disabled ? 'disabled' : ''}`}
-          onClick={() =>
+          className={className}
+          disabled={disabled}
+          onChange={() =>
             !disabled && setAminoTheme(aminoTheme === 'day' ? 'night' : 'day')
           }
-        >
-          <AminoSwitchWrapper checked={checked}>
-            <AminoSwitch checked={checked} id="amino-theme-switch" />
-            <SunnyIconStyled isActive={aminoTheme === 'day'} size={20} />
-            <NightIconStyled isActive={aminoTheme === 'night'} size={20} />
-          </AminoSwitchWrapper>
-        </SwitchContainer>
+          switchIconLeft={<NightIcon />}
+          switchIconRight={<SunnyIcon />}
+        />
       )}
     </>
   );


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR brings over the switch we have with icons nested in the switch. I already made the replacement in Amino for the theme switch toggle on zonos.com/docs and will be used for the new mobile/desktop view in dashboard.

## Todo

- [x] Bump version and add tag
