### PR TITLE
refactor(css): convert to CSS modules

### DIFF
--- a/src/components/checkbox/Checkbox.module.scss
+++ b/src/components/checkbox/Checkbox.module.scss
@@ -1,0 +1,90 @@
+@use 'theme';
+
+$background: var(--amino-checkbox-background);
+$border: var(--amino-checkbox-border); 
+$box-shadow: var(--amino-checkbox-box-shadow);
+$disabled-background: var(--amino-checkbox-disabled-background);
+$disabled-border: var(--amino-checkbox-disabled-border);
+
+.aminoCheckbox {
+  width: 16px;
+  height: 16px;
+  min-width: 16px;
+  min-height: 16px;
+  line-height: 16px;
+  border-radius: theme.$amino-radius-4;
+  background: $background;
+  border: $border;
+  transition: all 150ms ease-in-out;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  user-select: none;
+  box-shadow: $box-shadow;
+
+  &.checked {
+    background: theme.$amino-primary;
+    border: none;
+    box-shadow: theme.$amino-shadow-button-primary;
+  }
+
+  svg {
+    color: theme.$amino-gray-0;
+    width: 16px;
+    height: 16px;
+  }
+}
+
+.infoWrapper {
+  margin-left: 8px;
+}
+
+.styledLabelDescription {
+  margin-left: 4px;
+  color: theme.$amino-gray-600;
+}
+
+.styledLabel {
+  margin-bottom: 0 !important;
+}
+
+.labelWrapper {
+  display: flex;
+  align-items: center;
+  line-height: 16px;
+
+  svg {
+    margin-right: 4px;
+  }
+}
+
+.checkboxContainer {
+  display: flex;
+  flex-direction: row;
+  user-select: none;
+  cursor: pointer;
+
+  &.disabled {
+    .aminoCheckbox {
+      background: $disabled-background;
+      border: $disabled-border;
+      box-shadow: none;
+    }
+
+    .styledLabel {
+      color: theme.$amino-gray-600;
+    }
+
+    .styledSubtitle {
+      color: theme.$amino-gray-400;
+    }
+
+    .labelWrapper {
+      svg {
+        opacity: 0.6;
+      }
+    }
+
+    cursor: not-allowed;
+  }
+}

--- a/src/components/checkbox/Checkbox.module.scss.d.ts
+++ b/src/components/checkbox/Checkbox.module.scss.d.ts
@@ -1,0 +1,9 @@
+export declare const aminoCheckbox: string;
+export declare const checkboxContainer: string;
+export declare const checked: string;
+export declare const disabled: string;
+export declare const infoWrapper: string;
+export declare const labelWrapper: string;
+export declare const styledLabel: string;
+export declare const styledLabelDescription: string;
+export declare const styledSubtitle: string;

