### PR TITLE
Refactor/simple table

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.1.62",
+  "version": "5.1.63",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/filter/filter-select/FilterSelect.tsx
+++ b/src/components/filter/filter-select/FilterSelect.tsx
@@ -22,6 +22,10 @@ export type FilterSelectProps<
     | CustomSelectProps<T, O>
     | ((editingValue: O | null) => CustomSelectProps<T, O>);
   value: O | null;
+  /**
+   * @default `is ${value.label}`
+   */
+  getFilterText?: (value: O) => string;
   onChange: (value: O | null) => void;
 };
 
@@ -29,6 +33,7 @@ export const FilterSelect = <
   T extends string = string,
   O extends SelectOption<T> = SelectOption<T>,
 >({
+  getFilterText = v => `is ${v.label}`,
   onChange,
   options,
   selectProps,
@@ -40,7 +45,10 @@ export const FilterSelect = <
 
   const handleApply: FilterApplyCallback = setFilterText => {
     onChange(editingValue);
-    setFilterText(`is ${editingValue?.label || ''}`);
+    if (editingValue) {
+      const filterText = getFilterText(editingValue);
+      setFilterText(filterText);
+    }
   };
 
   const handleRemove = () => {

--- a/src/components/simple-table/__stories__/SimpleTable.stories.tsx
+++ b/src/components/simple-table/__stories__/SimpleTable.stories.tsx
@@ -117,6 +117,17 @@ export const Basic = () => (
   />
 );
 
+const link = 'https://letmegooglethat.com';
+
+export const WithLink = () => (
+  <SimpleTable
+    getRowLink={item => `${link}/?q=${item.name}`}
+    headers={tableHeaders}
+    items={items}
+    keyExtractor={item => String(item.id)}
+  />
+);
+
 export const Selectable: StoryFn<SimpleTableProps<object>> = ({ loading }) => {
   const [selectedRowIndexes, setSelectedRowIndexes] = useState<number[]>([]);
 
@@ -163,7 +174,7 @@ export const Selectable: StoryFn<SimpleTableProps<object>> = ({ loading }) => {
 };
 
 export const Loading = () => {
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
 
   return (
     <>


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->
When using the order filters, I realize it was a terrible experience to create a filter, and then click on an order only for it to navigate and lose all the filters when going back. It is much more work to add the filter state to the URL (should be done eventually...) so I added native link functionality to the SimpleTable, so one can cmd + click and open in a new tab and preserve state.

Also:
- refactors it to use more vanilla styling.
- FilterSelect can customize the filter text

## Todo

- [x] Bump version and add tag
