### PR TITLE
fix: small bugs from css modules conversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.1.92",
+  "version": "5.1.93",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -220,6 +220,7 @@ export const Input = <T extends string>({
   return (
     <div
       className={clsx(
+        className,
         'amino-input-wrapper',
         disabled && 'disabled',
         styles.aminoInputWrapper,

--- a/src/components/select/_StyledReactSelect.module.scss
+++ b/src/components/select/_StyledReactSelect.module.scss
@@ -51,7 +51,7 @@ $color: var(--amino-styled-react-select-color);
       margin-bottom: -2px;
     }
   }
-  .md.hasLabel &,
+  .md.hasValue &,
   .md.isFocused & {
     top: 6px;
   }


### PR DESCRIPTION
## Jira issue
Related to [FE-810 - Dashboard to css modules](https://myzonos.atlassian.net/browse/FE-810)

## Description

This PR fixes some small bugs from the css module conversion:
- fix medium `_StyledReactSelect` top value from `hasLabel` to `hasValue`
- pass `className` to default `Input` component

## Todo

- [x] Bump version and add tag