--- a/src/components/collapse/Collapse.tsx
+++ b/src/components/collapse/Collapse.tsx
@@ -27,12 +27,14 @@ export const Collapse = ({
   collapsed = false,
   collapseSize = 0,
   orientation,
+  style,
 }: CollapseProps) => (
   <MuiCollapse
     className={className}
     collapsedSize={collapseSize}
     in={!collapsed}
     orientation={orientation}
+    style={style}
   >
     {children}
   </MuiCollapse>

--- a/src/components/confirm-dialog/ConfirmDialog.module.scss
+++ b/src/components/confirm-dialog/ConfirmDialog.module.scss
@@ -1,0 +1,28 @@
+@use 'theme';
+
+.content {
+  padding: theme.$amino-space-24;
+
+  & > div {
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  margin-top: theme.$amino-space-24;
+
+  & > button + button {
+    margin-left: theme.$amino-space-8;
+  }
+
+  button {
+    flex: 1;
+  }
+}

--- a/src/components/confirm-dialog/ConfirmDialog.module.scss.d.ts
+++ b/src/components/confirm-dialog/ConfirmDialog.module.scss.d.ts
@@ -1,0 +1,2 @@
+export declare const content: string;
+export declare const footer: string;

--- a/src/components/confirm-dialog/ConfirmDialog.tsx
+++ b/src/components/confirm-dialog/ConfirmDialog.tsx
@@ -1,7 +1,5 @@
 import type { ReactNode } from 'react';
 
-import styled from 'styled-components';
-
 import { Button } from 'src/components/button/Button';
 import { BaseDialog } from 'src/components/dialog/BaseDialog';
 import { VStack } from 'src/components/stack/VStack';
@@ -10,38 +8,13 @@ import { Thumbnail } from 'src/components/thumbnail/Thumbnail';
 import { ExclamationMarkDuotoneIcon } from 'src/icons/ExclamationMarkDuotoneIcon';
 import { HelpDuotoneIcon } from 'src/icons/HelpDuotoneIcon';
 import { WarningDuotoneIcon } from 'src/icons/WarningDuotoneIcon';
-import { theme } from 'src/styles/constants/theme';
+import type { BaseProps } from 'src/types/BaseProps';
 import type { Intent } from 'src/types/Intent';
 import type { Theme } from 'src/types/Theme';
 
-const Content = styled.div`
-  padding: ${theme.space24};
+import styles from './ConfirmDialog.module.scss';
 
-  & > div {
-    text-align: center;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  }
-`;
-
-const Footer = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  margin-top: ${theme.space24};
-
-  & > button + button {
-    margin-left: ${theme.space8};
-  }
-
-  button {
-    flex: 1;
-  }
-`;
-
-export type ConfirmDialogProps = {
+export type ConfirmDialogProps = BaseProps & {
   confirmText?: string;
   dismissText?: string;
   intent: Intent;
@@ -101,11 +74,12 @@ export const ConfirmDialog = ({
   intent,
   label,
   open,
+  style,
   subtitle,
   themeOverride,
 }: ConfirmDialogProps) => (
-  <BaseDialog data-theme={themeOverride} open={open} width={350}>
-    <Content>
+  <BaseDialog data-theme={themeOverride} open={open} style={style} width={350}>
+    <div className={styles.content}>
       <VStack spacing={24}>
         <Thumbnail
           color={getColorForIntent(intent)}
@@ -120,7 +94,7 @@ export const ConfirmDialog = ({
             </Text>
           )}
         </VStack>
-        <Footer>
+        <div className={styles.footer}>
           <Button onClick={dismissAction} size="lg" variant="standard">
             {dismissText}
           </Button>
@@ -131,8 +105,8 @@ export const ConfirmDialog = ({
           >
             {confirmText}
           </Button>
-        </Footer>
+        </div>
       </VStack>
-    </Content>
+    </div>
   </BaseDialog>
 );

--- a/src/components/connection-map/ConnectionMap.module.scss
+++ b/src/components/connection-map/ConnectionMap.module.scss
@@ -1,0 +1,20 @@
+@use 'theme';
+
+.map {
+  background: theme.$amino-gray-50;
+  border-radius: theme.$amino-radius-12;
+  overflow: hidden;
+
+  * {
+    outline: none;
+  }
+}
+
+.mapSkeleton {
+  box-sizing: border-box;
+  border-radius: theme.$amino-radius-12;
+  width: 100%;
+  /* 50% padding is 100% of width, ratio is 33%, so half */
+  padding: 16.5%;
+  margin: 0;
+}

--- a/src/components/connection-map/ConnectionMap.module.scss.d.ts
+++ b/src/components/connection-map/ConnectionMap.module.scss.d.ts
@@ -1,0 +1,2 @@
+export declare const map: string;
+export declare const mapSkeleton: string;

--- a/src/components/connection-map/ConnectionMap.tsx
+++ b/src/components/connection-map/ConnectionMap.tsx
@@ -7,8 +7,8 @@ import {
   Marker,
 } from 'react-simple-maps';
 
+import clsx from 'clsx';
 import { geoCentroid, geoDistance } from 'd3-geo';
-import styled from 'styled-components';
 import { feature } from 'topojson-client';
 
 import { Skeleton } from 'src/components/skeleton/Skeleton';
@@ -18,24 +18,7 @@ import { type CountryOption } from 'src/types/Country';
 import { type GeoJsonWorld } from 'src/types/GeoJsonWorld';
 import { getCountryCodeByName } from 'src/utils/getCountryCodeByName';
 
-const Map = styled.div`
-  background: ${theme.gray50};
-  border-radius: ${theme.radius12};
-  overflow: hidden;
-
-  * {
-    outline: none;
-  }
-`;
-
-const MapSkeleton = styled(Skeleton)`
-  box-sizing: border-box;
-  border-radius: ${theme.radius12};
-  width: 100%;
-  /* 50% padding is 100% of width, ratio is 33%, so half */
-  padding: 16.5%;
-  margin: 0;
-`;
+import styles from './ConnectionMap.module.scss';
 
 const getScale = (xDistance: number, yDistance: number) => {
   // Account for large vertical distances not being scaled properly relative to horizntal distances because our viewport width is much greater than height
@@ -64,6 +47,7 @@ export const ConnectionMap = ({
   countries,
   from,
   height = 400,
+  style,
   to,
   worldData,
 }: Props) => {
@@ -142,11 +126,11 @@ export const ConnectionMap = ({
   }, [coordsForIso, to, from, loading]);
 
   if (loading) {
-    return <MapSkeleton height={height} />;
+    return <Skeleton className={styles.mapSkeleton} height={height} />;
   }
 
   return (
-    <Map className={className}>
+    <div className={clsx(styles.map, className)} style={style}>
       <ComposableMap
         height={height}
         projection="geoEqualEarth"
@@ -197,6 +181,6 @@ export const ConnectionMap = ({
           <circle fill={theme.blue600} r={2} />
         </Marker>
       </ComposableMap>
-    </Map>
+    </div>
   );
 };

--- a/src/components/cover-sheet/CoverSheet.module.scss
+++ b/src/components/cover-sheet/CoverSheet.module.scss
@@ -1,0 +1,50 @@
+@use 'theme';
+
+.dialog {
+  z-index: 990;
+  outline: none;
+  overflow-y: auto;
+  box-sizing: border-box;
+  overscroll-behavior: contain;
+  background: theme.$amino-page-background;
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100vw;
+  height: 100vh;
+  color: theme.$amino-text-color;
+
+  @media print {
+    height: unset;
+    min-height: 100vh;
+    position: absolute;
+  }
+}
+
+.closeButton {
+  margin-right: theme.$amino-space-16;
+}
+
+.header {
+  flex-grow: 1;
+}
+
+.headerContainer {
+  border-bottom: theme.$amino-border;
+  padding: theme.$amino-space-16 theme.$amino-space-32;
+  display: flex;
+  align-items: center;
+  height: 64px;
+  position: sticky;
+  top: 0;
+  z-index: 99;
+  background-color: theme.$amino-page-background;
+
+  @media print {
+    display: none;
+  }
+}
+
+.content {
+  padding: theme.$amino-space-56;
+}

--- a/src/components/cover-sheet/CoverSheet.module.scss.d.ts
+++ b/src/components/cover-sheet/CoverSheet.module.scss.d.ts
@@ -1,0 +1,5 @@
+export declare const closeButton: string;
+export declare const content: string;
+export declare const dialog: string;
+export declare const header: string;
+export declare const headerContainer: string;

--- a/src/components/cover-sheet/CoverSheet.tsx
+++ b/src/components/cover-sheet/CoverSheet.tsx
@@ -1,64 +1,18 @@
 import { type ReactNode, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 
+import clsx from 'clsx';
 import { AnimatePresence, motion } from 'framer-motion';
-import styled from 'styled-components';
 
 import { Button } from 'src/components/button/Button';
 import { CoverSheetActions } from 'src/components/cover-sheet/CoverSheetActions';
 import { Text } from 'src/components/text/Text';
 import { RemoveIcon } from 'src/icons/RemoveIcon';
-import { theme } from 'src/styles/constants/theme';
 import type { Theme } from 'src/types';
 import type { BaseProps } from 'src/types/BaseProps';
 import { useAminoTheme } from 'src/utils/hooks/useAminoTheme';
 
-const StyledDialog = styled(motion.div)`
-  z-index: 990;
-  outline: none;
-  overflow-y: auto;
-  box-sizing: border-box;
-  overscroll-behavior: contain;
-  background: ${theme.pageBackground};
-  position: fixed;
-  left: 0;
-  top: 0;
-  width: 100vw;
-  height: 100vh;
-  color: ${theme.textColor};
-
-  @media print {
-    height: unset;
-    min-height: 100vh;
-    position: absolute;
-  }
-`;
-
-const StyledCloseButton = styled(Button)`
-  margin-right: ${theme.space16};
-`;
-const StyledHeader = styled(Text)`
-  flex-grow: 1;
-`;
-const Header = styled.header`
-  border-bottom: ${theme.border};
-  padding: ${theme.space16} ${theme.space32};
-  display: flex;
-  align-items: center;
-  height: 64px;
-  position: sticky;
-  top: 0;
-  z-index: 99;
-  background-color: ${theme.pageBackground};
-
-  @media print {
-    display: none;
-  }
-`;
-
-const Content = styled.div`
-  padding: ${theme.space56};
-`;
+import styles from './CoverSheet.module.scss';
 
 export type CoverSheetProps = BaseProps & {
   /** used for setting id of the wrapper of where the action will be located */
@@ -79,6 +33,7 @@ export const CoverSheet = ({
   label,
   onClose,
   open,
+  style,
   themeOverride,
 }: CoverSheetProps) => {
   const { aminoTheme } = useAminoTheme();
@@ -108,20 +63,24 @@ export const CoverSheet = ({
       return createPortal(
         <AnimatePresence>
           {open && (
-            <StyledDialog
+            <motion.div
               animate={{ opacity: 1, translateY: 0 }}
-              className={className}
+              className={clsx(styles.dialog, className)}
               data-theme={themeOverride || aminoTheme}
               exit={{ opacity: 0, translateY: 5 }}
               initial={{ opacity: 0, translateY: 10 }}
+              style={style}
               transition={{ duration: 0.35, ease: [0.4, 0, 0.2, 1] }}
             >
-              <Header>
-                <StyledCloseButton
+              <header className={styles.headerContainer}>
+                <Button
+                  className={styles.closeButton}
                   icon={<RemoveIcon size={20} />}
                   onClick={onClose}
                 />
-                <StyledHeader type="subheader">{label}</StyledHeader>
+                <Text className={styles.header} type="subheader">
+                  {label}
+                </Text>
                 <div id={actionWrapperId}>
                   {actions && (
                     <CoverSheetActions coverSheetActionId={actionWrapperId}>
@@ -129,9 +88,9 @@ export const CoverSheet = ({
                     </CoverSheetActions>
                   )}
                 </div>
-              </Header>
-              <Content>{children}</Content>
-            </StyledDialog>
+              </header>
+              <div className={styles.content}>{children}</div>
+            </motion.div>
           )}
         </AnimatePresence>,
         body,

--- a/src/components/currency/Currency.module.scss
+++ b/src/components/currency/Currency.module.scss
@@ -1,0 +1,9 @@
+@use 'theme';
+
+.styledCurrency {
+  font-feature-settings: 'tnum' 1;
+  /** Make it not break line */
+  white-space: nowrap;
+  display: flex;
+  gap: theme.$amino-space-4;
+}

--- a/src/components/currency/Currency.module.scss.d.ts
+++ b/src/components/currency/Currency.module.scss.d.ts
@@ -1,0 +1,1 @@
+export declare const styledCurrency: string;

--- a/src/components/currency/Currency.tsx
+++ b/src/components/currency/Currency.tsx
@@ -1,23 +1,16 @@
-import styled from 'styled-components';
+import clsx from 'clsx';
 
 import { Text } from 'src/components/text/Text';
-import { theme } from 'src/styles/constants/theme';
 import type { BaseProps } from 'src/types/BaseProps';
 
-const StyledCurrency = styled.span`
-  font-feature-settings: 'tnum' 1;
-  /** Make it not break line */
-  white-space: nowrap;
-  display: flex;
-  gap: ${theme.space4};
-`;
+import styles from './Currency.module.scss';
 
 type Props = BaseProps & {
   amount: number;
   code: string;
 };
 
-export const Currency = ({ amount, className, code }: Props) => {
+export const Currency = ({ amount, className, code, style }: Props) => {
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#options
   const formattedCurrency = new Intl.NumberFormat(`en-US`, {
     currency: code,
@@ -30,13 +23,13 @@ export const Currency = ({ amount, className, code }: Props) => {
   const isNegative = amount < 0;
 
   return (
-    <StyledCurrency className={className}>
+    <span className={clsx(styles.styledCurrency, className)} style={style}>
       <Text color={isNegative ? 'red600' : 'gray1200'} type="label">
         {formattedCurrency}
       </Text>
       <Text color={isNegative ? 'red400' : 'gray700'}>
         {code.toUpperCase()}
       </Text>
-    </StyledCurrency>
+    </span>
   );
 };

--- a/src/components/currency/DualCurrency.module.scss
+++ b/src/components/currency/DualCurrency.module.scss
@@ -1,0 +1,16 @@
+@use 'theme';
+
+$width: var(--amino-dual-currency-width);
+$font-variant-numeric: var(--amino-dual-currency-font-variant-numeric);
+$display: var(--amino-dual-currency-display);
+$grid-template-columns: var(--amino-dual-currency-grid-template-columns);
+
+.dualCurrencyWrapper {
+  align-items: center;
+  justify-items: right;
+  grid-column-gap: theme.$amino-space-8;
+  width: $width;
+  font-variant-numeric: $font-variant-numeric;
+  display: $display;
+  grid-template-columns: $grid-template-columns;
+}

--- a/src/components/currency/DualCurrency.module.scss.d.ts
+++ b/src/components/currency/DualCurrency.module.scss.d.ts
@@ -1,0 +1,1 @@
+export declare const dualCurrencyWrapper: string;

--- a/src/components/currency/DualCurrency.tsx
+++ b/src/components/currency/DualCurrency.tsx
@@ -1,37 +1,15 @@
-import styled, { css } from 'styled-components';
+import clsx from 'clsx';
 
 import { Currency } from 'src/components/currency/Currency';
 import { ArrowSwapIcon } from 'src/icons/ArrowSwapIcon';
-import { theme } from 'src/styles/constants/theme';
 import type { BaseProps } from 'src/types/BaseProps';
+
+import styles from './DualCurrency.module.scss';
 
 type StyledProps = {
   isTabular: boolean;
   width?: string;
 };
-
-const tableCss = css<StyledProps>`
-  font-variant-numeric: tabular-nums;
-  display: grid;
-  grid-template-columns: 1.25fr 0fr 1.25fr;
-`;
-
-const inlineCss = css`
-  display: flex;
-`;
-
-const DualCurrencyWrapper = styled.div<StyledProps>`
-  display: flex;
-  align-items: center;
-  justify-items: right;
-  ${p => (p.isTabular ? tableCss : inlineCss)}
-  grid-column-gap: ${theme.space8};
-  ${p =>
-    p.width &&
-    css`
-      width: p.width;
-    `};
-`;
 
 type Props = BaseProps & {
   conversionRate?: number;
@@ -51,6 +29,7 @@ export const DualCurrency = ({
   localeCode = 'USD',
   showForeign = true,
   showLocale = true,
+  style,
   value,
   width,
 }: Props) => {
@@ -74,15 +53,24 @@ export const DualCurrency = ({
 
   if (showForeignCurrency && showLocaleCurrency && !isSameCode) {
     return (
-      <DualCurrencyWrapper
-        className={className}
-        isTabular={isTabular}
-        width={width?.toString()}
+      <div
+        className={clsx(styles.dualCurrencyWrapper, className)}
+        style={{
+          ...style,
+          '--amino-dual-currency-display': isTabular ? 'grid' : 'flex',
+          '--amino-dual-currency-font-variant-numberic': isTabular
+            ? 'tabular-nums'
+            : '',
+          '--amino-dual-currency-grid-template-columns': isTabular
+            ? '1.25fr 0fr 1.25fr'
+            : '',
+          '--amino-dual-currency-width': width?.toString() || '',
+        }}
       >
         {renderLocaleCurrency()}
         <ArrowSwapIcon size={12} />
         {renderForeignCurrency()}
-      </DualCurrencyWrapper>
+      </div>
     );
   }
 

--- a/src/components/danger-zone/DangerZone.module.scss
+++ b/src/components/danger-zone/DangerZone.module.scss
@@ -1,0 +1,14 @@
+@use 'theme';
+
+.dangerZone {
+  border-color: theme.$amino-red-200;
+  box-shadow: 0px 1px 5px rgba(255, 0, 0, 0.19);
+
+  header {
+    border-color: theme.$amino-red-200;
+  }
+
+  h4 {
+    color: theme.$amino-red-600;
+  }
+}

--- a/src/components/danger-zone/DangerZone.module.scss.d.ts
+++ b/src/components/danger-zone/DangerZone.module.scss.d.ts
@@ -1,0 +1,1 @@
+export declare const dangerZone: string;

--- a/src/components/danger-zone/DangerZone.tsx
+++ b/src/components/danger-zone/DangerZone.tsx
@@ -1,17 +1,19 @@
-import styled from 'styled-components';
+import type { ReactNode } from 'react';
 
-import { Card } from 'src/components/card/Card';
-import { theme } from 'src/styles/constants/theme';
+import clsx from 'clsx';
 
-export const DangerZone = styled(Card)`
-  border-color: ${theme.red200};
-  box-shadow: 0px 1px 5px rgba(255, 0, 0, 0.19);
+import { type CardProps, Card } from 'src/components/card/Card';
+import type { BaseProps } from 'src/types/BaseProps';
 
-  header {
-    border-color: ${theme.red200};
-  }
+import styles from './DangerZone.module.scss';
 
-  h4 {
-    color: ${theme.red600};
-  }
-`;
+export const DangerZone = ({
+  children,
+  className,
+  style,
+  ...props
+}: BaseProps & CardProps & { children: ReactNode }) => (
+  <Card className={clsx(styles.dangerZone, className)} style={style} {...props}>
+    {children}
+  </Card>
+);

--- a/src/components/dialog/BaseDialog.module.scss
+++ b/src/components/dialog/BaseDialog.module.scss
@@ -1,0 +1,30 @@
+@use 'theme';
+
+$width: var(--amino-base-dialog-width);
+$border: var(--amino-base-dialog-border);
+
+.backdrop {
+  width: 100vw;
+  height: 100vh;
+  left: 0;
+  top: 0;
+  z-index: 1000;
+  position: fixed;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: theme.$amino-text-color;
+}
+
+.popup {
+  z-index: 1001;
+  background: theme.$amino-surface-color;
+  width: $width;
+  border-radius: theme.$amino-radius-12;
+  outline: none;
+  box-shadow: theme.$amino-v3-shadow-xxl;
+  border: $border;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}

--- a/src/components/dialog/BaseDialog.module.scss.d.ts
+++ b/src/components/dialog/BaseDialog.module.scss.d.ts
@@ -1,0 +1,2 @@
+export declare const backdrop: string;
+export declare const popup: string;

--- a/src/components/dialog/BaseDialog.tsx
+++ b/src/components/dialog/BaseDialog.tsx
@@ -1,39 +1,14 @@
 import React, { type ReactNode, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 
+import clsx from 'clsx';
 import { type MotionProps, AnimatePresence, motion } from 'framer-motion';
-import styled from 'styled-components';
 
 import { theme } from 'src/styles/constants/theme';
 import type { BaseProps } from 'src/types/BaseProps';
 import type { Theme } from 'src/types/Theme';
 
-const Backdrop = styled(motion.div)`
-  width: 100vw;
-  height: 100vh;
-  left: 0;
-  top: 0;
-  z-index: 1000;
-  position: fixed;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  color: ${theme.textColor};
-`;
-
-const Popup = styled(motion.div)<{ $width: number; $withBorder: boolean }>`
-  z-index: 1001;
-  background: ${theme.surfaceColor};
-  width: ${p => p.$width}px;
-  max-height: 90vh;
-  border-radius: ${theme.radius12};
-  outline: none;
-  box-shadow: ${theme.v3ShadowXxl};
-  border: ${p => p.$withBorder && theme.border};
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-`;
+import styles from './BaseDialog.module.scss';
 
 export type BaseDialogProps = BaseProps & {
   children: ReactNode;
@@ -134,7 +109,8 @@ export const BaseDialog = ({
     return createPortal(
       <AnimatePresence>
         {open && (
-          <Backdrop
+          <motion.div
+            className={clsx(styles.backdrop, className)}
             {...backdropMotionProps}
             key="dialog-backdrop"
             ref={backdropRef}
@@ -155,24 +131,26 @@ export const BaseDialog = ({
               // reset the mouse down target
               mouseDownTarget.current = null;
             }}
-            style={style}
+            style={{
+              ...style,
+              '--amino-base-dialog-border': withBorder ? theme.border : '',
+              '--amino-base-dialog-width': `${width}px`,
+            }}
             tabIndex={-1}
             transition={{ duration: 0.3 }}
           >
-            <Popup
+            <motion.div
               {...combinedPopupMotionProps}
               key="dialog"
-              $width={width}
-              $withBorder={withBorder}
-              className={[className || '', 'elevated'].join(' ')}
+              className={clsx(className, styles.popup, 'elevated')}
               onClick={e => {
                 // Prevent dialog from closing when clicking in the dialog
                 e.stopPropagation();
               }}
             >
               {children}
-            </Popup>
-          </Backdrop>
+            </motion.div>
+          </motion.div>
         )}
       </AnimatePresence>,
       document.querySelector('body')!,

--- a/src/components/dialog/Dialog.module.scss
+++ b/src/components/dialog/Dialog.module.scss
@@ -1,0 +1,57 @@
+@use 'theme';
+
+.header {
+  padding: theme.$amino-space-24;
+  padding-bottom: theme.$amino-space-16;
+  border-top-left-radius: theme.$amino-radius-12;
+  border-top-right-radius: theme.$amino-radius-12;
+  display: flex;
+  flex-direction: column;
+  gap: theme.$amino-space-12;
+}
+
+.title {
+  width: 100%;
+  display: flex;
+  align-items: center;
+
+  > :not(button) {
+    margin: 0;
+    flex-grow: 1;
+  }
+}
+
+.styledActionBaseWrapper {
+  flex-grow: 1;
+  display: flex;
+}
+
+.styledLeftActionWrapper {
+  justify-content: flex-start;
+  display: flex;
+  gap: theme.$amino-space-8;
+}
+
+.styledRightActionWrapper {
+  justify-content: flex-end;
+  display: flex;
+  gap: theme.$amino-space-8;
+}
+
+.footer {
+  padding: theme.$amino-space-24;
+  display: flex;
+  align-items: center;
+  border-bottom-left-radius: theme.$amino-radius-12;
+  border-bottom-right-radius: theme.$amino-radius-12;
+
+  & > div + div {
+    margin-left: theme.$amino-space-8;
+  }
+}
+
+.content {
+  padding: theme.$amino-space-8 theme.$amino-space-24;
+  overflow-y: auto;
+  flex-grow: 1;
+}

--- a/src/components/dialog/Dialog.module.scss.d.ts
+++ b/src/components/dialog/Dialog.module.scss.d.ts
@@ -1,0 +1,7 @@
+export declare const content: string;
+export declare const footer: string;
+export declare const header: string;
+export declare const styledActionBaseWrapper: string;
+export declare const styledLeftActionWrapper: string;
+export declare const styledRightActionWrapper: string;
+export declare const title: string;

--- a/src/components/dialog/Dialog.tsx
+++ b/src/components/dialog/Dialog.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode, forwardRef } from 'react';
 
-import styled from 'styled-components';
+import clsx from 'clsx';
 
 import { ButtonIcon } from 'src/components/button/ButtonIcon';
 import {
@@ -9,62 +9,8 @@ import {
 } from 'src/components/dialog/BaseDialog';
 import { Text } from 'src/components/text/Text';
 import { RemoveCircleDuotoneIcon } from 'src/icons/RemoveCircleDuotoneIcon';
-import { theme } from 'src/styles/constants/theme';
 
-const Header = styled.div`
-  padding: ${theme.space24};
-  padding-bottom: ${theme.space16};
-  border-top-left-radius: ${theme.radius12};
-  border-top-right-radius: ${theme.radius12};
-  display: flex;
-  flex-direction: column;
-  gap: ${theme.space12};
-`;
-
-const Title = styled.div`
-  width: 100%;
-  display: flex;
-  align-items: center;
-
-  > :not(button) {
-    margin: 0;
-    flex-grow: 1;
-  }
-`;
-
-const StyledActionBaseWrapper = styled.div`
-  flex-grow: 1;
-  display: flex;
-`;
-
-const StyledLeftActionWrapper = styled(StyledActionBaseWrapper)`
-  justify-content: flex-start;
-  display: flex;
-  gap: ${theme.space8};
-`;
-const StyledRightActionWrapper = styled(StyledActionBaseWrapper)`
-  justify-content: flex-end;
-  display: flex;
-  gap: ${theme.space8};
-`;
-
-const Footer = styled.div`
-  padding: ${theme.space24};
-  display: flex;
-  align-items: center;
-  border-bottom-left-radius: ${theme.radius12};
-  border-bottom-right-radius: ${theme.radius12};
-
-  & > div + div {
-    margin-left: ${theme.space8};
-  }
-`;
-
-const Content = styled.div`
-  padding: ${theme.space8} ${theme.space24};
-  overflow-y: auto;
-  flex-grow: 1;
-`;
+import styles from './Dialog.module.scss';
 
 export type DialogProps = BaseDialogProps & {
   actions?: ReactNode;
@@ -76,12 +22,21 @@ export type DialogProps = BaseDialogProps & {
 
 export const Dialog = forwardRef<HTMLDivElement, DialogProps>(
   (
-    { actions, children, label, leftActions, onClose, subtitle, ...props },
+    {
+      actions,
+      children,
+      label,
+      leftActions,
+      onClose,
+      style,
+      subtitle,
+      ...props
+    },
     ref,
   ) => (
     <BaseDialog {...props} onClose={onClose}>
-      <Header>
-        <Title>
+      <div className={styles.header}>
+        <div className={styles.title}>
           <Text type="title">{label}</Text>
           <ButtonIcon
             icon={<RemoveCircleDuotoneIcon size={24} />}
@@ -89,19 +44,35 @@ export const Dialog = forwardRef<HTMLDivElement, DialogProps>(
             onClick={onClose}
             variant="text"
           />
-        </Title>
+        </div>
         {subtitle && <Text type="subtitle">{subtitle}</Text>}
-      </Header>
-      <Content ref={ref}>{children}</Content>
+      </div>
+      <div ref={ref} className={styles.content}>
+        {children}
+      </div>
       {(actions || leftActions) && (
-        <Footer>
+        <div className={styles.footer}>
           {leftActions && (
-            <StyledLeftActionWrapper>{leftActions}</StyledLeftActionWrapper>
+            <div
+              className={clsx(
+                styles.styledActionBaseWrapper,
+                styles.styledLeftActionWrapper,
+              )}
+            >
+              {leftActions}
+            </div>
           )}
           {actions && (
-            <StyledRightActionWrapper>{actions}</StyledRightActionWrapper>
+            <div
+              className={clsx(
+                styles.styledActionBaseWrapper,
+                styles.styledRightActionWrapper,
+              )}
+            >
+              {actions}
+            </div>
           )}
-        </Footer>
+        </div>
       )}
     </BaseDialog>
   ),

--- a/src/components/divider/Divider.module.scss
+++ b/src/components/divider/Divider.module.scss
@@ -1,0 +1,13 @@
+@use 'theme';
+
+.dividerHorizontal {
+  margin: theme.$amino-space-24 0;
+  border-color: theme.$amino-border-color;
+}
+
+.dividerVertical {
+  margin: 0 theme.$amino-space-24;
+  height: auto;
+  align-self: stretch;
+  border-right: solid thin theme.$amino-border-color;
+}

--- a/src/components/divider/Divider.module.scss.d.ts
+++ b/src/components/divider/Divider.module.scss.d.ts
@@ -1,0 +1,2 @@
+export declare const dividerHorizontal: string;
+export declare const dividerVertical: string;

--- a/src/components/divider/Divider.tsx
+++ b/src/components/divider/Divider.tsx
@@ -1,27 +1,18 @@
+import clsx from 'clsx';
 import styled from 'styled-components';
 
 import { theme } from 'src/styles/constants/theme';
 import type { BaseProps } from 'src/types/BaseProps';
 
-const DividerHorizontal = styled.hr`
-  margin: ${theme.space24} 0;
-  border-color: ${theme.borderColor};
-`;
-
-const DividerVertical = styled.hr`
-  margin: 0 ${theme.space24};
-  height: auto;
-  align-self: stretch;
-  border-right: solid thin ${theme.borderColor};
-`;
+import styles from './Divider.module.scss';
 
 type Props = BaseProps & {
   vertical?: boolean;
 };
 
-export const Divider = ({ className, vertical = false }: Props) =>
+export const Divider = ({ className, style, vertical = false }: Props) =>
   vertical ? (
-    <DividerVertical className={className} />
+    <hr className={clsx(styles.dividerVertical, className)} style={style} />
   ) : (
-    <DividerHorizontal className={className} />
+    <hr className={clsx(styles.dividerHorizontal, className)} style={style} />
   );

--- a/src/components/drop-zone/DropZone.module.scss
+++ b/src/components/drop-zone/DropZone.module.scss
@@ -1,0 +1,69 @@
+@use 'theme';
+
+$opacity: var(--amino-drop-zone-opacity);
+$cursor: var(--amino-drop-zone-cursor);
+$border-color: var(--amino-drop-zone-border-color);
+
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: theme.$amino-space-16;
+  opacity: $opacity;
+  cursor: $cursor;
+}
+
+.uploadWrapper {
+  border: 2px dashed;
+  border-color: $border-color;
+  border-radius: theme.$amino-radius-12;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.contentWrapper {
+  padding: theme.$amino-space-16;
+  outline: none;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: theme.$amino-space-12;
+  width: 100%;
+  height: 100%;
+}
+
+.instructionTextWrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: theme.$amino-space-4;
+}
+
+.browseButton {
+  display: inline;
+}
+
+.removeFileButton {
+  margin-left: auto;
+}
+
+.uploadedFilesWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: theme.$amino-space-4;
+}
+
+.uploadedFileRow {
+  border: theme.$amino-border;
+  border-radius: theme.$amino-radius-12;
+  padding: theme.$amino-space-16;
+  display: flex;
+  justify-content: flex-start;
+  gap: theme.$amino-space-12;
+}
+
+.uploadedFileInfoWrapper {
+  display: flex;
+  flex-direction: column;
+}

--- a/src/components/drop-zone/DropZone.module.scss.d.ts
+++ b/src/components/drop-zone/DropZone.module.scss.d.ts
@@ -1,0 +1,9 @@
+export declare const browseButton: string;
+export declare const contentWrapper: string;
+export declare const instructionTextWrapper: string;
+export declare const removeFileButton: string;
+export declare const uploadedFileInfoWrapper: string;
+export declare const uploadedFileRow: string;
+export declare const uploadedFilesWrapper: string;
+export declare const uploadWrapper: string;
+export declare const wrapper: string;

--- a/src/components/drop-zone/DropZone.tsx
+++ b/src/components/drop-zone/DropZone.tsx
@@ -1,8 +1,10 @@
 import { type DropzoneOptions, useDropzone } from 'react-dropzone';
 
+import clsx from 'clsx';
 import styled from 'styled-components';
 
 import { ImageAvatar } from 'src/components/avatar/ImageAvatar';
+import { Button } from 'src/components/button/Button';
 import { ButtonIcon } from 'src/components/button/ButtonIcon';
 import { Spinner } from 'src/components/spinner/Spinner';
 import { Text } from 'src/components/text/Text';
@@ -13,6 +15,8 @@ import { RemoveCircleDuotoneIcon } from 'src/icons/RemoveCircleDuotoneIcon';
 import { theme } from 'src/styles/constants/theme';
 import type { BaseProps } from 'src/types/BaseProps';
 import { type UploadedFile } from 'src/types/UploadedFile';
+
+import styles from './DropZone.module.scss';
 
 const Wrapper = styled.div<{ $disabled: boolean }>`
   display: flex;
@@ -122,6 +126,7 @@ export const DropZone = ({
   loadingText = 'Uploading file(s)...',
   noIcon = false,
   onRemoveFile,
+  style,
   uploadedFiles,
 }: DropZoneProps) => {
   const maxFiles = dropzoneOptions.maxFiles || 0;
@@ -135,32 +140,37 @@ export const DropZone = ({
 
   const renderUpload = () => (
     // The role gets set to button despite setting `noClick`, so override it as `undefined`
-    <ContentWrapper {...getRootProps()} role={undefined}>
+    <div className={styles.contentWrapper} {...getRootProps()} role={undefined}>
       <input {...getInputProps()} />
       {!noIcon && <Thumbnail icon={<FileUploadDuotoneIcon />} size={40} />}
-      <InstructionTextWrapper>
+      <div className={styles.instructionTextWrapper}>
         <Text type="label">
           {instructionText} or{' '}
-          <BrowseButton disabled={disabled} onClick={open} type="button">
+          <button
+            className={styles.browseButton}
+            disabled={disabled}
+            onClick={open}
+            type="button"
+          >
             <Text color="blue600" type="label">
               browse
             </Text>
-          </BrowseButton>
+          </button>
         </Text>
         {helpText && <Text type="caption">{helpText}</Text>}
-      </InstructionTextWrapper>
-    </ContentWrapper>
+      </div>
+    </div>
   );
 
   const renderFiles = () =>
     uploadedFiles.map((file, index) => (
-      <UploadedFileRow key={file.name}>
+      <div key={file.name} className={styles.uploadedFileRow}>
         {file.imageUrl ? (
           <ImageAvatar imageUrl={file.imageUrl} shape="rounded" />
         ) : (
           <FileDuotoneIcon />
         )}
-        <UploadedFileInfoWrapper>
+        <div className={styles.uploadedFileInfoWrapper}>
           <Text color="gray1200" type="label">
             {file.name}
           </Text>
@@ -169,15 +179,16 @@ export const DropZone = ({
               {file.size}
             </Text>
           )}
-        </UploadedFileInfoWrapper>
+        </div>
         {onRemoveFile && (
-          <RemoveFileButton
+          <ButtonIcon
+            className={styles.removeFileButton}
             icon={<RemoveCircleDuotoneIcon size={20} />}
             onClick={() => onRemoveFile(index)}
             variant="text"
           />
         )}
-      </UploadedFileRow>
+      </div>
     ));
 
   const uploadedMaxFiles = maxFiles !== 0 && uploadedFiles.length >= maxFiles;
@@ -185,31 +196,42 @@ export const DropZone = ({
   const renderContent = () => {
     if (loading) {
       return (
-        <UploadWrapper>
-          <ContentWrapper>
+        <div className={styles.uploadWrapper}>
+          <div className={styles.contentWrapper}>
             <Spinner />
             <Text color="gray800" type="label">
               {loadingText}
             </Text>
-          </ContentWrapper>
-        </UploadWrapper>
+          </div>
+        </div>
       );
     }
 
     return (
       <>
         {!uploadedMaxFiles && (
-          <UploadWrapper $error={error}>{renderUpload()}</UploadWrapper>
+          <div className={styles.uploadWrapper}>{renderUpload()}</div>
         )}
         {!!uploadedFiles.length && (
-          <UploadedFilesWrapper>{renderFiles()}</UploadedFilesWrapper>
+          <div className={styles.uploadedFilesWrapper}>{renderFiles()}</div>
         )}
       </>
     );
   };
 
   return (
-    <Wrapper $disabled={disabled} className={className}>
+    <Wrapper
+      $disabled={disabled}
+      className={clsx(styles.wrapper, className)}
+      style={{
+        ...style,
+        '--amino-drop-zone-border-color': error
+          ? theme.danger
+          : theme.borderColor,
+        '--amino-drop-zone-cursor': disabled ? 'not-allowed' : 'auto',
+        '--amino-drop-zone-opacity': disabled ? 0.5 : 1,
+      }}
+    >
       {renderContent()}
     </Wrapper>
   );


### PR DESCRIPTION
## Jira issue
[CSS Modules - C-D](https://myzonos.atlassian.net/browse/FE-743)

## Description

This PR converts the following components from Styled Components to CSS Modules:

- Checkbox
- Collapse
- ConfirmDialog
- ConnectionMap
- CoverSheet
- Currency
- DualCurrency
- DangerZone
- BaseDialog
- Dialog
- Divider
- DropZone

## Testing
Preview domain: [css-modules.amino.zonos.com](https://css-modules.amino.zonos.com/)

Check the above components against the current versions at [https://amino.zonos.com](Amino)

## Todo

- [ ] Bump version and add tag
