### PR TITLE
refactor(css): convert to css modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.1.66",
+  "version": "5.1.67",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/all.ts
+++ b/src/all.ts
@@ -33,7 +33,7 @@ import './components/file-upload/FileUpload';
 import './components/filter/filter-amount/FilterAmount';
 import './components/filter/filter-amount/filterAmountReducer';
 import './components/filter/filter-date/DateControls';
-import './components/filter/filter-date/dateUtils';
+import './components/filter/filter-date/DateControlsWrapper';
 import './components/filter/filter-date/FilterDate';
 import './components/filter/filter-date/filterDateReducer';
 import './components/filter/filter-multi-select/FilterMultiSelect';

--- a/src/components/file-upload/FileUpload.module.scss
+++ b/src/components/file-upload/FileUpload.module.scss
@@ -1,0 +1,43 @@
+@use 'theme';
+
+$border-color: var(--amino-file-upload-border-color);
+$opacity: var(--amino-file-upload-opacity);
+$cursor: var(--amino-file-upload-cursor);
+
+.wrapper {
+  display: flex;
+  justify-content: flex-start;
+  padding: theme.$amino-space-8 theme.$amino-space-12;
+  border-radius: theme.$amino-radius-10;
+  border: theme.$amino-border;
+  border-color: $border-color;
+
+  opacity: $opacity;
+  cursor: $cursor;
+}
+
+.styledFileInput {
+  outline: none;
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+}
+
+.contentWrapper {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  gap: theme.$amino-space-12;
+}
+
+.uploadedFileInfoWrapper {
+  display: flex;
+  gap: theme.$amino-space-4;
+  align-items: center;
+}
+
+.removeFileButton {
+  margin-left: auto;
+}

--- a/src/components/file-upload/FileUpload.module.scss.d.ts
+++ b/src/components/file-upload/FileUpload.module.scss.d.ts
@@ -1,0 +1,5 @@
+export declare const contentWrapper: string;
+export declare const removeFileButton: string;
+export declare const styledFileInput: string;
+export declare const uploadedFileInfoWrapper: string;
+export declare const wrapper: string;

--- a/src/components/file-upload/FileUpload.tsx
+++ b/src/components/file-upload/FileUpload.tsx
@@ -1,6 +1,6 @@
 import { type DropzoneOptions, useDropzone } from 'react-dropzone';
 
-import styled from 'styled-components';
+import clsx from 'clsx';
 
 import { Button } from 'src/components/button/Button';
 import { ButtonIcon } from 'src/components/button/ButtonIcon';
@@ -9,48 +9,7 @@ import { RemoveCircleDuotoneIcon } from 'src/icons/RemoveCircleDuotoneIcon';
 import { theme } from 'src/styles/constants/theme';
 import type { BaseProps } from 'src/types/BaseProps';
 
