### PR TITLE
Fix(thumbnail): add color override props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.2.10",
+  "version": "5.2.11",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/thumbnail/Thumbnail.tsx
+++ b/src/components/thumbnail/Thumbnail.tsx
@@ -17,6 +17,7 @@ const thumbnailShapes = {
 
 export type ThumbnailProps = BaseProps & {
   /** @default 'gray' */
+  /** @description automatically applies a color scheme based on the color passed */
   color?: ColorPrefix;
   icon: ReactNode;
   /** @default 'full' */

--- a/src/components/thumbnail/Thumbnail.tsx
+++ b/src/components/thumbnail/Thumbnail.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import type { ImageSize } from 'src/components/avatar/AvatarBase';
 import { theme } from 'src/styles/constants/theme';
 import type { BaseProps } from 'src/types/BaseProps';
-import type { ColorPrefix } from 'src/types/Color';
+import type { Color, ColorPrefix } from 'src/types/Color';
 
 import styles from './Thumbnail.module.scss';
 
@@ -21,6 +21,10 @@ export type ThumbnailProps = BaseProps & {
   icon: ReactNode;
   /** @default 'full' */
   intent?: 'full' | 'outline' | 'bordered';
+  /** @description mainColorOverride is used if the "color" prop is not sufficient for your needs */
+  mainColorOverride?: Color;
+  /** @description secondaryColorOverride is used if the "color" prop is not sufficient for your needs */
+  secondaryColorOverride?: Color;
   /** @default 'round' */
   shape?: keyof typeof thumbnailShapes;
   /** @default 32 */
@@ -32,6 +36,8 @@ export const Thumbnail = ({
   color = 'gray',
   icon,
   intent = 'full',
+  mainColorOverride,
+  secondaryColorOverride,
   shape = 'round',
   size = 32,
   style,
@@ -48,8 +54,10 @@ export const Thumbnail = ({
       '--amino-thumbnail-background-color': theme[`${color}100`],
       '--amino-thumbnail-border-radius': thumbnailShapes[shape],
       '--amino-thumbnail-size': `${size}px`,
-      '--amino-thumbnail-svg-main-color': theme[`${color}800`],
-      '--amino-thumbnail-svg-secondary-color': theme[`${color}400`],
+      '--amino-thumbnail-svg-main-color':
+        theme[mainColorOverride || `${color}800`],
+      '--amino-thumbnail-svg-secondary-color':
+        theme[secondaryColorOverride || `${color}400`],
     }}
   >
     {icon}

--- a/src/components/thumbnail/__stories__/Thumbnail.stories.tsx
+++ b/src/components/thumbnail/__stories__/Thumbnail.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryFn } from '@storybook/react';
 
 import { HStack } from 'src/components/stack/HStack';
-import { Text } from 'src/components/text/Text';
 import {
   type ThumbnailProps,
   Thumbnail as ThumbnailComponent,
@@ -43,15 +42,10 @@ type StoryProps = Omit<ThumbnailProps, 'shape' | 'icon'> & {
 
 const Template: StoryFn<StoryProps> = ({ icon, ...props }) => {
   const Icon = icons[icon];
-  const duotoneIcon = icon
-    .split('Icon')
-    .join('DuotoneIcon') as keyof typeof icons;
-  const DuotoneIcon = icons[duotoneIcon];
 
   return (
     <HStack>
       <div className={styles.wrapper}>
-        <Text type="header">Basic</Text>
         <ThumbnailComponent {...props} icon={<Icon />} shape="round" />
         <ThumbnailComponent {...props} icon={<Icon />} shape="rounded" />
         <ThumbnailComponent {...props} icon={<Icon />} shape="square" />
@@ -65,30 +59,6 @@ const Template: StoryFn<StoryProps> = ({ icon, ...props }) => {
         <ThumbnailComponent
           {...props}
           icon={<Icon />}
-          intent="outline"
-          shape="square"
-        />
-      </div>
-
-      <div className={styles.wrapper}>
-        <Text type="header">Duotone</Text>
-        <ThumbnailComponent {...props} icon={<DuotoneIcon />} shape="round" />
-        <ThumbnailComponent {...props} icon={<DuotoneIcon />} shape="rounded" />
-        <ThumbnailComponent {...props} icon={<DuotoneIcon />} shape="square" />
-        <ThumbnailComponent
-          {...props}
-          icon={<DuotoneIcon />}
-          intent="outline"
-        />
-        <ThumbnailComponent
-          {...props}
-          icon={<DuotoneIcon />}
-          intent="outline"
-          shape="rounded"
-        />
-        <ThumbnailComponent
-          {...props}
-          icon={<DuotoneIcon />}
           intent="outline"
           shape="square"
         />

--- a/src/components/thumbnail/__stories__/Thumbnail.stories.tsx
+++ b/src/components/thumbnail/__stories__/Thumbnail.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryFn } from '@storybook/react';
 
+import { HStack } from 'src/components/stack/HStack';
+import { Text } from 'src/components/text/Text';
 import {
   type ThumbnailProps,
   Thumbnail as ThumbnailComponent,
@@ -41,26 +43,57 @@ type StoryProps = Omit<ThumbnailProps, 'shape' | 'icon'> & {
 
 const Template: StoryFn<StoryProps> = ({ icon, ...props }) => {
   const Icon = icons[icon];
+  const duotoneIcon = icon
+    .split('Icon')
+    .join('DuotoneIcon') as keyof typeof icons;
+  const DuotoneIcon = icons[duotoneIcon];
 
   return (
-    <div className={styles.wrapper}>
-      <ThumbnailComponent {...props} icon={<Icon />} shape="round" />
-      <ThumbnailComponent {...props} icon={<Icon />} shape="rounded" />
-      <ThumbnailComponent {...props} icon={<Icon />} shape="square" />
-      <ThumbnailComponent {...props} icon={<Icon />} intent="outline" />
-      <ThumbnailComponent
-        {...props}
-        icon={<Icon />}
-        intent="outline"
-        shape="rounded"
-      />
-      <ThumbnailComponent
-        {...props}
-        icon={<Icon />}
-        intent="outline"
-        shape="square"
-      />
-    </div>
+    <HStack>
+      <div className={styles.wrapper}>
+        <Text type="header">Basic</Text>
+        <ThumbnailComponent {...props} icon={<Icon />} shape="round" />
+        <ThumbnailComponent {...props} icon={<Icon />} shape="rounded" />
+        <ThumbnailComponent {...props} icon={<Icon />} shape="square" />
+        <ThumbnailComponent {...props} icon={<Icon />} intent="outline" />
+        <ThumbnailComponent
+          {...props}
+          icon={<Icon />}
+          intent="outline"
+          shape="rounded"
+        />
+        <ThumbnailComponent
+          {...props}
+          icon={<Icon />}
+          intent="outline"
+          shape="square"
+        />
+      </div>
+
+      <div className={styles.wrapper}>
+        <Text type="header">Duotone</Text>
+        <ThumbnailComponent {...props} icon={<DuotoneIcon />} shape="round" />
+        <ThumbnailComponent {...props} icon={<DuotoneIcon />} shape="rounded" />
+        <ThumbnailComponent {...props} icon={<DuotoneIcon />} shape="square" />
+        <ThumbnailComponent
+          {...props}
+          icon={<DuotoneIcon />}
+          intent="outline"
+        />
+        <ThumbnailComponent
+          {...props}
+          icon={<DuotoneIcon />}
+          intent="outline"
+          shape="rounded"
+        />
+        <ThumbnailComponent
+          {...props}
+          icon={<DuotoneIcon />}
+          intent="outline"
+          shape="square"
+        />
+      </div>
+    </HStack>
   );
 };
 


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR adds color overrides to Thumbnails when we don't want to use the default color schemes for thumbnails.

PREVIEW
<https://vercel.live/open-feedback/amino-git-fix-thumbnail-zonos.vercel.app?via=pr-comment-visit-preview-link&passThrough=1>
1. Open thumbnail
2. Choose a duotone icon
3. Select override colors for both

## Todo

- [x] Bump version and add tag
