### PR TITLE
Add max-height to dialog popup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.1.75",
+  "version": "5.1.76",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/dialog/BaseDialog.module.scss
+++ b/src/components/dialog/BaseDialog.module.scss
@@ -18,6 +18,7 @@ $width: var(--amino-base-dialog-width);
 .popup {
   z-index: 1001;
   background: theme.$amino-surface-color;
+  max-height: 90vh;
   width: $width;
   border-radius: theme.$amino-radius-12;
   outline: none;


### PR DESCRIPTION
This pull request adds a max-height property to the dialog popup component, ensuring that it does not exceed 90% of the viewport height.

### Before:

![Screenshot 2023-12-19 at 10 30 49 AM](https://github.com/Zonos/amino/assets/12107173/976c8d5d-0513-4bdb-8c2c-09eb67ec64d5)

### After:

![Screenshot 2023-12-19 at 10 31 00 AM](https://github.com/Zonos/amino/assets/12107173/673c7a06-3d42-45f1-ae9c-259c3daa4800)
