### PR TITLE
Fix/more ssr errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -134,7 +134,7 @@ export const Input = ({
             readOnly={readOnly}
             required={required}
             size={size}
-            suffix={suffix === null ? null : suffix}
+            suffix={suffix}
             tabIndex={tabIndex}
             value={value || ''}
             valuePrefix={valuePrefix}

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -2,7 +2,6 @@ import type {
   ChangeEventHandler,
   InputHTMLAttributes,
   MutableRefObject,
-  ReactNode,
 } from 'react';
 
 import clsx from 'clsx';
@@ -24,12 +23,10 @@ import { theme } from 'src/styles/constants/theme';
 import styles from './Input.module.scss';
 
 type InputType = {
-  inputPrefix?: ReactNode;
   /** Need to pass the ref here to preserve generics, as forwardRef doesn't allow it
    * @link https://stackoverflow.com/questions/58469229/react-with-typescript-generics-while-using-react-forwardref
    */
   inputRef?: MutableRefObject<HTMLInputElement | null>;
-  inputSuffix?: ReactNode;
   onChange: ChangeEventHandler<HTMLInputElement>;
   /** A value (in px) that will determine how wide the input is. If nothing is passed, it defaults to 100% */
   width?: number;
@@ -46,9 +43,7 @@ export const Input = ({
   error,
   helpText,
   inputMode,
-  inputPrefix,
   inputRef,
-  inputSuffix,
   label,
   onChange,
   onKeyDown,
@@ -83,11 +78,11 @@ export const Input = ({
             onKeyDown={onKeyDown}
             pattern={pattern}
             placeholder={placeholder}
-            prefix={prefix || inputPrefix}
+            prefix={prefix}
             readOnly={readOnly}
             required={required}
             size={size}
-            suffix={suffix || inputSuffix}
+            suffix={suffix}
             tabIndex={tabIndex}
             value={value || ''}
             valuePrefix={valuePrefix}
@@ -109,11 +104,11 @@ export const Input = ({
             onKeyDown={onKeyDown}
             pattern={pattern}
             placeholder={placeholder}
-            prefix={prefix || inputPrefix}
+            prefix={prefix}
             readOnly={readOnly}
             required={required}
             size={size}
-            suffix={suffix || inputSuffix}
+            suffix={suffix}
             tabIndex={tabIndex}
             type={type}
             value={value || ''}
@@ -135,11 +130,11 @@ export const Input = ({
             onKeyDown={onKeyDown}
             pattern={pattern}
             placeholder={placeholder}
-            prefix={prefix || inputPrefix}
+            prefix={prefix}
             readOnly={readOnly}
             required={required}
             size={size}
-            suffix={suffix === null ? null : suffix || inputSuffix}
+            suffix={suffix === null ? null : suffix}
             tabIndex={tabIndex}
             value={value || ''}
             valuePrefix={valuePrefix}
@@ -161,11 +156,11 @@ export const Input = ({
             onKeyDown={onKeyDown}
             pattern={pattern}
             placeholder={placeholder}
-            prefix={prefix || inputPrefix}
+            prefix={prefix}
             readOnly={readOnly}
             required={required}
             size={size}
-            suffix={suffix || inputSuffix}
+            suffix={suffix}
             tabIndex={tabIndex}
             value={value || ''}
             valuePrefix={valuePrefix}
@@ -186,11 +181,11 @@ export const Input = ({
             onKeyDown={onKeyDown}
             pattern={pattern}
             placeholder={placeholder}
-            prefix={prefix || inputPrefix}
+            prefix={prefix}
             readOnly={readOnly}
             required={required}
             size={size}
-            suffix={suffix || inputSuffix}
+            suffix={suffix}
             tabIndex={tabIndex}
             type={type}
             value={value || ''}

--- a/src/components/input/__stories__/Input.stories.tsx
+++ b/src/components/input/__stories__/Input.stories.tsx
@@ -12,16 +12,6 @@ import { FlagIcon } from 'src/icons/flag-icon/FlagIcon';
 
 const InputMeta: Meta = {
   argTypes: {
-    inputPrefix: {
-      table: {
-        disable: true,
-      },
-    },
-    inputSuffix: {
-      table: {
-        disable: true,
-      },
-    },
     prefix: {
       mapping: {
         'No prefix': null,

--- a/src/components/input/input-type/_PasswordInput.module.scss
+++ b/src/components/input/input-type/_PasswordInput.module.scss
@@ -17,6 +17,7 @@
     background: theme.$amino-gray-100;
   }
   &:focus {
+    color: theme.$amino-primary;
     outline: none;
   }
 }

--- a/src/components/input/input-type/_PasswordInput.module.scss
+++ b/src/components/input/input-type/_PasswordInput.module.scss
@@ -5,20 +5,13 @@
   width: 100%;
 }
 
-.styledButtonAction {
+.styledButtonAction.styledButtonAction {
   padding: 6px;
   border-radius: 50%;
   transition: theme.$amino-transition;
 
   &:hover {
     background: theme.$amino-hover-color;
-  }
-  &:active {
-    background: theme.$amino-gray-100;
-  }
-  &:focus {
-    color: theme.$amino-primary;
-    outline: none;
   }
 }
 

--- a/src/components/input/input-type/_PasswordInput.tsx
+++ b/src/components/input/input-type/_PasswordInput.tsx
@@ -2,6 +2,7 @@ import { forwardRef, useState } from 'react';
 
 import clsx from 'clsx';
 
+import { Button } from 'src/components/button/Button';
 import {
   type FloatLabelInputProps,
   FloatLabelInput,
@@ -55,19 +56,20 @@ export const PasswordInput = forwardRef<HTMLInputElement, FloatLabelInputProps>(
           required={required}
           suffix={
             suffix || (
-              <button
+              <Button
                 className={styles.styledButtonAction}
+                icon={
+                  inputType === 'password' ? (
+                    <EyeIcon size={24} />
+                  ) : (
+                    <EyeOffIcon size={24} />
+                  )
+                }
                 onClick={() =>
                   setInputType(inputType === 'password' ? 'text' : 'password')
                 }
-                type="button"
-              >
-                {inputType === 'password' ? (
-                  <EyeIcon size={24} />
-                ) : (
-                  <EyeOffIcon size={24} />
-                )}
-              </button>
+                variant="subtle"
+              />
             )
           }
           tabIndex={tabIndex}

--- a/src/components/theme-select/ThemeSelect.tsx
+++ b/src/components/theme-select/ThemeSelect.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import clsx from 'clsx';
 
 import { Card } from 'src/components/card/Card';
@@ -40,6 +42,7 @@ export const ThemeSelect = ({
   type = 'select',
 }: Props) => {
   const { aminoTheme, setAminoTheme } = useAminoTheme();
+  const [checked, setChecked] = useState<boolean>(false);
 
   const getIcon = () => {
     switch (aminoTheme) {
@@ -52,7 +55,11 @@ export const ThemeSelect = ({
     }
   };
 
-  const checked = aminoTheme === 'day';
+  // This logic is necessary because on the server the theme is always 'day', which casuses SSR hydration mismatch issues
+  useEffect(() => {
+    // This code will only run on the client side
+    setChecked(aminoTheme === 'day');
+  }, [aminoTheme]);
 
   return (
     <>

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -68,7 +68,6 @@ export const Toast = ({
     },
     exit: getDirection(),
     initial: getDirection(),
-    key: toastKey,
   };
 
   const parseIntent = () => {
@@ -94,6 +93,7 @@ export const Toast = ({
       layout
       style={style}
       {...baseProps}
+      key={toastKey}
     >
       {intentValues.icon}
       {children}


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR fixes some more SSR errors encountered within the app router.

- `Toast`: key spreading (can't spread the `key` prop in react)
- `ThemeSelect`: server was always day (default value), which caused some class conflicts in stuff like the toggle, so added logic to only run on client

also: 
- password input eye icon has a visible focus state now (was bad UX when using keyboard navigation and you can't tell what element is focused)
- remove `inputPrefix` and `inputSuffix` from `Input`. This was logic related to upstream usage of `NumberInput`, which shouldn't be in amino

## Todo

- [x] Bump version and add tag
