### PR TITLE
fix: undo class passing to input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.1.94",
+  "version": "5.1.95",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.1.93",
+  "version": "5.1.94",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.1.92",
+  "version": "5.1.93",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.1.95",
+  "version": "5.1.93",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -220,7 +220,6 @@ export const Input = <T extends string>({
   return (
     <div
       className={clsx(
-        className,
         'amino-input-wrapper',
         disabled && 'disabled',
         styles.aminoInputWrapper,


### PR DESCRIPTION
## Description
This PR fixes a mistake from the previous version.
I misunderstood what I was looking at in the Input component. The previous "fix" ends up passing the classname twice, which explodes in the input when it is styled.

## Todo

- [ ] Bump version and add tag