-type WrapperProps = {
-  disabled: boolean;
-  error: boolean;
-};
-
-const Wrapper = styled.div<WrapperProps>`
-  display: flex;
-  justify-content: flex-start;
-  padding: ${theme.space8} ${theme.space12};
-  border-radius: ${theme.radius10};
-  border: ${theme.border};
-  border-color: ${({ error }) => (error ? theme.danger : theme.borderColor)};
-
-  opacity: ${p => (p.disabled ? 0.5 : 1)};
-  cursor: ${p => (p.disabled ? 'not-allowed' : 'auto')};
-`;
-
-const StyledFileInput = styled.div`
-  outline: none;
-  text-align: center;
-  display: flex;
-  justify-content: center;
-  flex-direction: column;
-  align-items: center;
-`;
-
-const ContentWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: ${theme.space12};
-`;
-
-const UploadedFileInfoWrapper = styled.div`
-  display: flex;
-  gap: ${theme.space4};
-  align-items: center;
-`;
-
-const RemoveFileButton = styled(ButtonIcon)`
-  margin-left: auto;
-`;
+import styles from './FileUpload.module.scss';
 
 type UploadFileNoImage = {
   name: string;
@@ -94,6 +53,7 @@ export const FileUpload = ({
   loading,
   loadingText = 'Uploading...',
   onRemoveFile,
+  style,
   uploadedFile,
 }: FileUploadProps) => {
   const { getInputProps, getRootProps, open } = useDropzone({
@@ -109,7 +69,7 @@ export const FileUpload = ({
       const { name, size } = uploadedFile;
 
       return (
-        <UploadedFileInfoWrapper>
+        <div className={styles.uploadedFileInfoWrapper}>
           <Text color="gray1200" type="label">
             {name}
           </Text>
@@ -118,7 +78,7 @@ export const FileUpload = ({
               {size}
             </Text>
           )}
-        </UploadedFileInfoWrapper>
+        </div>
       );
     }
 
@@ -138,27 +98,38 @@ export const FileUpload = ({
   };
 
   const renderContent = () => (
-    <StyledFileInput {...getRootProps()}>
+    <div className={styles.styledFileInput} {...getRootProps()}>
       <input {...getInputProps()} />
-      <ContentWrapper>
+      <div className={styles.contentWrapper}>
         <Button loading={loading} onClick={open} spinnerColor="black">
           Browse
         </Button>
         {renderText()}
-      </ContentWrapper>
-    </StyledFileInput>
+      </div>
+    </div>
   );
 
   return (
-    <Wrapper className={className} disabled={disabled} error={error}>
+    <div
+      className={clsx(styles.wrapper, className)}
+      style={{
+        ...style,
+        '--amino-file-upload-border-color': error
+          ? theme.danger
+          : theme.borderColor,
+        '--amino-file-upload-cursor': disabled ? 'not-allowed' : 'auto',
+        '--amino-file-upload-opacity': disabled ? 0.5 : 1,
+      }}
+    >
       {renderContent()}
       {onRemoveFile && uploadedFile && (
-        <RemoveFileButton
+        <ButtonIcon
+          className={styles.removeFileButton}
           icon={<RemoveCircleDuotoneIcon size={20} />}
           onClick={() => onRemoveFile()}
           variant="text"
         />
       )}
-    </Wrapper>
+    </div>
   );
 };

--- a/src/components/filter/FilterWrapper.module.scss
+++ b/src/components/filter/FilterWrapper.module.scss
@@ -1,0 +1,74 @@
+@use 'theme';
+
+$border-top-right-radius: var(--amino-filter-wrapper-border-top-right-radius);
+$border-bottom-right-radius: var(--amino-filter-wrapper-border-bottom-right-radius);
+$border-right-color: var(--amino-filter-wrapper-border-right-color);
+
+.filterWrapper {
+  position: relative;
+}
+
+.badgeWrapper {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 100px;
+  border: 1px dashed theme.$amino-gray-200;
+  background-color: transparent;
+  color: theme.$amino-gray-700;
+
+  &:global(.active) {
+    border: theme.$amino-border;
+  }
+}
+
+.toggleWrapper {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: theme.$amino-space-8;
+  padding: theme.$amino-space-4 theme.$amino-space-8;
+  border-radius: 100px;
+  border-top-right-radius: $border-top-right-radius;
+  border-bottom-right-radius: $border-bottom-right-radius;
+  border-right: 1px solid $border-right-color;
+  
+  &:hover {
+    background-color: theme.$amino-gray-100;
+  }
+}
+
+.styledDropdownTrigger {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: theme.$amino-space-8;
+  padding: theme.$amino-space-4 theme.$amino-space-8;
+  border-radius: 100px;
+  border-top-left-radius: 0px;
+  border-bottom-left-radius: 0px;
+
+  &:hover {
+    background-color: theme.$amino-gray-100;
+  }
+}
+
+.dropdownWrapper {
+  z-index: 1;
+  min-width: 400px;
+  position: absolute;
+  border-radius: theme.$amino-radius-12;
+  background-color: theme.$amino-surface-color;
+  box-shadow: theme.$amino-v3-shadow-xl;
+  padding: theme.$amino-space-24;
+  display: flex;
+  flex-direction: column;
+  gap: theme.$amino-space-24;
+  outline: none;
+}
+
+.controlsWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: theme.$amino-space-8;
+  max-height: 400px;;
+}

--- a/src/components/filter/FilterWrapper.module.scss.d.ts
+++ b/src/components/filter/FilterWrapper.module.scss.d.ts
@@ -1,0 +1,6 @@
+export declare const badgeWrapper: string;
+export declare const controlsWrapper: string;
+export declare const dropdownWrapper: string;
+export declare const filterWrapper: string;
+export declare const styledDropdownTrigger: string;
+export declare const toggleWrapper: string;

--- a/src/components/filter/FilterWrapper.tsx
+++ b/src/components/filter/FilterWrapper.tsx
@@ -1,0 +1,113 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+import type { KeyboardEvent, MouseEvent, ReactNode, RefObject } from 'react';
+
+import clsx from 'clsx';
+
+import { Button } from 'src/components/button/Button';
+import { Text } from 'src/components/text/Text';
+import { ChevronDownIcon } from 'src/icons/ChevronDownIcon';
+import { MinusCircleDuotoneIcon } from 'src/icons/MinusCircleDuotoneIcon';
+import { PlusCircleDuotoneIcon } from 'src/icons/PlusCircleDuotoneIcon';
+import { theme } from 'src/styles/constants/theme';
+import type { BaseProps } from 'src/types/BaseProps';
+
+import styles from './FilterWrapper.module.scss';
+
+type FilterWrapperProps = BaseProps & {
+  active: boolean;
+  children: ReactNode;
+  dropDownOpen: boolean;
+  dropdownRef: RefObject<HTMLDivElement>;
+  dropdownTitle: string;
+  filterText: string;
+  hasFilter: boolean;
+  label: string;
+  ref: RefObject<HTMLDivElement>;
+  handleApply: () => void;
+  handleKeyDown: (event: KeyboardEvent) => void;
+  handleOpenDropdown: (e: MouseEvent) => void;
+  handleToggle: () => void;
+};
+
+export const FilterWrapper = ({
+  active,
+  children,
+  className,
+  dropDownOpen,
+  dropdownRef,
+  dropdownTitle,
+  filterText,
+  handleApply,
+  handleKeyDown,
+  handleOpenDropdown,
+  handleToggle,
+  hasFilter,
+  label,
+  ref,
+  style,
+}: FilterWrapperProps) => (
+  <div
+    ref={ref}
+    className={clsx(className, styles.filterWrapper)}
+    style={{
+      ...style,
+      '--amino-filter-wrapper-border-bottom-right-radius': hasFilter
+        ? '0px'
+        : '100px',
+      '--amino-filter-wrapper-border-right-color': active
+        ? theme.borderColor
+        : theme.gray200,
+      '--amino-filter-wrapper-border-top-right-radius': hasFilter
+        ? '0px'
+        : '100px',
+    }}
+  >
+    <div
+      className={clsx(active && 'active', styles.badgeWrapper)}
+      onClick={handleToggle}
+    >
+      <div className={styles.toggleWrapper}>
+        {active ? (
+          <MinusCircleDuotoneIcon
+            color="gray0"
+            secondaryColor="gray600"
+            size={24}
+          />
+        ) : (
+          <PlusCircleDuotoneIcon
+            color="gray0"
+            secondaryColor="gray600"
+            size={24}
+          />
+        )}
+        <Text fontWeight={600}>{label}</Text>
+      </div>
+      {hasFilter && (
+        <div
+          className={styles.styledDropdownTrigger}
+          onClick={handleOpenDropdown}
+        >
+          <Text color="blue600" fontWeight={600}>
+            {filterText}
+          </Text>
+          <ChevronDownIcon size={24} />
+        </div>
+      )}
+    </div>
+    {dropDownOpen && (
+      <div
+        ref={dropdownRef}
+        className={styles.dropdownWrapper}
+        onKeyDown={handleKeyDown}
+        tabIndex={-1}
+      >
+        <Text type="bold-subheader">{dropdownTitle}</Text>
+        <div className={styles.controlsWrapper}>{children}</div>
+        <Button onClick={handleApply} size="md" variant="primary">
+          Apply
+        </Button>
+      </div>
+    )}
+  </div>
+);

--- a/src/components/filter/filter-amount/FilterAmount.module.scss
+++ b/src/components/filter/filter-amount/FilterAmount.module.scss
@@ -1,0 +1,15 @@
+@use 'theme';
+
+.inputWrapper {
+  display: flex;
+  align-items: center;
+  gap: theme.$amino-space-8;
+
+  svg {
+    min-width: theme.$amino-space-24;
+  }
+
+  :global(.arrow-right) {
+    margin-right: theme.$amino-space-16;
+  }
+}

--- a/src/components/filter/filter-amount/FilterAmount.module.scss.d.ts
+++ b/src/components/filter/filter-amount/FilterAmount.module.scss.d.ts
@@ -1,0 +1,1 @@
+export declare const inputWrapper: string;

--- a/src/components/filter/filter-amount/FilterAmount.tsx
+++ b/src/components/filter/filter-amount/FilterAmount.tsx
@@ -1,7 +1,5 @@
 import { type Dispatch, type KeyboardEvent, useState } from 'react';
 
-import styled from 'styled-components';
-
 import {
   type FilterAmountAction,
   type FilterAmountState,
@@ -16,21 +14,8 @@ import {
 import { Input } from 'src/components/input/Input';
 import { Select } from 'src/components/select/Select';
 import { ArrowRightIcon } from 'src/icons/ArrowRightIcon';
-import { theme } from 'src/styles/constants/theme';
 
-const InputWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  gap: ${theme.space8};
-
-  svg {
-    min-width: 24px;
-  }
-
-  & .arrow-right {
-    margin-right: ${theme.space16};
-  }
-`;
+import styles from './FilterAmount.module.scss';
 
 export type FilterAmountType = 'equal' | 'between' | 'greater' | 'less';
 
