### PR TITLE
fix: change the Avater rounded border radius

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.2.23",
+  "version": "5.2.24",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/avatar/AvatarBase.tsx
+++ b/src/components/avatar/AvatarBase.tsx
@@ -11,7 +11,7 @@ export type ImageSize = 16 | 24 | 32 | 40 | 48 | 56 | 64;
 
 export const avatarShapes = {
   round: '50%',
-  rounded: '10px',
+  rounded: '', // custom calculation based on size
   square: '0px',
 } as const;
 
@@ -71,7 +71,8 @@ export const AvatarBase = ({
       '--amino-avatar-base-border': bordered
         ? `${size / 16}px solid ${theme.gray0}`
         : '',
-      '--amino-avatar-base-border-radius': avatarShapes[shape],
+      '--amino-avatar-base-border-radius':
+        shape === 'rounded' ? `${(size / 8 - 1) * 2}px` : avatarShapes[shape],
       '--amino-avatar-base-height': `${size}px`,
       '--amino-avatar-base-width': `${size}px`,
     }}


### PR DESCRIPTION
## Linear issue
[FE-870 : Update Avatar `rounded` border radius](https://linear.app/zonos/issue/FE-870/update-avatar-rounded-border-radius)

## Description
This is being used in the gql-fulfillment branch of Dashboard.

Design wants the border-radius for the Avater components to be different based on the size of the component I was able to calculate the sizes they want into an equation.

This PR updates the border radius for the BaseAvatar

## Todo

- [x] Bump version and add tag
