### PR TITLE
Refactor/export filter types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.1.46",
+  "version": "5.1.47",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/filter/filter-amount/FilterAmount.tsx
+++ b/src/components/filter/filter-amount/FilterAmount.tsx
@@ -34,7 +34,7 @@ const InputWrapper = styled.div`
 
 export type FilterAmountType = 'equal' | 'between' | 'greater' | 'less';
 
-type FilterAmountProps = BaseFilterProps & {
+export type FilterAmountProps = BaseFilterProps & {
   dispatch: Dispatch<FilterAmountAction>;
   filter: FilterAmountState;
 };

--- a/src/components/filter/filter-date/FilterDate.tsx
+++ b/src/components/filter/filter-date/FilterDate.tsx
@@ -13,7 +13,7 @@ import {
   useFilterWrapper,
 } from 'src/components/filter/useFilterWrapper';
 
-type BadgeFilterDateProps = BaseFilterProps & {
+export type FilterDateProps = BaseFilterProps & {
   dispatch: Dispatch<FilterDateAction>;
   filter: FilterDateState;
 };
@@ -26,7 +26,7 @@ export const FilterDate = ({
   dropdownTitle,
   filter,
   label,
-}: BadgeFilterDateProps) => {
+}: FilterDateProps) => {
   const [editingValue, setEditingValue] = useState<FilterDateData>(
     filter.dateData,
   );

--- a/src/components/filter/filter-multi-select/FilterMultiSelect.tsx
+++ b/src/components/filter/filter-multi-select/FilterMultiSelect.tsx
@@ -8,11 +8,12 @@ import {
 } from 'src/components/filter/useFilterWrapper';
 import type { SelectOption } from 'src/types/SelectOption';
 
-type FilterMultiSelectProps<T extends string = string> = BaseFilterProps & {
-  options: SelectOption<T>[];
-  value: SelectOption<T>[];
-  onChange: (value: SelectOption<T>[]) => void;
-};
+export type FilterMultiSelectProps<T extends string = string> =
+  BaseFilterProps & {
+    options: SelectOption<T>[];
+    value: SelectOption<T>[];
+    onChange: (value: SelectOption<T>[]) => void;
+  };
 
 export const FilterMultiSelect = <T extends string = string>({
   dropdownTitle,

--- a/src/components/filter/filter-select/FilterSelect.tsx
+++ b/src/components/filter/filter-select/FilterSelect.tsx
@@ -8,7 +8,7 @@ import {
 import { Select } from 'src/components/select/Select';
 import type { SelectOption } from 'src/types/SelectOption';
 
-type FilterSelectProps<
+export type FilterSelectProps<
   T extends string = string,
   O extends SelectOption<string> = SelectOption<T>,
 > = BaseFilterProps & {

--- a/src/components/theme-select/ThemeSelect.tsx
+++ b/src/components/theme-select/ThemeSelect.tsx
@@ -56,6 +56,9 @@ const themes: { label: string; value: Theme }[] = [
 export type Props = {
   className?: string;
   disabled?: boolean;
+  /**
+   * @default select
+   */
   type?: 'cards' | 'select' | 'toggle';
 };
 


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR exports the filter prop types so it is easier to redefine the prop types when dynamically importing them upstream.

## Todo

- [ ] Bump version and add tag