@@ -44,6 +29,7 @@ export const FilterAmount = ({
   dropdownTitle,
   filter,
   label,
+  style,
 }: FilterAmountProps) => {
   const [filterType, setFilterType] = useState<FilterAmountType>(
     filter.amountFilterType,
@@ -161,10 +147,11 @@ export const FilterAmount = ({
         onMenuOpen={() => setMenuOpen(true)}
         options={filterAmountOptions}
         size="md"
+        style={style}
         value={filterAmountOptions.filter(item => item.value === filterType)}
       />
 
-      <InputWrapper>
+      <div className={styles.inputWrapper}>
         <ArrowRightIcon className="arrow-right" color="blue600" size={24} />
         <Input
           onChange={e => setEditingAmount1(e.target.valueAsNumber)}
@@ -183,7 +170,7 @@ export const FilterAmount = ({
             />
           </>
         )}
-      </InputWrapper>
+      </div>
     </>,
   );
 };

--- a/src/components/filter/filter-amount/FilterAmount.tsx
+++ b/src/components/filter/filter-amount/FilterAmount.tsx
@@ -29,7 +29,6 @@ export const FilterAmount = ({
   dropdownTitle,
   filter,
   label,
-  style,
 }: FilterAmountProps) => {
   const [filterType, setFilterType] = useState<FilterAmountType>(
     filter.amountFilterType,
@@ -147,7 +146,6 @@ export const FilterAmount = ({
         onMenuOpen={() => setMenuOpen(true)}
         options={filterAmountOptions}
         size="md"
-        style={style}
         value={filterAmountOptions.filter(item => item.value === filterType)}
       />
 

--- a/src/components/filter/filter-date/DateControls.module.scss
+++ b/src/components/filter/filter-date/DateControls.module.scss
@@ -1,0 +1,19 @@
+@use 'theme';
+
+.controlsValueWrapper {
+  display: flex;
+  align-items: center;
+  gap: theme.$amino-space-16;
+
+  > svg {
+    flex-shrink: 0;
+  }
+}
+
+.dateControlsWrapper {
+  width: 100%;
+  display: grid;
+  grid-auto-flow: column;
+  gap: theme.$amino-space-8;
+  align-items: center;
+}

--- a/src/components/filter/filter-date/DateControls.module.scss.d.ts
+++ b/src/components/filter/filter-date/DateControls.module.scss.d.ts
@@ -1,0 +1,2 @@
+export declare const controlsValueWrapper: string;
+export declare const dateControlsWrapper: string;

--- a/src/components/filter/filter-date/DateControls.tsx
+++ b/src/components/filter/filter-date/DateControls.tsx
@@ -32,7 +32,7 @@ type DateControlProps = BaseProps & {
   setRangeType: (range: FilterDateRangeType) => void;
 };
 
-export const DateControl = ({
+export const DateControls = ({
   onChange,
   onChangeFilterText,
   rangeType,

--- a/src/components/filter/filter-date/DateControls.tsx
+++ b/src/components/filter/filter-date/DateControls.tsx
@@ -1,7 +1,5 @@
 import { type KeyboardEvent, useState } from 'react';
 
-import styled from 'styled-components';
-
 import { IsAfter } from 'src/components/filter/filter-date/_DateControls/_IsAfter';
 import { IsBefore } from 'src/components/filter/filter-date/_DateControls/_IsBefore';
 import { IsBeforeOrOn } from 'src/components/filter/filter-date/_DateControls/_IsBeforeOrOn';
@@ -17,24 +15,16 @@ import {
 } from 'src/components/filter/filter-date/filterDateReducer';
 import { Select } from 'src/components/select/Select';
 import { ArrowRightIcon } from 'src/icons/ArrowRightIcon';
-import { theme } from 'src/styles/constants/theme';
+import type { BaseProps } from 'src/types/BaseProps';
 
-const ControlsValueWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  gap: ${theme.space16};
-
-  > svg {
-    flex-shrink: 0;
-  }
-`;
+import styles from './DateControls.module.scss';
 
 const optionsDate = filterDateRanges.map(r => ({
   label: r,
   value: r,
 }));
 
-type DateControlProps = {
+type DateControlProps = BaseProps & {
   rangeType: FilterDateRangeType;
   value: FilterDateData;
   onChange: (value: FilterDateData) => void;
@@ -47,6 +37,7 @@ export const DateControl = ({
   onChangeFilterText,
   rangeType,
   setRangeType,
+  style,
   value,
 }: DateControlProps) => {
   const [menuOpen, setMenuOpen] = useState(false);
@@ -140,12 +131,13 @@ export const DateControl = ({
         onMenuOpen={() => setMenuOpen(true)}
         options={optionsDate}
         size="sm"
+        style={style}
         value={optionsDate.filter(item => item.value === rangeType)}
       />
-      <ControlsValueWrapper>
+      <div className={styles.controlsValueWrapper} style={style}>
         <ArrowRightIcon color="blue600" />
         {renderRangeControl()}
-      </ControlsValueWrapper>
+      </div>
     </>
   );
 };

--- a/src/components/filter/filter-date/DateControls.tsx
+++ b/src/components/filter/filter-date/DateControls.tsx
@@ -37,7 +37,6 @@ export const DateControls = ({
   onChangeFilterText,
   rangeType,
   setRangeType,
-  style,
   value,
 }: DateControlProps) => {
   const [menuOpen, setMenuOpen] = useState(false);
@@ -131,10 +130,9 @@ export const DateControls = ({
         onMenuOpen={() => setMenuOpen(true)}
         options={optionsDate}
         size="sm"
-        style={style}
         value={optionsDate.filter(item => item.value === rangeType)}
       />
-      <div className={styles.controlsValueWrapper} style={style}>
+      <div className={styles.controlsValueWrapper}>
         <ArrowRightIcon color="blue600" />
         {renderRangeControl()}
       </div>

--- a/src/components/filter/filter-date/DateControlsWrapper.tsx
+++ b/src/components/filter/filter-date/DateControlsWrapper.tsx
@@ -1,16 +1,12 @@
+import type { ReactNode } from 'react';
+
+import clsx from 'clsx';
 import dayjs from 'dayjs';
-import styled from 'styled-components';
 
 import type { FilterDateData } from 'src/components/filter/filter-date/filterDateReducer';
-import { theme } from 'src/styles/constants/theme';
+import type { BaseProps } from 'src/types/BaseProps';
 
-export const DateControlsWrapper = styled.div`
-  width: 100%;
-  display: grid;
-  grid-auto-flow: column;
-  gap: ${theme.space8};
-  align-items: center;
-`;
+import styles from './DateControls.module.scss';
 
 export type _DateControlProps = {
   value: FilterDateData;
@@ -21,3 +17,13 @@ export type _DateControlProps = {
 export const formatDate = (date: string) => dayjs(date).format('MM/DD/YYYY');
 
 export const defaultDateFormat = `YYYY-MM-DD`;
+
+export const DateControlsWrapper = ({
+  children,
+  className,
+  style,
+}: BaseProps & { children: ReactNode }) => (
+  <div className={clsx(styles.dateControlsWrapper, className)} style={style}>
+    {children}
+  </div>
+);

--- a/src/components/filter/filter-date/FilterDate.tsx
+++ b/src/components/filter/filter-date/FilterDate.tsx
@@ -27,6 +27,7 @@ export const FilterDate = ({
   dropdownTitle,
   filter,
   label,
+  style,
 }: FilterDateProps) => {
   const [editingValue, setEditingValue] = useState<FilterDateData>(
     filter.dateData,
@@ -115,6 +116,7 @@ export const FilterDate = ({
       onChangeFilterText={handleChangeFilterText}
       rangeType={rangeType}
       setRangeType={setRangeType}
+      style={style}
       value={editingValue}
     />,
   );

--- a/src/components/filter/filter-date/FilterDate.tsx
+++ b/src/components/filter/filter-date/FilterDate.tsx
@@ -1,6 +1,6 @@
 import { type Dispatch, useState } from 'react';
 
-import { DateControl } from 'src/components/filter/filter-date/DateControls';
+import { DateControls } from 'src/components/filter/filter-date/DateControls';
 import {
   type FilterDateAction,
   type FilterDateData,
@@ -111,7 +111,7 @@ export const FilterDate = ({
   };
 
   return renderWrapper(
-    <DateControl
+    <DateControls
       onChange={setEditingValue}
       onChangeFilterText={handleChangeFilterText}
       rangeType={rangeType}

--- a/src/components/filter/filter-date/FilterDate.tsx
+++ b/src/components/filter/filter-date/FilterDate.tsx
@@ -27,7 +27,6 @@ export const FilterDate = ({
   dropdownTitle,
   filter,
   label,
-  style,
 }: FilterDateProps) => {
   const [editingValue, setEditingValue] = useState<FilterDateData>(
     filter.dateData,
@@ -116,7 +115,6 @@ export const FilterDate = ({
       onChangeFilterText={handleChangeFilterText}
       rangeType={rangeType}
       setRangeType={setRangeType}
-      style={style}
       value={editingValue}
     />,
   );

--- a/src/components/filter/filter-date/_DateControls/_IsAfter.tsx
+++ b/src/components/filter/filter-date/_DateControls/_IsAfter.tsx
@@ -7,7 +7,7 @@ import {
   DateControlsWrapper,
   defaultDateFormat,
   formatDate,
-} from 'src/components/filter/filter-date/dateUtils';
+} from 'src/components/filter/filter-date/DateControlsWrapper';
 import { Input } from 'src/components/input/Input';
 
 export const IsAfter = ({

--- a/src/components/filter/filter-date/_DateControls/_IsBefore.tsx
+++ b/src/components/filter/filter-date/_DateControls/_IsBefore.tsx
@@ -7,7 +7,7 @@ import {
   DateControlsWrapper,
   defaultDateFormat,
   formatDate,
-} from 'src/components/filter/filter-date/dateUtils';
+} from 'src/components/filter/filter-date/DateControlsWrapper';
 import { Input } from 'src/components/input/Input';
 
 export const IsBefore = ({

--- a/src/components/filter/filter-date/_DateControls/_IsBeforeOrOn.tsx
+++ b/src/components/filter/filter-date/_DateControls/_IsBeforeOrOn.tsx
@@ -7,7 +7,7 @@ import {
   DateControlsWrapper,
   defaultDateFormat,
   formatDate,
-} from 'src/components/filter/filter-date/dateUtils';
+} from 'src/components/filter/filter-date/DateControlsWrapper';
 import { Input } from 'src/components/input/Input';
 
 export const IsBeforeOrOn = ({

--- a/src/components/filter/filter-date/_DateControls/_IsBetween.tsx
+++ b/src/components/filter/filter-date/_DateControls/_IsBetween.tsx
@@ -7,7 +7,7 @@ import {
   DateControlsWrapper,
   defaultDateFormat,
   formatDate,
-} from 'src/components/filter/filter-date/dateUtils';
+} from 'src/components/filter/filter-date/DateControlsWrapper';
 import { Input } from 'src/components/input/Input';
 import { Text } from 'src/components/text/Text';
 

--- a/src/components/filter/filter-date/_DateControls/_IsEqualTo.tsx
+++ b/src/components/filter/filter-date/_DateControls/_IsEqualTo.tsx
@@ -7,7 +7,7 @@ import {
   DateControlsWrapper,
   defaultDateFormat,
   formatDate,
-} from 'src/components/filter/filter-date/dateUtils';
+} from 'src/components/filter/filter-date/DateControlsWrapper';
 import { Input } from 'src/components/input/Input';
 
 export const IsEqualTo = ({

--- a/src/components/filter/filter-date/_DateControls/_IsInTheLast.tsx
+++ b/src/components/filter/filter-date/_DateControls/_IsInTheLast.tsx
@@ -6,7 +6,7 @@ import {
   type _DateControlProps,
   DateControlsWrapper,
   defaultDateFormat,
-} from 'src/components/filter/filter-date/dateUtils';
+} from 'src/components/filter/filter-date/DateControlsWrapper';
 import {
   type FilterDateLastRangeUnit,
   dateUnits,

--- a/src/components/filter/filter-date/_DateControls/_IsOnOrAfter.tsx
+++ b/src/components/filter/filter-date/_DateControls/_IsOnOrAfter.tsx
@@ -7,7 +7,7 @@ import {
   DateControlsWrapper,
   defaultDateFormat,
   formatDate,
-} from 'src/components/filter/filter-date/dateUtils';
+} from 'src/components/filter/filter-date/DateControlsWrapper';
 import { Input } from 'src/components/input/Input';
 
 export const IsOnOrAfter = ({

--- a/src/components/filter/filter-multi-select/FilterMultiSelect.module.scss
+++ b/src/components/filter/filter-multi-select/FilterMultiSelect.module.scss
@@ -1,0 +1,6 @@
+@use 'theme';
+
+.vStackStyled {
+  max-height: 400px;
+  overflow-y: auto;
+}

--- a/src/components/filter/filter-multi-select/FilterMultiSelect.module.scss.d.ts
+++ b/src/components/filter/filter-multi-select/FilterMultiSelect.module.scss.d.ts
@@ -1,0 +1,1 @@
+export declare const vStackStyled: string;

--- a/src/components/filter/filter-multi-select/FilterMultiSelect.tsx
+++ b/src/components/filter/filter-multi-select/FilterMultiSelect.tsx
@@ -1,7 +1,5 @@
 import { useState } from 'react';
 
-import styled from 'styled-components';
-
 import { Checkbox } from 'src/components/checkbox/Checkbox';
 import {
   type BaseFilterProps,
@@ -11,10 +9,7 @@ import {
 import { VStack } from 'src/components/stack/VStack';
 import type { SelectOption } from 'src/types/SelectOption';
 
-const VStackStyled = styled(VStack)`
-  max-height: 400px;
-  overflow-y: auto;
-`;
+import styles from './FilterMultiSelect.module.scss';
 
 export type FilterMultiSelectProps<T extends string | number = string> =
   BaseFilterProps & {
@@ -28,6 +23,7 @@ export const FilterMultiSelect = <T extends string | number = string>({
   label,
   onChange,
   options,
+  style,
   value,
 }: FilterMultiSelectProps<T>) => {
   const [editingSelectedValues, setEditingSelectedValues] =
@@ -61,7 +57,7 @@ export const FilterMultiSelect = <T extends string | number = string>({
   });
 
   return renderWrapper(
-    <VStackStyled spacing={8}>
+    <VStack className={styles.vStackStyled} spacing={8} style={style}>
       {options.map(option => (
         <Checkbox
           key={option.value}
@@ -80,6 +76,6 @@ export const FilterMultiSelect = <T extends string | number = string>({
           }}
         />
       ))}
-    </VStackStyled>,
+    </VStack>,
   );
 };

--- a/src/components/filter/filter-multi-select/FilterMultiSelect.tsx
+++ b/src/components/filter/filter-multi-select/FilterMultiSelect.tsx
@@ -23,7 +23,6 @@ export const FilterMultiSelect = <T extends string | number = string>({
   label,
   onChange,
   options,
-  style,
   value,
 }: FilterMultiSelectProps<T>) => {
   const [editingSelectedValues, setEditingSelectedValues] =
@@ -57,7 +56,7 @@ export const FilterMultiSelect = <T extends string | number = string>({
   });
 
   return renderWrapper(
-    <VStack className={styles.vStackStyled} spacing={8} style={style}>
+    <VStack className={styles.vStackStyled} spacing={8}>
       {options.map(option => (
         <Checkbox
           key={option.value}

--- a/src/components/filter/filter-select/FilterSelect.tsx
+++ b/src/components/filter/filter-select/FilterSelect.tsx
@@ -37,7 +37,6 @@ export const FilterSelect = <
   onChange,
   options,
   selectProps,
-  style,
   value,
   ...props
 }: FilterSelectProps<T, O>) => {
@@ -94,7 +93,6 @@ export const FilterSelect = <
       onMenuOpen={() => setMenuOpen(true)}
       options={options}
       size="sm"
-      style={style}
       value={options.filter(item => item.value === editingValue?.value)}
       {...selectPropsResolved}
     />,

--- a/src/components/filter/filter-select/FilterSelect.tsx
+++ b/src/components/filter/filter-select/FilterSelect.tsx
@@ -37,6 +37,7 @@ export const FilterSelect = <
   onChange,
   options,
   selectProps,
+  style,
   value,
   ...props
 }: FilterSelectProps<T, O>) => {
@@ -93,6 +94,7 @@ export const FilterSelect = <
       onMenuOpen={() => setMenuOpen(true)}
       options={options}
       size="sm"
+      style={style}
       value={options.filter(item => item.value === editingValue?.value)}
       {...selectPropsResolved}
     />,

--- a/src/components/filter/filter-text/FilterText.tsx
+++ b/src/components/filter/filter-text/FilterText.tsx
@@ -16,6 +16,7 @@ export const FilterText = ({
   dropdownTitle,
   label,
   onChange,
+  style,
   value,
 }: FilterTextProps) => {
   const [editingValue, setEditingValue] = useState<string>(value || '');
@@ -47,6 +48,7 @@ export const FilterText = ({
     <Input
       onChange={e => setEditingValue(e.target.value)}
       size="sm"
+      style={style}
       type="text"
       value={editingValue}
     />,

--- a/src/components/filter/filter-text/FilterText.tsx
+++ b/src/components/filter/filter-text/FilterText.tsx
@@ -16,7 +16,6 @@ export const FilterText = ({
   dropdownTitle,
   label,
   onChange,
-  style,
   value,
 }: FilterTextProps) => {
   const [editingValue, setEditingValue] = useState<string>(value || '');
@@ -48,7 +47,6 @@ export const FilterText = ({
     <Input
       onChange={e => setEditingValue(e.target.value)}
       size="sm"
-      style={style}
       type="text"
       value={editingValue}
     />,

--- a/src/components/filter/useFilterWrapper.tsx
+++ b/src/components/filter/useFilterWrapper.tsx
@@ -8,88 +8,9 @@ import {
   useState,
 } from 'react';
 
-import styled from 'styled-components';
-
-import { Button } from 'src/components/button/Button';
-import { Text } from 'src/components/text/Text';
-import { ChevronDownIcon } from 'src/icons/ChevronDownIcon';
-import { MinusCircleDuotoneIcon } from 'src/icons/MinusCircleDuotoneIcon';
-import { PlusCircleDuotoneIcon } from 'src/icons/PlusCircleDuotoneIcon';
-import { theme } from 'src/styles/constants/theme';
 import type { BaseProps } from 'src/types/BaseProps';
 
-const Wrapper = styled.div`
-  position: relative;
-`;
-
-const BadgeWrapper = styled.div`
-  display: inline-flex;
-  align-items: center;
-  border-radius: 100px;
-  border: 1px dashed ${theme.gray200};
-  background-color: transparent;
-  color: ${theme.gray700};
-
-  &.active {
-    border: ${theme.border};
-  }
-`;
-
-const ToggleWrapper = styled.div<{ $active: boolean; $hasFilter: boolean }>`
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  gap: ${theme.space8};
-  padding: ${theme.space4} ${theme.space8};
-  border-radius: 100px;
-
-  border-top-right-radius: ${p => (p.$hasFilter ? '0px' : '100px')};
-  border-bottom-right-radius: ${p => (p.$hasFilter ? '0px' : '100px')};
-
-  border-right: 1px solid
-    ${p => (p.$active ? theme.borderColor : theme.gray200)};
-
-  &:hover {
-    background-color: ${theme.gray100};
-  }
-`;
-
-const StyledDropdownTrigger = styled.div`
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  gap: ${theme.space8};
-  padding: ${theme.space4} ${theme.space8};
-  border-radius: 100px;
-
-  border-top-left-radius: 0px;
-  border-bottom-left-radius: 0px;
-
-  &:hover {
-    background-color: ${theme.gray100};
-  }
-`;
-
-const DropdownWrapper = styled.div`
-  z-index: 1;
-  min-width: 400px;
-  position: absolute;
-  border-radius: ${theme.radius12};
-  background-color: ${theme.surfaceColor};
-  box-shadow: ${theme.v3ShadowXl};
-  padding: ${theme.space24};
-  display: flex;
-  flex-direction: column;
-  gap: ${theme.space24};
-  outline: none;
-`;
-
-const ControlsWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: ${theme.space8};
-  max-height: 400px;
-`;
+import { FilterWrapper } from './FilterWrapper';
 
 export type BaseFilterProps = BaseProps & {
   dropdownTitle: string;
@@ -120,6 +41,7 @@ export const useFilterWrapper = ({
   onApply,
   onClose,
   onRemove,
+  style,
 }: FilterProps) => {
   const [active, setActive] = useState(false);
   const [dropDownOpen, setDropDownOpen] = useState(false);
@@ -200,50 +122,24 @@ export const useFilterWrapper = ({
   }, [filterExists]);
 
   const renderWrapper = (control: ReactNode) => (
-    <Wrapper ref={wrapperRef}>
-      <BadgeWrapper
-        className={[className, active && 'active'].join(' ')}
-        onClick={handleToggle}
-      >
-        <ToggleWrapper $active={active} $hasFilter={active && filterExists}>
-          {active ? (
-            <MinusCircleDuotoneIcon
-              color="gray0"
-              secondaryColor="gray600"
-              size={24}
-            />
-          ) : (
-            <PlusCircleDuotoneIcon
-              color="gray0"
-              secondaryColor="gray600"
-              size={24}
-            />
-          )}
-          <Text fontWeight={600}>{label}</Text>
-        </ToggleWrapper>
-        {active && filterExists && (
-          <StyledDropdownTrigger onClick={handleOpenDropdown}>
-            <Text color="blue600" fontWeight={600}>
-              {filterText}
-            </Text>
-            <ChevronDownIcon size={24} />
-          </StyledDropdownTrigger>
-        )}
-      </BadgeWrapper>
-      {dropDownOpen && (
-        <DropdownWrapper
-          ref={dropdownRef}
-          onKeyDown={handleKeyDown}
-          tabIndex={-1}
-        >
-          <Text type="bold-subheader">{dropdownTitle}</Text>
-          <ControlsWrapper>{control}</ControlsWrapper>
-          <Button onClick={handleApply} size="md" variant="primary">
-            Apply
-          </Button>
-        </DropdownWrapper>
-      )}
-    </Wrapper>
+    <FilterWrapper
+      ref={wrapperRef}
+      active={active}
+      className={className}
+      dropDownOpen={dropDownOpen}
+      dropdownRef={dropdownRef}
+      dropdownTitle={dropdownTitle}
+      filterText={filterText}
+      handleApply={handleApply}
+      handleKeyDown={handleKeyDown}
+      handleOpenDropdown={handleOpenDropdown}
+      handleToggle={handleToggle}
+      hasFilter={active && filterExists}
+      label={label}
+      style={style}
+    >
+      {control}
+    </FilterWrapper>
   );
 
   return {

--- a/src/components/glow/GlowWrapper.module.scss
+++ b/src/components/glow/GlowWrapper.module.scss
@@ -1,0 +1,34 @@
+@use 'theme';
+
+$padding: var(--amino-glow-wrapper-padding);
+$border-radius: var(--amino-glow-wrapper-border-radius);
+$background: var(--amino-glow-wrapper-background);
+
+.wrapper {
+  z-index: 1;
+  position: relative;
+  overflow: hidden;
+  padding: $padding;
+  box-shadow: inset 0px 0px 1px 1px theme.$amino-gray-200;
+  border-radius: $border-radius;
+
+  ::after {
+    content: '';
+    z-index: -1;
+    position: absolute;
+    width: min(100%, 400px);
+    height: min(100%, 400px);
+    top: calc(var(--y, 0) * 1px - min(50%, calc(400px / 2)));
+    left: calc(var(--x, 0) * 1px - min(50%, calc(400px / 2)));
+    background: $background;
+    filter: blur(20px);
+    transition: opacity 0.5s;
+    opacity: 0;
+  }
+
+  :hover {
+    ::after {
+      opacity: 1;
+    }
+  }
+}

--- a/src/components/glow/GlowWrapper.module.scss
+++ b/src/components/glow/GlowWrapper.module.scss
@@ -3,6 +3,8 @@
 $padding: var(--amino-glow-wrapper-padding);
 $border-radius: var(--amino-glow-wrapper-border-radius);
 $background: var(--amino-glow-wrapper-background);
+$y: var(--y, 0);
+$x: var(--x, 0);
 
 .wrapper {
   z-index: 1;
@@ -18,8 +20,8 @@ $background: var(--amino-glow-wrapper-background);
     position: absolute;
     width: min(100%, 400px);
     height: min(100%, 400px);
-    top: calc(var(--y, 0) * 1px - min(50%, calc(400px / 2)));
-    left: calc(var(--x, 0) * 1px - min(50%, calc(400px / 2)));
+    top: calc($y * 1px - min(50%, calc(400px / 2)));
+    left: calc($x * 1px - min(50%, calc(400px / 2)));
     background: $background;
     filter: blur(20px);
     transition: opacity 0.5s;

--- a/src/components/glow/GlowWrapper.module.scss.d.ts
+++ b/src/components/glow/GlowWrapper.module.scss.d.ts
@@ -1,0 +1,1 @@
+export declare const wrapper: string;

--- a/src/components/glow/GlowWrapper.tsx
+++ b/src/components/glow/GlowWrapper.tsx
@@ -1,48 +1,13 @@
 import { type ReactNode, useEffect, useMemo, useRef } from 'react';
 
-import styled from 'styled-components';
+import clsx from 'clsx';
 
-import { theme } from 'src/styles/constants/theme';
-import { type StyledProps } from 'src/types';
 import type { BaseProps } from 'src/types/BaseProps';
 import type { Color } from 'src/types/Color';
+import { getAminoColor } from 'src/utils/getAminoColor';
 import { type Product, getProductDetails } from 'src/utils/getProductDetails';
 
-type GlowWrapperProps = {
-  gradient: string;
-  radius: number;
-  size: number;
-};
-
-const Wrapper = styled.div<StyledProps<GlowWrapperProps>>`
-  z-index: 1;
-  position: relative;
-  overflow: hidden;
-  padding: ${p => p.$size}px;
-  box-shadow: inset 0px 0px 1px 1px ${theme.gray200};
-  border-radius: ${p => p.$radius}px;
-
-  &::after {
-    content: '';
-    z-index: -1;
-    position: absolute;
-    width: min(100%, 400px);
-    height: min(100%, 400px);
-    top: calc(var(--y, 0) * 1px - min(50%, calc(400px / 2)));
-    left: calc(var(--x, 0) * 1px - min(50%, calc(400px / 2)));
-    background: ${p => p.$gradient};
-    filter: blur(20px);
-
-    transition: opacity 0.5s;
-    opacity: 0;
-  }
-
-  :hover {
-    &::after {
-      opacity: 1;
-    }
-  }
-`;
+import styles from './GlowWrapper.module.scss';
 
 type Props = BaseProps & {
   children?: ReactNode;
@@ -73,20 +38,17 @@ export const GlowWrapper = ({
   product,
   radius = 6,
   size = 1,
+  style,
 }: Props) => {
   const ref = useRef<HTMLDivElement>(null);
 
   const gradient = useMemo(() => {
     if (!product) {
-      return `radial-gradient(
-        circle,
-        ${theme[glowColor]} 0%,
-        white 70%
-      );`;
+      return null;
     }
 
     return getProductDetails({ product }).gradient;
-  }, [glowColor, product]);
+  }, [product]);
 
   useEffect(() => {
     const { current } = ref;
@@ -105,14 +67,19 @@ export const GlowWrapper = ({
   }, []);
 
   return (
-    <Wrapper
+    <div
       ref={ref}
-      $gradient={gradient}
-      $radius={radius}
-      $size={size}
-      className={className}
+      className={clsx(styles.wrapper, className)}
+      style={{
+        ...style,
+        '--amino-glow-wrapper-background':
+          gradient ||
+          `radial-gradient(circle, ${getAminoColor(glowColor)} 0%, white 70%)`,
+        '--amino-glow-wrapper-border-radius': `${radius}px`,
+        '--amino-glow-wrapper-padding': `${size}px`,
+      }}
     >
       {children}
-    </Wrapper>
+    </div>
   );
 };

--- a/src/components/graph-matrix/GraphMatrix.module.scss
+++ b/src/components/graph-matrix/GraphMatrix.module.scss
@@ -1,0 +1,39 @@
+@use 'theme';
+
+// These rules are !important because graphiql inlines their styles
+.styledWrapper {
+  height: 100%;
+
+  :global(.graphiql-tab > .graphiql-tab-button) {
+    outline: none;
+  }
+
+  :global(.docExplorerWrap) {
+    /* Built-in plugin height is set to 100% which prevents the plugin bar scrolling */
+    height: auto !important;
+    /* Don't cap explorer width */
+    width: auto !important;
+  }
+
+  :global(.graphiql-explorer-graphql-arguments) {
+    svg {
+      display: inline-block;
+    }
+  }
+
+  :global(.graphiql-explorer-root > div) {
+    overflow: auto !important;
+  }
+}
+
+.styledTableWrap {
+  height: 100%;
+}
+
+.styledPivotTableWrapper {
+  height: 100vh;
+  overflow: auto;
+  padding: 0 theme.$amino-space-12;
+  display: flex;
+  flex-direction: column;
+}

--- a/src/components/graph-matrix/GraphMatrix.module.scss.d.ts
+++ b/src/components/graph-matrix/GraphMatrix.module.scss.d.ts
@@ -1,0 +1,3 @@
+export declare const styledPivotTableWrapper: string;
+export declare const styledTableWrap: string;
+export declare const styledWrapper: string;

--- a/src/components/graph-matrix/GraphMatrix.tsx
+++ b/src/components/graph-matrix/GraphMatrix.tsx
@@ -62,7 +62,6 @@ export const GraphMatrix = ({
   query = '',
   schema,
   schemaName,
-  style,
   url,
   variables = '',
 }: GraphMatrixProps) => {
@@ -142,7 +141,7 @@ export const GraphMatrix = ({
   };
 
   return (
-    <div className={styles.styledWrapper} style={style}>
+    <div className={styles.styledWrapper}>
       <SplitPanel
         collapseAll={!showTable}
         onSetSizes={setSplitPanelSizes}

--- a/src/components/graph-matrix/GraphMatrix.tsx
+++ b/src/components/graph-matrix/GraphMatrix.tsx
@@ -8,7 +8,6 @@ import {
 import type { CodeMirrorEditor } from '@graphiql/react/types/editor/types';
 import { GraphiQL } from 'graphiql';
 import { type GraphQLSchema } from 'graphql';
-import styled from 'styled-components';
 
 import { GraphiqlContextWrapper } from 'src/components/graph-matrix/_GraphiqlContextWrapper';
 import { Loading } from 'src/components/graph-matrix/_LoadingIcon';
@@ -16,7 +15,7 @@ import { NestedDataTable } from 'src/components/nested-data-table/NestedDataTabl
 import { SplitPanel } from 'src/components/split-panel/SplitPanel';
 import { EyeIcon } from 'src/icons/EyeIcon';
 import { EyeOffIcon } from 'src/icons/EyeOffIcon';
-import { theme } from 'src/styles/constants/theme';
+import type { BaseProps } from 'src/types/BaseProps';
 import type {
   ExecutionResultType,
   GraphiqlExecutionResult,
@@ -26,42 +25,9 @@ import { useGraphiqlExplorer } from 'src/utils/hooks/_useGraphiqlExplorer';
 import { useGraphiqlFetcher } from 'src/utils/hooks/_useGraphiqlFetcher';
 import { useGraphiqlStorage } from 'src/utils/hooks/_useGraphiqlStorage';
 
-// These rules are !important because graphiql inlines their styles
-const StyledWrapper = styled.div`
-  height: 100%;
-  .graphiql-tab > .graphiql-tab-button {
-    outline: none;
-  }
-  .docExplorerWrap {
-    /* Built-in plugin height is set to 100% which prevents the plugin bar scrolling */
-    height: auto !important;
-    /* Don't cap explorer width */
-    width: auto !important;
-  }
-  .graphiql-explorer-graphql-arguments {
-    svg {
-      display: inline-block;
-    }
-  }
+import styles from './GraphMatrix.module.scss';
 
-  .graphiql-explorer-root > div {
-    overflow: auto !important;
-  }
-`;
-
-const StyleTableWrap = styled.div`
-  height: 100%;
-`;
-
-const StyledPivotTableWrapper = styled.div`
-  height: 100vh;
-  overflow: auto;
-  padding: 0 ${theme.space12};
-  display: flex;
-  flex-direction: column;
-`;
-
-type GraphMatrixProps = {
+type GraphMatrixProps = BaseProps & {
   // Toolbar item. You can add your own toolbar item and use the built in <GraphMatrix.ToolbarButton>
   customToolbar?: ReactNode;
   /**
@@ -96,6 +62,7 @@ export const GraphMatrix = ({
   query = '',
   schema,
   schemaName,
+  style,
   url,
   variables = '',
 }: GraphMatrixProps) => {
@@ -154,7 +121,7 @@ export const GraphMatrix = ({
 
     if (actionResultList) {
       return (
-        <StyledPivotTableWrapper>
+        <div className={styles.styledPivotTableWrapper}>
           {actionResultList.map(([actionName, actionResult]) => {
             if (Array.isArray(actionResult) || actionResult) {
               return (
@@ -168,20 +135,20 @@ export const GraphMatrix = ({
             }
             return null;
           })}
-        </StyledPivotTableWrapper>
+        </div>
       );
     }
     return null;
   };
 
   return (
-    <StyledWrapper>
+    <div className={styles.styledWrapper} style={style}>
       <SplitPanel
         collapseAll={!showTable}
         onSetSizes={setSplitPanelSizes}
         sizes={splitPanelSizes}
       >
-        <StyleTableWrap>
+        <div className={styles.styledTableWrap}>
           {isClientRendering && (
             <GraphiQL
               fetcher={graphiqlFetcher}
@@ -219,10 +186,10 @@ export const GraphMatrix = ({
               </GraphiqlContextWrapper>
             </GraphiQL>
           )}
-        </StyleTableWrap>
+        </div>
         {renderTableData()}
       </SplitPanel>
-    </StyledWrapper>
+    </div>
   );
 };
 

--- a/src/components/graph-matrix/_LoadingIcon.module.scss
+++ b/src/components/graph-matrix/_LoadingIcon.module.scss
@@ -1,0 +1,54 @@
+@use 'theme';
+
+@keyframes rotate {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes dots {
+  0%,
+  20% {
+    content: '.';
+  }
+  40% {
+    content: '..';
+  }
+  60% {
+    content: '...';
+  }
+  90%,
+  100% {
+    content: '';
+  }
+}
+
+.wrapper {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: theme.$amino-space-12;
+}
+
+.styledIcon {
+  animation: rotate 2s linear infinite;
+}
+
+.styledText {
+  position: relative;
+
+  :after {
+    position: absolute;
+    animation: dots 1200ms linear infinite;
+    content: '';
+  }
+}

--- a/src/components/graph-matrix/_LoadingIcon.module.scss.d.ts
+++ b/src/components/graph-matrix/_LoadingIcon.module.scss.d.ts
@@ -1,0 +1,5 @@
+export declare const dots: string;
+export declare const rotate: string;
+export declare const styledIcon: string;
+export declare const styledText: string;
+export declare const wrapper: string;

--- a/src/components/graph-matrix/_LoadingIcon.tsx
+++ b/src/components/graph-matrix/_LoadingIcon.tsx
@@ -1,65 +1,14 @@
-import styled, { keyframes } from 'styled-components';
-
 import { Text } from 'src/components/text/Text';
 import { ZonosLogoIcon } from 'src/icons/custom/ZonosLogoIcon';
-import { theme } from 'src/styles/constants/theme';
+import type { BaseProps } from 'src/types/BaseProps';
 
-const Wrapper = styled.div`
-  position: fixed;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  gap: ${theme.space12};
-`;
+import styles from './_LoadingIcon.module.scss';
 
-const Rotate = keyframes`
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
-`;
-
-const StyledIcon = styled(ZonosLogoIcon)`
-  animation: ${Rotate} 2s linear infinite;
-`;
-
-const StyledText = styled(Text)`
-  position: relative;
-
-  &:after {
-    position: absolute;
-    animation: dots 1200ms linear infinite;
-    content: '';
-  }
-
-  @keyframes dots {
-    0%,
-    20% {
-      content: '.';
-    }
-    40% {
-      content: '..';
-    }
-    60% {
-      content: '...';
-    }
-    90%,
-    100% {
-      content: '';
-    }
-  }
-`;
-
-export const Loading = () => (
-  <Wrapper>
-    <StyledIcon size={64} />
-    <StyledText type="bold-subheader">Loading</StyledText>
-  </Wrapper>
+export const Loading = ({ style }: BaseProps) => (
+  <div className={styles.wrapper} style={style}>
+    <ZonosLogoIcon className={styles.styledIcon} size={64} />
+    <Text className={styles.styledText} type="bold-subheader">
+      Loading
+    </Text>
+  </div>
 );

--- a/src/components/graph-matrix/_LoadingIcon.tsx
+++ b/src/components/graph-matrix/_LoadingIcon.tsx
@@ -1,11 +1,10 @@
 import { Text } from 'src/components/text/Text';
 import { ZonosLogoIcon } from 'src/icons/custom/ZonosLogoIcon';
-import type { BaseProps } from 'src/types/BaseProps';
 
 import styles from './_LoadingIcon.module.scss';
 
-export const Loading = ({ style }: BaseProps) => (
-  <div className={styles.wrapper} style={style}>
+export const Loading = () => (
+  <div className={styles.wrapper}>
     <ZonosLogoIcon className={styles.styledIcon} size={64} />
     <Text className={styles.styledText} type="bold-subheader">
       Loading

--- a/src/components/help-text/HelpText.module.scss
+++ b/src/components/help-text/HelpText.module.scss
@@ -1,0 +1,5 @@
+@use 'theme';
+
+.styledHelpText {
+  margin-top: theme.$amino-space-8;
+}

--- a/src/components/help-text/HelpText.module.scss.d.ts
+++ b/src/components/help-text/HelpText.module.scss.d.ts
@@ -1,0 +1,1 @@
+export declare const styledHelpText: string;

--- a/src/components/help-text/HelpText.tsx
+++ b/src/components/help-text/HelpText.tsx
@@ -1,15 +1,13 @@
 import type { ReactNode } from 'react';
 
-import styled from 'styled-components';
+import clsx from 'clsx';
 
 import { Text } from 'src/components/text/Text';
-import { theme } from 'src/styles/constants/theme';
+import type { BaseProps } from 'src/types/BaseProps';
 
-const StyledHelpText = styled.div`
-  margin-top: ${theme.space8};
-`;
+import styles from './HelpText.module.scss';
 
-export type HelpTextProps = {
+export type HelpTextProps = BaseProps & {
   /**
    * Is this an error state.
    */
@@ -20,27 +18,36 @@ export type HelpTextProps = {
   helpText?: ReactNode;
 };
 
-export const HelpText = ({ error, helpText }: HelpTextProps) => {
+export const HelpText = ({
+  className,
+  error,
+  helpText,
+  style,
+}: HelpTextProps) => {
   if (helpText) {
     if (error && typeof helpText === 'string') {
       return (
-        <StyledHelpText>
+        <div className={clsx(className, styles.styledHelpText)} style={style}>
           <Text color="red700" type="caption">
             {helpText}
           </Text>
-        </StyledHelpText>
+        </div>
       );
     }
 
     if (typeof helpText === 'string') {
       return (
-        <StyledHelpText>
+        <div className={clsx(className, styles.styledHelpText)} style={style}>
           <Text type="caption">{helpText}</Text>
-        </StyledHelpText>
+        </div>
       );
     }
 
-    return <StyledHelpText>{helpText}</StyledHelpText>;
+    return (
+      <div className={clsx(className, styles.styledHelpText)} style={style}>
+        {helpText}
+      </div>
+    );
   }
   return null;
 };

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -9,6 +9,7 @@ import type {
 
 import { type HelpTextProps } from 'src/components/help-text/HelpText';
 import { StyledReactSelect } from 'src/components/select/_StyledReactSelect';
+import type { BaseProps } from 'src/types/BaseProps';
 import type { SelectOption } from 'src/types/SelectOption';
 import type { Size } from 'src/types/Size';
 
@@ -43,7 +44,8 @@ export type SelectProps<
   onChange: (changed: Option | null, actionMeta: ActionMeta<Option>) => void;
 } & Omit<Props<Option, IsMulti, Group>, 'isMulti' | RequiredProps> &
   Required<Pick<Props<Option, IsMulti, Group>, RequiredProps>> &
-  HelpTextProps;
+  HelpTextProps &
+  BaseProps;
 
 export const Select = <
   Option extends SelectOption,
@@ -51,6 +53,7 @@ export const Select = <
 >({
   isClearable = true,
   label,
+  style,
   value,
   ...props
 }: SelectProps<Option, false, Group>) => {
@@ -65,6 +68,7 @@ export const Select = <
       isClearable={isClearable}
       isMulti={false}
       label={label}
+      style={style}
       value={value}
     />
   );

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -53,7 +53,6 @@ export const Select = <
 >({
   isClearable = true,
   label,
-  style,
   value,
   ...props
 }: SelectProps<Option, false, Group>) => {
@@ -68,7 +67,6 @@ export const Select = <
       isClearable={isClearable}
       isMulti={false}
       label={label}
-      style={style}
       value={value}
     />
   );

--- a/src/components/select/_StyledReactSelect.tsx
+++ b/src/components/select/_StyledReactSelect.tsx
@@ -514,7 +514,6 @@ export const StyledReactSelect = <
   menuPosition = 'fixed',
   placeholder,
   size = 'xl',
-  style,
   styles,
   ...props
 }: StyledReactSelectProps<Option, IsMulti, Group>) => {
@@ -551,7 +550,6 @@ export const StyledReactSelect = <
     <StyledSelectWrapper
       className={[error ? 'has-error' : ''].join(' ')}
       data-testid={testId}
-      style={style}
     >
       <ReactSelect<Option, IsMulti, Group>
         ref={selectElement}

--- a/src/components/select/_StyledReactSelect.tsx
+++ b/src/components/select/_StyledReactSelect.tsx
@@ -26,6 +26,7 @@ import { DoubleChevronIcon } from 'src/icons/DoubleChevronIcon';
 import { RemoveCircleIcon } from 'src/icons/RemoveCircleIcon';
 import { RemoveIcon } from 'src/icons/RemoveIcon';
 import { theme } from 'src/styles/constants/theme';
+import type { BaseProps } from 'src/types/BaseProps';
 import type { SelectOption } from 'src/types/SelectOption';
 import type { Size } from 'src/types/Size';
 import { getTestId } from 'src/utils/getTestId';
@@ -494,7 +495,8 @@ export type StyledReactSelectProps<
   styles?: StylesConfig<Option, IsMulti, Group>;
 } & Props<Option, IsMulti, Group> &
   HelpTextProps &
-  AdditionalProps<Option['value']>;
+  AdditionalProps<Option['value']> &
+  BaseProps;
 
 export const StyledReactSelect = <
   Option extends SelectOption,
@@ -512,6 +514,7 @@ export const StyledReactSelect = <
   menuPosition = 'fixed',
   placeholder,
   size = 'xl',
+  style,
   styles,
   ...props
 }: StyledReactSelectProps<Option, IsMulti, Group>) => {
@@ -548,6 +551,7 @@ export const StyledReactSelect = <
     <StyledSelectWrapper
       className={[error ? 'has-error' : ''].join(' ')}
       data-testid={testId}
+      style={style}
     >
       <ReactSelect<Option, IsMulti, Group>
         ref={selectElement}

--- a/src/components/stack/Stack.tsx
+++ b/src/components/stack/Stack.tsx
@@ -3,6 +3,7 @@ import type { HTMLAttributes, ReactNode } from 'react';
 import styled from 'styled-components';
 
 import type { GridAlignment, GridSpacing } from 'src/types';
+import type { BaseProps } from 'src/types/BaseProps';
 
 type DivProps = Omit<
   HTMLAttributes<HTMLDivElement>,
@@ -20,7 +21,8 @@ export type StackProps = {
   children: ReactNode;
   /** @default 24 */
   spacing?: GridSpacing;
-} & DivProps;
+} & DivProps &
+  BaseProps;
 /**
  * A stack
  *

--- a/src/components/stack/VStack.tsx
+++ b/src/components/stack/VStack.tsx
@@ -15,8 +15,13 @@ const StyledVStack = styled(Stack)<{ $spacing: GridSpacing }>`
  * @param alignment - Optional alignment
  * @param spacing - Optional spacing between elements
  */
-export const VStack = ({ children, spacing = 24, ...props }: StackProps) => (
-  <StyledVStack $spacing={spacing} {...props}>
+export const VStack = ({
+  children,
+  spacing = 24,
+  style,
+  ...props
+}: StackProps) => (
+  <StyledVStack $spacing={spacing} style={style} {...props}>
     {children}
   </StyledVStack>
 );


### PR DESCRIPTION
## Jira issue
[FE-745 - CSS Modules F-H](https://myzonos.atlassian.net/browse/FE-745)

## Description

This PR converts the following components to use css modules
- FileUpload
- FilterAmount
- DateControls
  - DateControlsWrapper
  - FilterDate
  - _IsAfter
  - _IsBefore
  - _IsBeforeOrOn
  - _IsBetween
  - _IsEqualTo
  - _IsInTheLast
  - _IsOnOrAfter
- FilterMultiSelect
- FilterSelect
- FilterText
- GlowWrapper
- _LoadingIcon
- _GraphMatrix
- HelpText

## Testing
Preview: [css-modules.amino.zonos.com](https://css-modules.amino.zonos.com/)

## Todo

- [x] Bump version and add tag
