### PR TITLE
Fix/vite env

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/select/_StyledReactSelect.tsx
+++ b/src/components/select/_StyledReactSelect.tsx
@@ -417,9 +417,7 @@ export const StyledReactSelect = <
     if (closeOnOutsideScroll) {
       return (e: Event) => {
         if (e.target instanceof HTMLElement) {
-          return (
-            !selectElement.current?.menuListRef?.isEqualNode(e.target) ?? true
-          );
+          return !selectElement.current?.menuListRef?.isEqualNode(e.target);
         }
         return true;
       };

--- a/src/components/select/__stories__/useCountryOptions.tsx
+++ b/src/components/select/__stories__/useCountryOptions.tsx
@@ -27,7 +27,11 @@ export const useCountryOptions = ({
   const [countryOptions, setCountryOptions] = useState<CountryOption[]>([]);
 
   const requestCountries = useCallback(async () => {
-    const response = await fetch(`${dashboardUrl}/api/address/getCountries`);
+    const response = await fetch(`${dashboardUrl}/api/address/getCountries`, {
+      headers: {
+        'cache-control': 'no-cache',
+      },
+    });
     if (response.ok) {
       const json = (await response.json()) as GetCountriesResponse;
       const options = prepCountryOptions({ json });

--- a/src/components/select/__stories__/useCountryOptions.tsx
+++ b/src/components/select/__stories__/useCountryOptions.tsx
@@ -9,7 +9,7 @@ import type { CountryOption, GetCountriesResponse } from 'src/types/Country';
 import { prepCountryOptions } from 'src/utils/prepCountryOptions';
 
 export const getCountryUrls = () => {
-  const dashboardUrl = process.env.STORYBOOK_ZONOS_DASHBOARD_URL || null;
+  const dashboardUrl = import.meta.env.STORYBOOK_ZONOS_DASHBOARD_URL || null;
   if (!dashboardUrl) {
     // eslint-disable-next-line no-console
     console.error('Missing environment variable STORYBOOK_ZONOS_DASHBOARD_URL');

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+type ImportMetaEnv = {
+  readonly VITE_APP_TITLE: string;
+  // more env variables...
+};
+
+type ImportMeta = {
+  readonly env: ImportMetaEnv;
+};


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

https://vite.amino.zonos.com/?path=/story/amino-select-countryselect--basic-country-select

This PR fixes an issue with environment variables when switching to vite.

client imports need to use `import.meta.env` now.

Also fixes some vite syntax warnings.


Probably contains one half of a CORS fix. (Needs a combo in dashboard, for no native cache, and no vercel cache).

I tried testing all combinations, and it looks like it is required in both places. Although there is a chance that I may be wrong, but the domain/env/cache testing has gotten lost in my head.

## Todo

- [x] Bump version and add tag
