### PR TITLE
feat(coversheet): make close button optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.1.112",
+  "version": "5.1.113",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/cover-sheet/CoverSheet.tsx
+++ b/src/components/cover-sheet/CoverSheet.tsx
@@ -20,6 +20,7 @@ export type CoverSheetProps = BaseDialogProps & {
   actions?: ReactNode;
   headerComponent?: ReactNode;
   label: string;
+  showCloseButton?: boolean;
 };
 
 export const CoverSheet = ({
@@ -31,6 +32,7 @@ export const CoverSheet = ({
   label,
   onClose,
   open,
+  showCloseButton = true,
   ...props
 }: CoverSheetProps) => {
   useEffect(() => {
@@ -67,7 +69,9 @@ export const CoverSheet = ({
     >
       <header className={styles.headerContainer}>
         <div className={styles.header}>
-          <Button icon={<RemoveIcon size={20} />} onClick={onClose} />
+          {showCloseButton && (
+            <Button icon={<RemoveIcon size={20} />} onClick={onClose} />
+          )}
           <Text type="subheader">{label}</Text>
         </div>
         <div className={styles.headerComponent}>{headerComponent}</div>

--- a/src/components/cover-sheet/CoverSheet.tsx
+++ b/src/components/cover-sheet/CoverSheet.tsx
@@ -19,8 +19,8 @@ export type CoverSheetProps = BaseDialogProps & {
   actionWrapperId?: string;
   actions?: ReactNode;
   headerComponent?: ReactNode;
+  hideCloseButton?: boolean;
   label: string;
-  showCloseButton?: boolean;
 };
 
 export const CoverSheet = ({
@@ -29,10 +29,10 @@ export const CoverSheet = ({
   children,
   className,
   headerComponent,
+  hideCloseButton = false,
   label,
   onClose,
   open,
-  showCloseButton = true,
   ...props
 }: CoverSheetProps) => {
   useEffect(() => {
@@ -69,7 +69,7 @@ export const CoverSheet = ({
     >
       <header className={styles.headerContainer}>
         <div className={styles.header}>
-          {showCloseButton && (
+          {!hideCloseButton && (
             <Button icon={<RemoveIcon size={20} />} onClick={onClose} />
           )}
           <Text type="subheader">{label}</Text>

--- a/src/components/cover-sheet/__stories__/CoverSheet.stories.tsx
+++ b/src/components/cover-sheet/__stories__/CoverSheet.stories.tsx
@@ -162,6 +162,14 @@ CoverSheetNoActions.args = {
   label: 'Label',
 };
 
+export const CoverSheetNoCloseButton = Template.bind({});
+CoverSheetNoCloseButton.args = {
+  actionPortalOpen: true,
+  children: <div />,
+  label: 'Label',
+  showCloseButton: false,
+};
+
 export const Scrollable: StoryObj<CoverSheetProps> = {
   args: {
     children: (

--- a/src/components/cover-sheet/__stories__/CoverSheet.stories.tsx
+++ b/src/components/cover-sheet/__stories__/CoverSheet.stories.tsx
@@ -166,8 +166,8 @@ export const CoverSheetNoCloseButton = Template.bind({});
 CoverSheetNoCloseButton.args = {
   actionPortalOpen: true,
   children: <div />,
+  hideCloseButton: true,
   label: 'Label',
-  showCloseButton: false,
 };
 
 export const Scrollable: StoryObj<CoverSheetProps> = {


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->
[Implement iframe for Screen calculator UI](https://linear.app/zonos/issue/TS-530/implement-iframe-for-screen-calculator-ui)

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR makes the close button optional. This will allow us to use Coversheets without a close button in iframes.

## Todo

- [x] Bump version and add tag
