### PR TITLE
fix(layout): auto sidebar footer height

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.2.9",
+  "version": "5.2.10",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.2.10",
+  "version": "5.2.9",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/layout/Layout.module.scss
+++ b/src/components/layout/Layout.module.scss
@@ -18,7 +18,7 @@ $height: var(--amino-layout-height);
   width: theme.$amino-sidebar-width;
   box-sizing: border-box;
   display: grid;
-  grid-template-rows: 1fr calc(39px + theme.$amino-space-24 * 2);
+  grid-template-rows: 1fr auto;
   height: inherit;
   background: theme.$amino-sidebar-color;
 }


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR removes the strict height on the amino Layout footer. Not sure why it was necessary in the first place? 🤔

I'm adding a new piece to the dashboard sidebar footer and this is what I need done.

## Todo

- [x] Bump version and add tag
