### PR TITLE
Feature/ts 1109 add secondary page header type to text input in amino

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.2.16",
+  "version": "5.2.17",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/text/Text.tsx
+++ b/src/components/text/Text.tsx
@@ -18,11 +18,18 @@ type OtherText = (typeof textOthers)[number];
 
 export const textOptions = [
   {
-    label: 'Page Header (3XL) · 34px (2.125rem)',
+    label: 'Page Header (3XL) · 30px (1.875rem)',
     size: '3xl',
-    tag: 'h2',
+    tag: 'h1',
     type: 'page-header', // default
     weight: 700,
+  },
+  {
+    label: 'Secondary Page Header (3XL) · 30px (1.875rem)',
+    size: '3xl',
+    tag: 'h2',
+    type: 'secondary-page-header', // default
+    weight: 500,
   },
   {
     label: 'Header (2XL) · 28px (1.75rem)',
@@ -112,6 +119,7 @@ export const textOptions = [
 
 const [
   pageHeaderOption,
+  secondaryPageHeaderOption,
   headerOption,
   descriptionHeaderOption,
   titleOption,
@@ -187,6 +195,8 @@ export const Text = ({
     };
 
     switch (as) {
+      case 'h1':
+        return <h1 {...typographyProps}>{children}</h1>;
       case 'h2':
         return <h2 {...typographyProps}>{children}</h2>;
       case 'h3':
@@ -208,6 +218,13 @@ export const Text = ({
         fontWeight: fontWeight || pageHeaderOption.weight,
         isUppercase,
         size: pageHeaderOption.size,
+      });
+    case 'secondary-page-header':
+      return renderTypography({
+        as: tag || secondaryPageHeaderOption.tag,
+        fontWeight: fontWeight || secondaryPageHeaderOption.weight,
+        isUppercase,
+        size: secondaryPageHeaderOption.size,
       });
     case 'header':
       return renderTypography({

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -632,8 +632,6 @@ video {
     height: auto;
 }
 
-/*# sourceMappingURL=base.css.map */
-
 
 /* https://andy-bell.co.uk/a-more-modern-css-reset */
 


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->
[TS-1109 : Add secondary page header type to `Text` input in Amino](https://linear.app/zonos/issue/TS-1109/add-secondary-page-header-type-to-text-input-in-amino)

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR adds new `secondary-page-header` type to `Text` component.

## Todo

- [x] Bump version and add tag
