### PR TITLE
feat(inlineLink): added inlineLink variant with no padding

### DIFF
--- a/src/components/button/Button.module.scss
+++ b/src/components/button/Button.module.scss
@@ -370,6 +370,22 @@ $text-button-disabled-color: var(--amino-button-text-button-disabled-color);
     }
   }
 
+  &.inlineLinkButton {
+    padding: 0;
+    display: inline-flex;
+    &:not([disabled]) {
+      &:hover, &:active {
+        color: $text-button-hover-color;
+        background: transparent;
+      }
+    }
+    &[disabled] {
+      .content {
+        opacity: theme.$amino-opacity-disabled;
+      }    
+    }
+  }
+
   &.textButton {
     color: $text-button-color;
     &:not([disabled]) {

--- a/src/components/button/Button.module.scss.d.ts
+++ b/src/components/button/Button.module.scss.d.ts
@@ -4,6 +4,7 @@ export declare const content: string;
 export declare const dangerButton: string;
 export declare const hasIcon: string;
 export declare const iconRight: string;
+export declare const inlineLinkButton: string;
 export declare const linkButton: string;
 export declare const loading: string;
 export declare const onlyIcon: string;

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -242,6 +242,7 @@ export function Button<T extends GroupTag = typeof DEFAULT_TAG>({
         }
         return 'white';
       case 'link':
+      case 'inlineLink':
         return 'info';
       case 'plain':
       case 'subtle':
@@ -263,6 +264,7 @@ export function Button<T extends GroupTag = typeof DEFAULT_TAG>({
       case 'danger':
         return theme.gray0;
       case 'link':
+      case 'inlineLink':
         return theme.primary;
       case 'subtle':
         return theme.textColorSecondary;
@@ -317,6 +319,7 @@ export function Button<T extends GroupTag = typeof DEFAULT_TAG>({
       case 'standard':
         return theme.raisedSurfaceColor;
       case 'subtle':
+      case 'inlineLink':
         return 'none';
       default:
         return '';

--- a/src/components/button/__stories__/Button.stories.tsx
+++ b/src/components/button/__stories__/Button.stories.tsx
@@ -228,6 +228,15 @@ LinkButton.args = {
   variant: 'link',
 };
 
+export const InlineLinkButton = Template.bind({});
+InlineLinkButton.args = {
+  children: 'Inline link button',
+  // @ts-expect-error Storybook struggles with our dynamic prop types
+  href: '#',
+  tag: 'a',
+  variant: 'inlineLink',
+};
+
 export const Subtle = Template.bind({});
 Subtle.args = {
   children: 'Example button',

--- a/src/types/Variant.ts
+++ b/src/types/Variant.ts
@@ -1,10 +1,11 @@
 export type Variant =
-  | 'standard'
-  | 'primary'
-  | 'success'
-  | 'warning'
   | 'danger'
-  | 'subtle'
+  | 'inlineLink'
   | 'link'
   | 'plain'
-  | 'text';
+  | 'primary'
+  | 'standard'
+  | 'subtle'
+  | 'success'
+  | 'text'
+  | 'warning';


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR adds an `inlineLink` button to allow us to do inline links that have no padding and can still use icons and other button props.

PREVIEW: <https://amino-git-feat-inline-link-zonos.vercel.app/?path=/story/amino-button--inline-link-button>

## Todo

- [ ] Bump version and add tag
