### PR TITLE
fix: ensure style is passed down, storybook fix

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -21,7 +21,14 @@ const storybookConfig: StorybookConfig = {
             test: /\.css|scss$/,
             use: [
               'style-loader',
-              'css-loader',
+              {
+                loader: 'css-loader',
+                options: {
+                  modules: {
+                    localIdentName: 'Amino_[name]__[local]--[hash:base64:5]',
+                  },
+                },
+              },
               {
                 loader: 'sass-loader',
                 options: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.1.88",
+  "version": "5.1.89",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/checkbox/Checkbox.tsx
+++ b/src/components/checkbox/Checkbox.tsx
@@ -97,9 +97,11 @@ export const Checkbox = ({
       {...props}
     >
       <div
-        className={clsx(styles.checkboxContainer, 'amino-input-wrapper', {
-          disabled,
-        })}
+        className={clsx(
+          styles.checkboxContainer,
+          'amino-input-wrapper',
+          disabled && styles.disabled,
+        )}
         data-testid={testId}
         onClick={e => {
           handleChange(e);

--- a/src/components/cover-sheet/CoverSheetActions.tsx
+++ b/src/components/cover-sheet/CoverSheetActions.tsx
@@ -21,6 +21,7 @@ export const CoverSheetActions = ({
   children,
   className,
   coverSheetActionId,
+  style,
 }: CoverSheetProps) => {
   const [coverSheetReady, setCoverSheetReady] = useState(false);
 
@@ -34,7 +35,7 @@ export const CoverSheetActions = ({
     const div = document.querySelector(`#${coverSheetActionId}`);
     if (div) {
       return createPortal(
-        <div className={clsx(className, styles.actions)}>
+        <div className={clsx(className, styles.actions)} style={style}>
           <HStack spacing={8}>{children}</HStack>
         </div>,
         div,

--- a/src/components/dialog/Dialog.tsx
+++ b/src/components/dialog/Dialog.tsx
@@ -34,7 +34,7 @@ export const Dialog = forwardRef<HTMLDivElement, DialogProps>(
     },
     ref,
   ) => (
-    <BaseDialog {...props} onClose={onClose}>
+    <BaseDialog {...props} onClose={onClose} style={style}>
       <div className={styles.header}>
         <div className={styles.title}>
           <Text type="title">{label}</Text>

--- a/src/components/glow/GlowWrapper.module.scss
+++ b/src/components/glow/GlowWrapper.module.scss
@@ -3,8 +3,8 @@
 $padding: var(--amino-glow-wrapper-padding);
 $border-radius: var(--amino-glow-wrapper-border-radius);
 $background: var(--amino-glow-wrapper-background);
-$y: var(--y, 0);
-$x: var(--x, 0);
+$y: var(--amino-glow-wrapper-y, 0);
+$x: var(--amino-glow-wrapper-x, 0);
 
 .wrapper {
   z-index: 1;

--- a/src/components/glow/GlowWrapper.tsx
+++ b/src/components/glow/GlowWrapper.tsx
@@ -55,8 +55,14 @@ export const GlowWrapper = ({
     const onMouseMove = (e: MouseEvent) => {
       if (current) {
         const { x, y } = current.getBoundingClientRect();
-        current.style.setProperty('--x', (e.clientX - x).toString());
-        current.style.setProperty('--y', (e.clientY - y).toString());
+        current.style.setProperty(
+          '--amino-glow-wrapper-x',
+          (e.clientX - x).toString(),
+        );
+        current.style.setProperty(
+          '--amino-glow-wrapper-y',
+          (e.clientY - y).toString(),
+        );
       }
     };
 

--- a/src/components/layout/Layout.module.scss
+++ b/src/components/layout/Layout.module.scss
@@ -1,6 +1,6 @@
 @use 'theme';
 
-$height: var(--height);
+$height: var(--amino-layout-height);
 
 .aminoLayout {
   height: 100vh;

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,5 +1,7 @@
 import type { ChangeEventHandler, ReactElement, ReactNode } from 'react';
 
+import clsx from 'clsx';
+
 import { SearchInput } from 'src/components/input/SearchInput';
 import { type NavigationGroupProps } from 'src/components/layout/NavigationGroup';
 import { theme } from 'src/styles/constants/theme';
@@ -30,11 +32,13 @@ export const Layout = ({
   logoSidebar,
   searchInput,
   sidebar,
+  style,
 }: LayoutProps) => (
   <main
-    className={[className, layoutStyles.aminoLayout].join(' ')}
+    className={clsx(className, layoutStyles.aminoLayout)}
     style={{
-      '--height': headerContent
+      ...style,
+      '--amino-layout-height': headerContent
         ? `calc(100vh - ${theme.appbarHeight})`
         : '100vh',
     }}

--- a/src/components/layout/NavigationGroup.tsx
+++ b/src/components/layout/NavigationGroup.tsx
@@ -3,11 +3,11 @@ import type { ReactElement, ReactNode } from 'react';
 import clsx from 'clsx';
 
 import { Collapse } from 'src/components/collapse/Collapse';
+import type { BaseProps } from 'src/types/BaseProps';
 
 import styles from './NavigationGroup.module.scss';
 
-export type NavigationItemProps = {
-  className?: string;
+export type NavigationItemProps = BaseProps & {
   content: ReactNode;
   icon?: ReactNode;
   /**
@@ -16,9 +16,8 @@ export type NavigationItemProps = {
   isActive?: boolean;
 };
 
-export type NavigationGroupProps = {
+export type NavigationGroupProps = BaseProps & {
   children: ReactNode;
-  className?: string;
   /**
    * @default false
    */
@@ -32,6 +31,7 @@ export const NavigationItem = ({
   content,
   icon,
   isActive = false,
+  style,
 }: NavigationItemProps) => (
   <div
     className={clsx(
@@ -39,6 +39,7 @@ export const NavigationItem = ({
       styles.styledNavigationItem,
       isActive && styles.active,
     )}
+    style={style}
   >
     {icon && <div className={styles.styledNavigationItemIcon}>{icon}</div>}
     {content}
@@ -50,8 +51,9 @@ export const NavigationGroup = ({
   className,
   collapsed = false,
   content,
+  style,
 }: NavigationGroupProps) => (
-  <div className={clsx(className, styles.wrapper)}>
+  <div className={clsx(className, styles.wrapper)} style={style}>
     <div
       className={clsx(styles.styledItemWrapper, !collapsed && styles.collapsed)}
     >

--- a/src/components/list-item/ListItem.tsx
+++ b/src/components/list-item/ListItem.tsx
@@ -46,6 +46,7 @@ export const ListItem = forwardRef<HTMLDivElement, Props>(
       onClick,
       rightDecorator,
       selected,
+      style,
       subtitle,
     },
     ref,
@@ -62,6 +63,7 @@ export const ListItem = forwardRef<HTMLDivElement, Props>(
       )}
       onClick={e => !disabled && onClick && onClick(e)}
       role="button"
+      style={style}
       tabIndex={0}
     >
       <div className={clsx('__icon-wrapper', decorator && styles.hasIcon)}>

--- a/src/components/nested-data-table/NestedDataTable.tsx
+++ b/src/components/nested-data-table/NestedDataTable.tsx
@@ -6,6 +6,7 @@ import { TableData } from 'src/components/nested-data-table/_TableData';
 import type { RowWithIndex } from 'src/components/pivot-table/PivotTable';
 import { RestState } from 'src/components/rest-state/RestState';
 import { Text } from 'src/components/text/Text';
+import type { BaseProps } from 'src/types/BaseProps';
 import { type flattenRow } from 'src/utils/flattenRow';
 
 import styles from './NestedDataTable.module.scss';
@@ -18,7 +19,7 @@ export type CustomColumnCells<TRow extends Record<string, unknown>> = {
   [key in keyof TRow]?: ColumnCell<TRow>;
 };
 
-type Props<TRow extends Record<string, unknown>> = {
+type Props<TRow extends Record<string, unknown>> = BaseProps & {
   currentPage?: number;
   customColumnCells?: CustomColumnCells<TRow>;
   /**
@@ -48,6 +49,7 @@ export const NestedDataTable = <
   isFetching,
   loadingComponent,
   restState,
+  style,
   tableData,
   title,
 }: Props<TRow>) => {
@@ -86,7 +88,7 @@ export const NestedDataTable = <
   };
 
   return (
-    <div className={styles.styledPivotTableContentWrapper}>
+    <div className={styles.styledPivotTableContentWrapper} style={style}>
       <div className={styles.styledTableHeader}>
         {!!title && <Text type="header">{title}</Text>}
         {/* Only show pagination if handlePagination and currentPage is provided */}

--- a/src/components/pivot-table/PivotTable.tsx
+++ b/src/components/pivot-table/PivotTable.tsx
@@ -10,6 +10,7 @@ import DataGrid, {
 
 import { ChevronDownIcon } from 'src/icons/ChevronDownIcon';
 import { ChevronUpIcon } from 'src/icons/ChevronUpIcon';
+import type { BaseProps } from 'src/types/BaseProps';
 import { addIndex } from 'src/utils/addIndex';
 
 import styles from './PivotTable.module.scss';
@@ -50,10 +51,11 @@ type Props<
   TRow extends RowWithIndex,
   TSummaryRow extends unknown,
   TRowKey extends KeyValue,
-> = Omit<
-  DataGridProps<TRow, TSummaryRow, TRowKey>,
-  keyof OverrideProps<TRow, TSummaryRow>
-> &
+> = BaseProps &
+  Omit<
+    DataGridProps<TRow, TSummaryRow, TRowKey>,
+    keyof OverrideProps<TRow, TSummaryRow>
+  > &
   OverrideProps<TRow, TSummaryRow>;
 
 type Comparator<TRow extends unknown> = (a: TRow, b: TRow) => number;
@@ -75,6 +77,7 @@ export const PivotTable = <
   rows,
   /** If the change want to make for this handler */
   sortColumns: _sortColumns = [],
+  style,
   tableHeight,
   ...rest
 }: Props<TRow, TSummaryRow, TRowKey>) => {
@@ -165,6 +168,7 @@ export const PivotTable = <
     <div
       className={styles.styledWrapper}
       style={{
+        ...style,
         '--amino-pivot-table-height': tableHeight || 'calc(100vh - 145px)',
         '--amino-pivot-table-min-height': tableHeight || '',
       }}

--- a/src/components/progress-bar/ProgressBar.tsx
+++ b/src/components/progress-bar/ProgressBar.tsx
@@ -16,6 +16,7 @@ export const ProgressBar = ({
   className,
   colorStyle = 'blue600',
   progress = 0,
+  style,
 }: ProgressBarProps) => {
   const validateProgress = () => {
     if (progress < 0) {
@@ -55,6 +56,7 @@ export const ProgressBar = ({
     <div
       className={clsx(className, styles.base)}
       style={{
+        ...style,
         '--amino-progress-bar-background-color': getBarColor() || '',
         '--amino-progress-bar-width': `${validatedProgress}%`,
       }}

--- a/src/components/radio/Radio.tsx
+++ b/src/components/radio/Radio.tsx
@@ -3,22 +3,31 @@ import { AnimatePresence, motion } from 'framer-motion';
 
 import { Text } from 'src/components/text/Text';
 import { theme } from 'src/styles/constants/theme';
+import type { BaseProps } from 'src/types/BaseProps';
 
 import styles from './Radio.module.scss';
 
-export type RadioProps = {
+export type RadioProps = BaseProps & {
   checked: boolean;
   disabled?: boolean;
   label?: string;
   onChange: (checked: boolean) => void;
 };
 
-export const Radio = ({ checked, disabled, label, onChange }: RadioProps) => (
+export const Radio = ({
+  checked,
+  className,
+  disabled,
+  label,
+  onChange,
+  style,
+}: RadioProps) => (
   // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
   <div
-    className={clsx(styles.radioContainer, disabled && 'disabled')}
+    className={clsx(className, styles.radioContainer, disabled && 'disabled')}
     onClick={() => !disabled && onChange(!checked)}
     style={{
+      ...style,
       '--amino-radio-background': checked
         ? theme.primary
         : theme.inputBackground,

--- a/src/components/radio/RadioGroup.tsx
+++ b/src/components/radio/RadioGroup.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import clsx from 'clsx';
 
 import { Radio } from 'src/components/radio/Radio';
+import type { BaseProps } from 'src/types/BaseProps';
 
 import styles from './RadioGroup.module.scss';
 
@@ -11,8 +12,7 @@ export type RadioGroupItem<T extends string = string> = {
   value: T;
 };
 
-export type RadioGroupProps<T extends string = string> = {
-  className?: string;
+export type RadioGroupProps<T extends string = string> = BaseProps & {
   disabled?: boolean;
   initialValue?: string;
   items: RadioGroupItem<T>[];
@@ -25,6 +25,7 @@ export const RadioGroup = <T extends string = string>({
   initialValue,
   items,
   onChange,
+  style,
 }: RadioGroupProps<T>) => {
   const [activeIndex, setActiveIndex] = useState(-1);
 
@@ -53,5 +54,9 @@ export const RadioGroup = <T extends string = string>({
     />
   ));
 
-  return <div className={clsx(className, styles.radioContainer)}>{radios}</div>;
+  return (
+    <div className={clsx(className, styles.radioContainer)} style={style}>
+      {radios}
+    </div>
+  );
 };

--- a/src/components/rest-state/RestState.tsx
+++ b/src/components/rest-state/RestState.tsx
@@ -3,12 +3,12 @@ import type { ReactNode } from 'react';
 import clsx from 'clsx';
 
 import { Text } from 'src/components/text/Text';
+import type { BaseProps } from 'src/types/BaseProps';
 
 import styles from './RestState.module.scss';
 
-export type RestStateProps = {
+export type RestStateProps = BaseProps & {
   action?: ReactNode;
-  className?: string;
   icon?: string;
   label: string;
   subtitle?: ReactNode;
@@ -19,9 +19,10 @@ export const RestState = ({
   className,
   icon,
   label,
+  style,
   subtitle,
 }: RestStateProps) => (
-  <div className={clsx(className, styles.styledRestState)}>
+  <div className={clsx(className, styles.styledRestState)} style={style}>
     {icon ? <img alt={label} className={styles.icon} src={icon} /> : null}
     <div className={styles.textWrapper}>
       <Text type="title">{label}</Text>

--- a/src/components/rich-card-select/RichCardStateSelect.tsx
+++ b/src/components/rich-card-select/RichCardStateSelect.tsx
@@ -17,6 +17,7 @@ export const RichCardStateSelect = <T extends UnitedState = UnitedState>({
   className,
   onClick,
   states,
+  style,
 }: RichCardStateSelectProps<T>) => {
   const regions = Array.from(new Set(states.map(state => state.region)));
 
@@ -25,7 +26,7 @@ export const RichCardStateSelect = <T extends UnitedState = UnitedState>({
   regions.sort((a, b) => regionOrder.indexOf(a) - regionOrder.indexOf(b));
 
   return (
-    <VStack className={className} spacing={24}>
+    <VStack className={className} spacing={24} style={style}>
       {regions.map(region => (
         <div key={region}>
           <VStack spacing={16}>

--- a/src/components/rich-checkbox/RichCheckbox.tsx
+++ b/src/components/rich-checkbox/RichCheckbox.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import { VStack } from 'src/components/stack/VStack';
 import { Text } from 'src/components/text/Text';
 import { CheckmarkIcon } from 'src/icons/CheckmarkIcon';
+import type { BaseProps } from 'src/types/BaseProps';
 
 import styles from './RichCheckbox.module.scss';
 
@@ -16,13 +17,22 @@ type RichCheckboxItemType = {
   value: string;
 };
 
-export type RichCheckboxProps = {
+export type RichCheckboxProps = BaseProps & {
   items: RichCheckboxItemType[];
   onClick: (newVal: string) => void;
 };
 
-export const RichCheckbox = ({ items, onClick }: RichCheckboxProps) => (
-  <VStack className={styles.styledVStack} spacing={16}>
+export const RichCheckbox = ({
+  className,
+  items,
+  onClick,
+  style,
+}: RichCheckboxProps) => (
+  <VStack
+    className={clsx(className, styles.styledVStack)}
+    spacing={16}
+    style={style}
+  >
     {items.map(item => {
       const { checked, icon, label, subtitle, value } = item;
       return (

--- a/src/components/rich-radio/RichRadio.tsx
+++ b/src/components/rich-radio/RichRadio.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 import { VStack } from 'src/components/stack/VStack';
 import { Text } from 'src/components/text/Text';
 import { CheckmarkIcon } from 'src/icons/CheckmarkIcon';
+import type { BaseProps } from 'src/types/BaseProps';
 
 import styles from './RichRadio.module.scss';
 
@@ -18,9 +19,8 @@ export type RichRadioItemType<T extends string> = {
   value: T;
 };
 
-export type RichRadioProps<T extends string = string> = {
+export type RichRadioProps<T extends string = string> = BaseProps & {
   activeIcon?: ReactNode;
-  className?: string;
   icon?: ReactNode;
   /**
    * @param itemHeight
@@ -41,6 +41,7 @@ export const RichRadio = <T extends string>({
   items,
   onChange,
   renderCustomText,
+  style,
   value,
 }: RichRadioProps<T>) => {
   const [selectedValue, setSelectedValue] = useState(value);
@@ -55,7 +56,11 @@ export const RichRadio = <T extends string>({
   };
 
   return (
-    <VStack className={clsx(className, styles.styledRadioGroup)} spacing={16}>
+    <VStack
+      className={clsx(className, styles.styledRadioGroup)}
+      spacing={16}
+      style={style}
+    >
       {items.map(item => (
         <button
           key={item.value}

--- a/src/components/rounded-icon/RoundedIcon.tsx
+++ b/src/components/rounded-icon/RoundedIcon.tsx
@@ -3,15 +3,15 @@ import type { ReactNode } from 'react';
 import clsx from 'clsx';
 
 import { theme } from 'src/styles/constants/theme';
+import type { BaseProps } from 'src/types/BaseProps';
 import type { Color } from 'src/types/Color';
 import type { Intent } from 'src/types/Intent';
 
 import styles from './RoundedIcon.module.scss';
 
-export type RoundedIconProps = {
+export type RoundedIconProps = BaseProps & {
   background?: Color;
   children: ReactNode;
-  className?: string;
   color?: Color;
   intent?: Intent;
 };
@@ -22,6 +22,7 @@ export const RoundedIcon = ({
   className,
   color,
   intent,
+  style,
 }: RoundedIconProps) => {
   const getIntentClass = () => {
     switch (intent) {
@@ -39,6 +40,7 @@ export const RoundedIcon = ({
     <div
       className={clsx(className, styles.iconWrapper, getIntentClass())}
       style={{
+        ...style,
         '--amino-rounded-icon-background': background
           ? theme[background]
           : theme.gray200,

--- a/src/components/section/HSection.tsx
+++ b/src/components/section/HSection.tsx
@@ -9,12 +9,12 @@ import { SectionSubheader } from 'src/components/section/_SectionSubheader';
 import { HStack } from 'src/components/stack/HStack';
 import { Text } from 'src/components/text/Text';
 import { ChevronUpIcon } from 'src/icons/ChevronUpIcon';
+import type { BaseProps } from 'src/types/BaseProps';
 
 import styles from './HSection.module.scss';
 
-export type HSectionProps = {
+export type HSectionProps = BaseProps & {
   children: ReactNode;
-  className?: string;
   /**
    * @info Initial collapse state. **Note**: only have effect when `collapsible` is specified
    * @default false
@@ -35,6 +35,7 @@ export const HSection = ({
   collapseByDefault = false,
   collapsible = false,
   label,
+  style,
   sublabel = '',
 }: HSectionProps) => {
   const [collapsed, setCollapsed] = useState(collapseByDefault);
@@ -45,7 +46,10 @@ export const HSection = ({
       <div>{children}</div>
     );
   return (
-    <HStack className={clsx(className, styles.styledSectionWrapper)}>
+    <HStack
+      className={clsx(className, styles.styledSectionWrapper)}
+      style={style}
+    >
       {label && (
         <SectionInnerWrapper>
           <div className={styles.styledDiv}>

--- a/src/components/section/VSection.tsx
+++ b/src/components/section/VSection.tsx
@@ -6,13 +6,13 @@ import { SectionHeader } from 'src/components/section/_SectionHeader';
 import { SectionInnerWrapper } from 'src/components/section/_SectionInnerWrapper';
 import { SectionSubheader } from 'src/components/section/_SectionSubheader';
 import { HStack } from 'src/components/stack/HStack';
+import type { BaseProps } from 'src/types/BaseProps';
 
 import styles from './VSection.module.scss';
 
-export type VSectionProps = {
+export type VSectionProps = BaseProps & {
   actions?: ReactNode;
   children: ReactNode;
-  className?: string;
   label?: ReactNode;
   sublabel?: ReactNode;
 };
@@ -22,9 +22,10 @@ export const VSection = ({
   children,
   className,
   label,
+  style,
   sublabel = '',
 }: VSectionProps) => (
-  <div className={clsx(className, styles.styledSectionWrapper)}>
+  <div className={clsx(className, styles.styledSectionWrapper)} style={style}>
     {label && (
       <SectionInnerWrapper>
         <SectionHeader>

--- a/src/components/select/CountryPhoneSelect.tsx
+++ b/src/components/select/CountryPhoneSelect.tsx
@@ -12,6 +12,7 @@ import type { HelpTextProps } from 'src/components/help-text/HelpText';
 import { Input } from 'src/components/input/Input';
 import { Select } from 'src/components/select/Select';
 import { ChevronDownIcon } from 'src/icons/ChevronDownIcon';
+import type { BaseProps } from 'src/types/BaseProps';
 import type { CountryOption } from 'src/types/Country';
 import type { SelectOption } from 'src/types/SelectOption';
 
@@ -49,7 +50,7 @@ export type CountryPhoneSelectProps<
   Option extends SelectOption = SelectOption,
   IsMulti extends false = false,
   Group extends GroupBase<Option> = GroupBase<Option>,
-> = {
+> = BaseProps & {
   components?: SelectComponentsConfig<Option, IsMulti, Group>;
   countryOptions: CountryOption[];
   hasGroups?: boolean;

--- a/src/components/select/CountrySelect.tsx
+++ b/src/components/select/CountrySelect.tsx
@@ -1,5 +1,6 @@
 import { type SelectProps, Select } from 'src/components/select/Select';
 import { type Flag, FlagIcon } from 'src/icons/flag-icon/FlagIcon';
+import type { BaseProps } from 'src/types/BaseProps';
 import type { CountryOption } from 'src/types/Country';
 
 type CountrySelectType<T extends string> = {
@@ -15,6 +16,7 @@ type CountrySelectType<T extends string> = {
 
 export type CountrySelectProps<T extends string = string> =
   CountrySelectType<T> &
+    BaseProps &
     Omit<SelectProps<CountryOption<T>>, keyof CountrySelectType<T> | 'options'>;
 
 export const CountrySelect = <T extends string>({

--- a/src/components/select/MultiSelect.tsx
+++ b/src/components/select/MultiSelect.tsx
@@ -15,6 +15,7 @@ import type {
 import { Checkbox } from 'src/components/checkbox/Checkbox';
 import { type HelpTextProps } from 'src/components/help-text/HelpText';
 import { StyledReactSelect } from 'src/components/select/_StyledReactSelect';
+import type { BaseProps } from 'src/types/BaseProps';
 import type { SelectOption } from 'src/types/SelectOption';
 
 type RequiredProps = 'onChange' | 'options' | 'value';
@@ -23,7 +24,7 @@ export type MultiSelectProps<
   Option extends SelectOption = SelectOption,
   IsMulti extends true = true,
   Group extends GroupBase<Option> = GroupBase<Option>,
-> = {
+> = BaseProps & {
   components?: SelectComponentsConfig<Option, IsMulti, Group>;
   hasGroups?: boolean;
   icon?: ReactNode;

--- a/src/components/simple-table/SimpleTable.tsx
+++ b/src/components/simple-table/SimpleTable.tsx
@@ -122,6 +122,7 @@ export const SimpleTable = <T extends object>({
   selectable = {
     enabled: false,
   },
+  style,
 }: SimpleTableProps<T>) => {
   const renderHeader = (header: SimpleTableHeader<T>, item: T) => {
     const value = item[header.key];
@@ -238,7 +239,7 @@ export const SimpleTable = <T extends object>({
   };
 
   return (
-    <table className={clsx(className, styles.tableStyled)}>
+    <table className={clsx(className, styles.tableStyled)} style={style}>
       <colgroup>
         {!!selectable.onHeaderCheckboxChange && <col width={0} />}
         {headers.map(header => (

--- a/src/components/slider/Slider.tsx
+++ b/src/components/slider/Slider.tsx
@@ -1,12 +1,13 @@
 import { Range, Root, Thumb, Track } from '@radix-ui/react-slider';
 import clsx from 'clsx';
 
+import type { BaseProps } from 'src/types/BaseProps';
+
 import styles from './Slider.module.scss';
 
 type SliderSize = 8 | 12;
 
-export type SliderProps = {
-  className?: string;
+export type SliderProps = BaseProps & {
   hideIndicator?: boolean;
   max?: number;
   min?: number;
@@ -32,12 +33,14 @@ export const Slider = ({
   onChange,
   size = 12,
   step,
+  style,
   suffix = '%',
   value,
 }: SliderProps) => (
   <div
     className={clsx(className, styles.sliderWrapper)}
     style={{
+      ...style,
       '--amino-slider-styled-thumb-height': `${size * 2}px`,
       '--amino-slider-styled-thumb-width': `${size * 2}px`,
       '--amino-slider-styled-track-height': `${size}px`,

--- a/src/components/sortable-list/SortableListItem.tsx
+++ b/src/components/sortable-list/SortableListItem.tsx
@@ -4,10 +4,11 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 
 import { DragIcon } from 'src/icons/DragIcon';
+import type { BaseProps } from 'src/types/BaseProps';
 
 import styles from './SortableListItem.module.scss';
 
-export type SortableListItemProps = {
+export type SortableListItemProps = BaseProps & {
   children: ReactNode;
   handleIconSize?: number;
   id: string;
@@ -19,12 +20,14 @@ export const SortableListItem = ({
   children,
   handleIconSize = 20,
   id,
+  style,
   useHandle,
 }: SortableListItemProps) => {
   const { attributes, listeners, setNodeRef, transform, transition } =
     useSortable({ id });
 
-  const style = {
+  const listItemStyle = {
+    ...style,
     transform: CSS.Transform.toString(transform),
     transition,
   };
@@ -32,7 +35,7 @@ export const SortableListItem = ({
   return (
     <div ref={setNodeRef}>
       {useHandle ? (
-        <div className={styles.styledSortableListItem} style={style}>
+        <div className={styles.styledSortableListItem} style={listItemStyle}>
           <div className={styles.styledSortableSection}>{children}</div>
           {/* eslint-disable-next-line react/jsx-props-no-spreading */}
           <div {...listeners} {...attributes}>

--- a/src/components/switch/Switch.tsx
+++ b/src/components/switch/Switch.tsx
@@ -27,6 +27,7 @@ export const Switch = ({
   labelDescription,
   labelIcon,
   onChange,
+  style,
   subtitle,
   switchIconLeft,
   switchIconRight,
@@ -44,6 +45,7 @@ export const Switch = ({
       )}
       htmlFor={labelAsHtmlAttribute}
       onClick={() => !disabled && onChange(!checked)}
+      style={style}
     >
       {hasIcons ? (
         <div

--- a/src/components/table/TableFooter.tsx
+++ b/src/components/table/TableFooter.tsx
@@ -1,10 +1,17 @@
 import type { ReactNode } from 'react';
 
-export type TableFooterProps = {
+import type { BaseProps } from 'src/types/BaseProps';
+
+export type TableFooterProps = BaseProps & {
   children: ReactNode;
-  className?: string;
 };
 
-export const TableFooter = ({ children, className }: TableFooterProps) => (
-  <tfoot className={className}>{children}</tfoot>
+export const TableFooter = ({
+  children,
+  className,
+  style,
+}: TableFooterProps) => (
+  <tfoot className={className} style={style}>
+    {children}
+  </tfoot>
 );

--- a/src/components/table/TableHead.tsx
+++ b/src/components/table/TableHead.tsx
@@ -1,10 +1,13 @@
 import type { ReactNode } from 'react';
 
-export type TableHeadProps = {
+import type { BaseProps } from 'src/types/BaseProps';
+
+export type TableHeadProps = BaseProps & {
   children: ReactNode;
-  className?: string;
 };
 
-export const TableHead = ({ children, className }: TableHeadProps) => (
-  <thead className={className}>{children}</thead>
+export const TableHead = ({ children, className, style }: TableHeadProps) => (
+  <thead className={className} style={style}>
+    {children}
+  </thead>
 );

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -1,17 +1,17 @@
 import clsx from 'clsx';
 
 import { Text } from 'src/components/text/Text';
+import type { BaseProps } from 'src/types/BaseProps';
 
 import styles from './Tabs.module.scss';
 
-export type TabsProps = {
+export type TabsProps = BaseProps & {
   /**
    * Only applies to subtle design
    * Align tabs horizontally.
    * @default 'start'
    */
   align?: 'start' | 'center' | 'end';
-  className?: string;
   items: string[];
   selected: number;
   /**
@@ -28,13 +28,14 @@ export const Tabs = ({
   items,
   onChange,
   selected,
+  style,
   subtle = false,
 }: TabsProps) => {
   if (subtle) {
     return (
       <div
         className={clsx(className, styles.baseTabs, styles.subtleTabs)}
-        style={{ '--amino-tabs-align': align }}
+        style={{ ...style, '--amino-tabs-align': align }}
       >
         {items.map(item => (
           // eslint-disable-next-line jsx-a11y/click-events-have-key-events
@@ -56,7 +57,10 @@ export const Tabs = ({
   }
 
   return (
-    <div className={clsx(className, styles.baseTabs, styles.aminoTabs)}>
+    <div
+      className={clsx(className, styles.baseTabs, styles.aminoTabs)}
+      style={style}
+    >
       {items.map(item => (
         // eslint-disable-next-line jsx-a11y/click-events-have-key-events
         <div

--- a/src/components/tag/Tag.tsx
+++ b/src/components/tag/Tag.tsx
@@ -3,14 +3,14 @@ import type { ReactNode } from 'react';
 import clsx from 'clsx';
 
 import { RemoveIcon } from 'src/icons/RemoveIcon';
+import type { BaseProps } from 'src/types/BaseProps';
 
 import styles from './Tag.module.scss';
 
 type TagSize = 'base' | 'lg';
 
-export type TagProps = {
+export type TagProps = BaseProps & {
   children?: ReactNode | string;
-  className?: string;
   icon?: ReactNode;
   iconRight?: boolean;
   size?: TagSize;
@@ -26,6 +26,7 @@ export const Tag = ({
   onClick,
   onClose,
   size = 'base',
+  style,
 }: TagProps) => (
   <div
     className={clsx(
@@ -33,6 +34,7 @@ export const Tag = ({
       styles.tagWrapper,
       size === 'base' && styles.base,
     )}
+    style={style}
   >
     <button
       className={clsx(styles.styledTagLeft, iconRight && styles.iconRight)}

--- a/src/components/textarea/Textarea.tsx
+++ b/src/components/textarea/Textarea.tsx
@@ -48,6 +48,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
       label,
       maxRows,
       rows,
+      style,
       value,
       width,
       ...props
@@ -72,7 +73,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
           'amino-input-wrapper',
           disabled && styles.disabled,
         )}
-        style={{ '--amino-textarea-width': width || '100%' }}
+        style={{ ...style, '--amino-textarea-width': width || '100%' }}
       >
         {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
         <div

--- a/src/components/thumbnail/Thumbnail.tsx
+++ b/src/components/thumbnail/Thumbnail.tsx
@@ -34,6 +34,7 @@ export const Thumbnail = ({
   intent = 'full',
   shape = 'round',
   size = 32,
+  style,
 }: ThumbnailProps) => (
   <div
     className={clsx(
@@ -43,6 +44,7 @@ export const Thumbnail = ({
       intent === 'outline' && styles.outline,
     )}
     style={{
+      ...style,
       '--amino-thumbnail-background-color': theme[`${color}100`],
       '--amino-thumbnail-border-radius': thumbnailShapes[shape],
       '--amino-thumbnail-size': `${size}px`,

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -8,12 +8,13 @@ import { InfoIcon } from 'src/icons/InfoIcon';
 import { RemoveCircleIcon } from 'src/icons/RemoveCircleIcon';
 import { WarningIcon } from 'src/icons/WarningIcon';
 import type { Intent } from 'src/types';
+import type { BaseProps } from 'src/types/BaseProps';
 
 import styles from './Toast.module.scss';
 
 export type Direction = 'top' | 'right' | 'bottom' | 'left';
 
-export type ToastProps = {
+export type ToastProps = BaseProps & {
   children: ReactNode;
   direction?: Direction;
   /** Dismiss delay (default 6000 ms) */
@@ -26,6 +27,7 @@ export const Toast = ({
   children,
   direction,
   intent,
+  style,
   toastKey,
 }: ToastProps) => {
   const getDirection = () => {
@@ -90,6 +92,7 @@ export const Toast = ({
     <motion.div
       className={clsx(styles.aminoToast, intentValues.class)}
       layout
+      style={style}
       {...baseProps}
     >
       {intentValues.icon}


### PR DESCRIPTION
## Jira issue
Related to [FE-810 - Dashboard to css modules](https://myzonos.atlassian.net/browse/FE-810)

## Description

This PR: 
adds Will's storybook fix
includes className fix for disabled checkbox styles
ensures that the style prop is passed to the appropriate components
- this was missed on some components that were done early on before we came up with this convention
- some were missed by Nick when coming back from zonos.com work

## Todo

- [x] Bump version and add tag
