### PR TITLE
Fix/country multi select props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.1.107",
+  "version": "5.1.108",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/card/Card.module.scss
+++ b/src/components/card/Card.module.scss
@@ -11,11 +11,6 @@ $footer-height: var(--amino-card-footer-height);
   border-radius: theme.$amino-radius-6;
   padding: $padding-spacing;
   background: theme.$amino-gray-0;
-
-  hr {
-    margin-left: $margin;
-    margin-right: $margin;
-  }
 }
 
 .cardHeader {

--- a/src/components/country-multi-select/CountryMultiSelectExpanded.module.scss
+++ b/src/components/country-multi-select/CountryMultiSelectExpanded.module.scss
@@ -4,6 +4,15 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
+
+  &.disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+
+    > * {
+      pointer-events: none;
+    }
+  }
 }
 
 .header {

--- a/src/components/country-multi-select/CountryMultiSelectExpanded.module.scss.d.ts
+++ b/src/components/country-multi-select/CountryMultiSelectExpanded.module.scss.d.ts
@@ -7,6 +7,7 @@ export declare const collapseIcon: string;
 export declare const componentHeaderWrapper: string;
 export declare const componentWrapper: string;
 export declare const countriesWrapper: string;
+export declare const disabled: string;
 export declare const groupWrapper: string;
 export declare const header: string;
 export declare const headerActions: string;

--- a/src/components/country-multi-select/CountryMultiSelectExpanded.tsx
+++ b/src/components/country-multi-select/CountryMultiSelectExpanded.tsx
@@ -14,10 +14,10 @@ import { getFuzzySearch } from 'src/utils/getFuzzySearch';
 
 import styles from './CountryMultiSelectExpanded.module.scss';
 
-export type ICountryMultiSelectExpandedOption<
-  TCountryCode extends string = string,
+export type CountryMultiSelectExpandedOption<
+  CountryCode extends string = string,
 > = {
-  code: TCountryCode;
+  code: CountryCode;
   disabled?: boolean;
   /**
    * Key to group by
@@ -32,16 +32,16 @@ export type ICountryMultiSelectExpandedOption<
   rightDecorator?: () => ReactNode;
 };
 
-type ICountryMultiSelectExpandedRegion<TCountryCode extends string = string> = {
-  countries: ICountryMultiSelectExpandedOption<TCountryCode>[];
+type ICountryMultiSelectExpandedRegion<CountryCode extends string = string> = {
+  countries: CountryMultiSelectExpandedOption<CountryCode>[];
   label: string;
 };
 
 export type CountryMultiSelectExpandedProps<
-  TCountryCode extends string = string,
+  CountryCode extends string = string,
 > = BaseProps & {
   actions?: ReactNode;
-  countries: ICountryMultiSelectExpandedOption<TCountryCode>[];
+  countries: CountryMultiSelectExpandedOption<CountryCode>[];
   /**
    * @default 380
    */
@@ -51,22 +51,19 @@ export type CountryMultiSelectExpandedProps<
    * @default false
    */
   noHeader?: boolean;
-  selectedCountries: ICountryMultiSelectExpandedOption<TCountryCode>[];
+  selectedCountries: CountryMultiSelectExpandedOption<CountryCode>[];
   /**
    * No search bar
    * @default false
    */
   withoutSearch?: boolean;
   onChange: (
-    countries: ICountryMultiSelectExpandedOption<TCountryCode>[],
+    countries: CountryMultiSelectExpandedOption<CountryCode>[],
   ) => void;
 };
 
-/**
- * Use the country flags with `flagType: 'amino'` otherwise the flags are slow to load when re-rendering
- */
 export const CountryMultiSelectExpanded = <
-  TCountryCode extends string = string,
+  CountryCode extends string = string,
 >({
   actions,
   className,
@@ -77,7 +74,7 @@ export const CountryMultiSelectExpanded = <
   selectedCountries,
   style,
   withoutSearch = false,
-}: CountryMultiSelectExpandedProps<TCountryCode>) => {
+}: CountryMultiSelectExpandedProps<CountryCode>) => {
   const [searchText, setSearchText] = useState('');
   const [expandedGroups, setExpandedGroups] = useState<string[]>([]);
 
@@ -96,7 +93,7 @@ export const CountryMultiSelectExpanded = <
     [countries],
   );
 
