### PR TITLE
feat(simple-table): customize th

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.1.90",
+  "version": "5.1.91",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/simple-table/SimpleTable.tsx
+++ b/src/components/simple-table/SimpleTable.tsx
@@ -32,7 +32,7 @@ export type SimpleTableHeader<T extends object> = {
     /** The key for each record that the header corresponds to */
     key: Key;
     /** null means don't show a header for this column */
-    name: string | null;
+    name: ReactNode | null;
 
     renderCustom?: (value: T[Key], item: T) => React.ReactNode;
   } & SimpleTableHeaderBaseProps;
@@ -268,13 +268,18 @@ export const SimpleTable = <T extends object>({
           {headers.map(header => (
             <th
               key={header.key}
+              className={clsx(header.noPadding && styles.noPadding)}
               style={{
                 textAlign: header.align || 'start',
               }}
             >
-              <Text color="gray800" type="small-header">
-                {header.name}
-              </Text>
+              {typeof header.name === 'string' ? (
+                <Text color="gray800" type="small-header">
+                  {header.name}
+                </Text>
+              ) : (
+                header.name
+              )}
             </th>
           ))}
         </tr>


### PR DESCRIPTION
## Jira issue

<!-- [Jira issue description](url) -->
<!-- Example:
[3106 - Loup Charmant - Need dashboard switched from Hello](https://myzonos.atlassian.net/browse/DM-550)
-->
[Add the ability to see the translations to the custom message settings](https://myzonos.atlassian.net/browse/FE-828)

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR allows customizing the table header with `noPadding` and passing in a React Node for the header name. This should allow proper formatting for the Translated messages dialog in Dashboard.
<img width="797" alt="Screenshot 2024-01-17 at 9 08 16 AM" src="https://github.com/Zonos/amino/assets/12107173/02dd76a1-000a-4c0a-8ec0-a43a00d6c6f9">

## Todo

- [ ] Bump version and add tag
