### PR TITLE
refactor: add prefix to all pseudo elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.1.76",
+  "version": "5.1.77",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/glow/GlowWrapper.module.scss
+++ b/src/components/glow/GlowWrapper.module.scss
@@ -14,7 +14,7 @@ $x: var(--x, 0);
   box-shadow: inset 0px 0px 1px 1px theme.$amino-gray-200;
   border-radius: $border-radius;
 
-  ::after {
+  &::after {
     content: '';
     z-index: -1;
     position: absolute;
@@ -28,8 +28,8 @@ $x: var(--x, 0);
     opacity: 0;
   }
 
-  :hover {
-    ::after {
+  &:hover {
+    &::after {
       opacity: 1;
     }
   }

--- a/src/components/input/__stories__/Input.stories.tsx
+++ b/src/components/input/__stories__/Input.stories.tsx
@@ -61,6 +61,12 @@ const Template: StoryFn<InputProps> = ({ value: _value, ...props }) => {
       />
       <Input
         {...props}
+        onChange={e => setValue(e.target.value)}
+        placeholder="Placeholder text"
+        value=""
+      />
+      <Input
+        {...props}
         disabled
         onChange={e => setValue(e.target.value)}
         value={value}

--- a/src/components/input/input-type/_FloatLabelInput.module.scss
+++ b/src/components/input/input-type/_FloatLabelInput.module.scss
@@ -35,7 +35,7 @@ $height: var(--amino-float-label-input-height);
   /**disabled state */
   :global(.disabled) & {
     pointer-events: inherit;
-    ::after {
+    &::after {
       cursor: not-allowed;
       z-index: 1;
     }
@@ -52,7 +52,7 @@ $height: var(--amino-float-label-input-height);
   display: flex;
   justify-content: center;
   align-items: center;
-  
+
   &.inputPrefix {
     border-top-left-radius: theme.$amino-radius-6;
     border-bottom-left-radius: theme.$amino-radius-6;
@@ -108,7 +108,7 @@ $height: var(--amino-float-label-input-height);
     }
   }
   &:not(:global(.has-label)) {
-    ::placeholder {
+    &::placeholder {
       opacity: 0.6;
     }
   }
@@ -116,7 +116,7 @@ $height: var(--amino-float-label-input-height);
     padding-left: theme.$amino-space-8;
   }
 
-  ::placeholder {
+  &::placeholder {
     transition: theme.$amino-transition;
     opacity: 0;
   }

--- a/src/components/layout/Layout.module.scss
+++ b/src/components/layout/Layout.module.scss
@@ -49,7 +49,7 @@ $height: var(--height);
   input {
     background-color: theme.$amino-gray-100;
     border: 0;
-    ::placeholder {
+    &::placeholder {
       color: theme.$amino-gray-1200;
     }
   }

--- a/src/components/textarea/Textarea.tsx
+++ b/src/components/textarea/Textarea.tsx
@@ -72,7 +72,7 @@ const StyledTextarea = styled.textarea<TextareaType>`
     margin-top: ${theme.space24};
     padding: 0 4px ${theme.space8} ${theme.space16};
 
-    ::placeholder {
+    &::placeholder {
       opacity: 0;
     }
 
@@ -101,7 +101,7 @@ const StyledTextarea = styled.textarea<TextareaType>`
     }
   }
 
-  ::placeholder {
+  &::placeholder {
     transition: ${theme.transition};
     color: ${theme.gray400};
     font-weight: 400;


### PR DESCRIPTION
## Issue

<!-- [Jira issue description](url) -->
<!-- Example:
[3106 - Loup Charmant - Need dashboard switched from Hello](https://myzonos.atlassian.net/browse/DM-550)
-->
Input placeholder overlap
<img width="961" alt="image" src="https://github.com/Zonos/amino/assets/17950626/3ec7e81f-f3e7-4bf2-ba09-75485b89d405">

## Testing
- Access this link: https://amino-git-fix-pseudo-element-prefix-zonos.vercel.app/?path=%2Fstory%2Famino-input--number-input. The second input of each `Input` story is the one with `placeholder`. `placeholder` will be hidden when there is nothing on it, click on it the placeholder should show up.
<img width="619" alt="image" src="https://github.com/Zonos/amino/assets/17950626/768ca1e2-4aa4-4d67-a926-9952e2948202">


## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR add prefix `&` to all pseudo selectors `::`

## Todo

- [ ] Bump version and add tag