-  const shownCountries: ICountryMultiSelectExpandedOption<TCountryCode>[] =
+  const shownCountries: CountryMultiSelectExpandedOption<CountryCode>[] =
     useMemo(() => {
       if (searchText === '') {
         return countries;
@@ -107,7 +104,7 @@ export const CountryMultiSelectExpanded = <
     }, [countries, searchCountries, searchText]);
 
   const groups = useMemo(() => {
-    const grouped: ICountryMultiSelectExpandedRegion<TCountryCode>[] =
+    const grouped: ICountryMultiSelectExpandedRegion<CountryCode>[] =
       Object.entries(groupBy(shownCountries, 'group')).map(
         ([group, groupCountries]) => ({
           countries: groupCountries,

--- a/src/components/country-multi-select/CountryMultiSelectExpanded.tsx
+++ b/src/components/country-multi-select/CountryMultiSelectExpanded.tsx
@@ -43,6 +43,10 @@ export type CountryMultiSelectExpandedProps<
   actions?: ReactNode;
   countries: CountryMultiSelectExpandedOption<CountryCode>[];
   /**
+   * @default false
+   */
+  disabled?: boolean;
+  /**
    * @default 380
    */
   maxHeight?: number;
@@ -68,6 +72,7 @@ export const CountryMultiSelectExpanded = <
   actions,
   className,
   countries,
+  disabled = false,
   maxHeight = 380,
   noHeader = false,
   onChange,
@@ -278,7 +283,10 @@ export const CountryMultiSelectExpanded = <
   };
 
   return (
-    <div className={clsx(styles.wrapper, className)} style={style}>
+    <div
+      className={clsx(styles.wrapper, className, disabled && styles.disabled)}
+      style={style}
+    >
       {!noHeader && (
         <div className={styles.header}>
           <Text type="bold-label">Countries and Regions</Text>

--- a/src/components/country-multi-select/__stories__/CountryMultiSelectExpanded.stories.tsx
+++ b/src/components/country-multi-select/__stories__/CountryMultiSelectExpanded.stories.tsx
@@ -4,8 +4,8 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import { Badge } from 'src/components/badge/Badge';
 import {
+  type CountryMultiSelectExpandedOption,
   type CountryMultiSelectExpandedProps,
-  type ICountryMultiSelectExpandedOption,
   CountryMultiSelectExpanded,
 } from 'src/components/country-multi-select/CountryMultiSelectExpanded';
 import { useCountryOptions } from 'src/components/select/__stories__/useCountryOptions';
@@ -26,11 +26,11 @@ const renderBadge = (label: string) => {
 const Template = (props: CountryMultiSelectExpandedProps) => {
   const countryOptions = useCountryOptions({});
 
-  const [value, setValue] = useState<ICountryMultiSelectExpandedOption[]>([]);
+  const [value, setValue] = useState<CountryMultiSelectExpandedOption[]>([]);
 
   const countries = useMemo(
     () =>
-      countryOptions.map<ICountryMultiSelectExpandedOption>(x => ({
+      countryOptions.map<CountryMultiSelectExpandedOption>(x => ({
         code: x.code,
         disabled: x.displayName.startsWith('C'),
         group: x.region,
@@ -66,20 +66,18 @@ export const Basic: StoryObj<CountryMultiSelectExpandedProps> = {};
 export const WithToggle = (props: CountryMultiSelectExpandedProps) => {
   const countryOptions = useCountryOptions({});
 
-  const [value, setValue] = useState<ICountryMultiSelectExpandedOption[]>([]);
+  const [value, setValue] = useState<CountryMultiSelectExpandedOption[]>([]);
   const [toggle, setToggle] = useState<string>('1');
 
   const countries = useMemo(() => {
-    const options = countryOptions.map<ICountryMultiSelectExpandedOption>(
-      x => ({
-        code: x.code,
-        disabled: x.displayName.startsWith('C'),
-        group: x.region,
-        icon: x.icon,
-        label: x.displayName,
-        rightDecorator: () => renderBadge(x.displayName),
-      }),
-    );
+    const options = countryOptions.map<CountryMultiSelectExpandedOption>(x => ({
+      code: x.code,
+      disabled: x.displayName.startsWith('C'),
+      group: x.region,
+      icon: x.icon,
+      label: x.displayName,
+      rightDecorator: () => renderBadge(x.displayName),
+    }));
 
     if (toggle === '1') {
       return options;
@@ -114,12 +112,12 @@ export const WithToggle = (props: CountryMultiSelectExpandedProps) => {
 export const WidthAdjustable = (props: CountryMultiSelectExpandedProps) => {
   const countryOptions = useCountryOptions({});
 
-  const [value, setValue] = useState<ICountryMultiSelectExpandedOption[]>([]);
+  const [value, setValue] = useState<CountryMultiSelectExpandedOption[]>([]);
   const [width, setWidth] = useState(632);
 
   const countries = useMemo(
     () =>
-      countryOptions.map<ICountryMultiSelectExpandedOption>(x => ({
+      countryOptions.map<CountryMultiSelectExpandedOption>(x => ({
         code: x.code,
         disabled: x.displayName.startsWith('C'),
         group: x.region,


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR fixes the prop naming (pulled from dashboard) for the country multi select and adds a disabled state.

Also removes some `hr` styling from the `Card` that wasn't used and was causing problems.

## Todo

- [ ] Bump version and add tag
