### PR TITLE
fix(tabs): add classname back for zonos.com tabs

### DIFF
--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -43,7 +43,11 @@ export const Tabs = ({
             key={item}
             className={clsx(
               styles.baseTab,
-              selected === items.indexOf(item) && styles.isSelected,
+              selected === items.indexOf(item) && [
+                styles.isSelected,
+                // Used for external styling
+                'is-selected',
+              ],
             )}
             onClick={() => onChange(items.indexOf(item))}
             role="button"


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR adds a classname of `is-selected` back in amino. We use this class in zonos.com to do custom styling.

## Todo

- [ ] Bump version and add tag
