### PR TITLE
adjust dark mode shadows and raised elements

### DIFF
--- a/build-utils/css/constants/theme/night/_shadow.ts
+++ b/build-utils/css/constants/theme/night/_shadow.ts
@@ -1,10 +1,10 @@
 export const shadow = {
-  'v3-shadow-base': `0px 1px 4px 0px rgba(0, 0, 0, 0.7), 0px 1px 3px rgba(0, 0, 0, 0.6), 0px 0px 0px 1px rgba(255, 255, 255, 0.12)`,
-  'v3-shadow-medium': `0px 2px 4px 0px rgba(0, 0, 0, 0.6), 0px 4px 6px rgba(0, 0, 0, 0.7), 0px 0px 0px 1px rgba(255, 255, 255, 0.12)`,
-  'v3-shadow-large': `0px 4px 6px 0px rgba(0, 0, 0, 0.6), 0px 10px 15px rgba(0, 0, 0, 0.7), 0px 0px 0px 1px rgba(255, 255, 255, 0.12)`,
-  'v3-shadow-xl': `0px 10px 10px 0px rgba(0, 0, 0, 0.6), 0px 20px 25px rgba(0, 0, 0, 0.7), 0px 0px 0px 1px rgba(255, 255, 255, 0.12)`,
+  'v3-shadow-base': `0px 0px 0px 1px rgba(255, 255, 255, 0.16), 0px 1px 4px 0px rgba(0, 0, 0, 0.7), 0px 1px 3px rgba(0, 0, 0, 0.6)`,
+  'v3-shadow-medium': `0px 0px 0px 1px rgba(255, 255, 255, 0.16), 0px 2px 4px 0px rgba(0, 0, 0, 0.6), 0px 4px 6px rgba(0, 0, 0, 0.7)`,
+  'v3-shadow-large': `0px 0px 0px 1px rgba(255, 255, 255, 0.16), 0px 4px 6px 0px rgba(0, 0, 0, 0.6), 0px 10px 15px rgba(0, 0, 0, 0.7)`,
+  'v3-shadow-xl': `0px 0px 0px 1px rgba(255, 255, 255, 0.16), 0px 10px 10px 0px rgba(0, 0, 0, 0.6), 0px 20px 25px rgba(0, 0, 0, 0.7)`,
   'v3-shadow-xxl':
-    '0px 32px 50px 0px rgba(0, 0, 0, 0.7), 0px 0px 0px 1px rgba(255, 255, 255, 0.12);',
+    '0px 0px 0px 1px rgba(255, 255, 255, 0.16), 0px 32px 50px 0px rgba(0, 0, 0, 0.7)',
   'v3-shadow-inset':
     ' 0px 2px 4px rgba(0, 0, 0, 0.24), 0px 1px 0px rgba(17, 17, 20, 1), inset 0px 0px 8px rgba(0, 0, 0, 0.16), inset 0px 0px 0px 0.5px rgba(0, 0, 0, 0.24), inset 0px 2px 4px rgba(0, 0, 0, 0.24),  inset 0px 1px 1px rgba(0, 0, 0, 0.24), 0px 0px 6px rgba(255, 255, 255, 0.08), 0px 0px 0px 1px rgba(255, 255, 255, 0.12);',
   'shadow-button-primary':

--- a/build-utils/css/utils/__tests__/__previous-test-files__/night-theme.css
+++ b/build-utils/css/utils/__tests__/__previous-test-files__/night-theme.css
@@ -95,16 +95,16 @@
   --amino-transparent-white: #101116bb;
   --amino-transparent-black: #ffffffbb;
   --amino-transparent-gray-600: #94969e1f;
-  --amino-v3-shadow-base: 0px 1px 4px 0px rgba(0, 0, 0, 0.7),
-    0px 1px 3px rgba(0, 0, 0, 0.6), 0px 0px 0px 1px rgba(255, 255, 255, 0.12);
-  --amino-v3-shadow-medium: 0px 2px 4px 0px rgba(0, 0, 0, 0.6),
-    0px 4px 6px rgba(0, 0, 0, 0.7), 0px 0px 0px 1px rgba(255, 255, 255, 0.12);
-  --amino-v3-shadow-large: 0px 4px 6px 0px rgba(0, 0, 0, 0.6),
-    0px 10px 15px rgba(0, 0, 0, 0.7), 0px 0px 0px 1px rgba(255, 255, 255, 0.12);
-  --amino-v3-shadow-xl: 0px 10px 10px 0px rgba(0, 0, 0, 0.6),
-    0px 20px 25px rgba(0, 0, 0, 0.7), 0px 0px 0px 1px rgba(255, 255, 255, 0.12);
-  --amino-v3-shadow-xxl: 0px 32px 50px 0px rgba(0, 0, 0, 0.7),
-    0px 0px 0px 1px rgba(255, 255, 255, 0.12);
+  --amino-v3-shadow-base: 0px 0px 0px 1px rgba(255, 255, 255, 0.16),
+    0px 1px 4px 0px rgba(0, 0, 0, 0.7), 0px 1px 3px rgba(0, 0, 0, 0.6);
+  --amino-v3-shadow-medium: 0px 0px 0px 1px rgba(255, 255, 255, 0.16),
+    0px 2px 4px 0px rgba(0, 0, 0, 0.6), 0px 4px 6px rgba(0, 0, 0, 0.7);
+  --amino-v3-shadow-large: 0px 0px 0px 1px rgba(255, 255, 255, 0.16),
+    0px 4px 6px 0px rgba(0, 0, 0, 0.6), 0px 10px 15px rgba(0, 0, 0, 0.7);
+  --amino-v3-shadow-xl: 0px 0px 0px 1px rgba(255, 255, 255, 0.16),
+    0px 10px 10px 0px rgba(0, 0, 0, 0.6), 0px 20px 25px rgba(0, 0, 0, 0.7);
+  --amino-v3-shadow-xxl: 0px 0px 0px 1px rgba(255, 255, 255, 0.16),
+    0px 32px 50px 0px rgba(0, 0, 0, 0.7);
   --amino-v3-shadow-inset: 0px 2px 4px rgba(0, 0, 0, 0.24),
     0px 1px 0px rgba(17, 17, 20, 1), inset 0px 0px 8px rgba(0, 0, 0, 0.16),
     inset 0px 0px 0px 0.5px rgba(0, 0, 0, 0.24),

--- a/build-utils/css/utils/__tests__/__snapshots__/generateCSS.test.ts.snap
+++ b/build-utils/css/utils/__tests__/__snapshots__/generateCSS.test.ts.snap
@@ -405,16 +405,16 @@ exports[`Case night theme: 1`] = `
   --amino-transparent-white: #101116bb;
   --amino-transparent-black: #ffffffbb;
   --amino-transparent-gray-600: #94969e1f;
-  --amino-v3-shadow-base: 0px 1px 4px 0px rgba(0, 0, 0, 0.7),
-    0px 1px 3px rgba(0, 0, 0, 0.6), 0px 0px 0px 1px rgba(255, 255, 255, 0.12);
-  --amino-v3-shadow-medium: 0px 2px 4px 0px rgba(0, 0, 0, 0.6),
-    0px 4px 6px rgba(0, 0, 0, 0.7), 0px 0px 0px 1px rgba(255, 255, 255, 0.12);
-  --amino-v3-shadow-large: 0px 4px 6px 0px rgba(0, 0, 0, 0.6),
-    0px 10px 15px rgba(0, 0, 0, 0.7), 0px 0px 0px 1px rgba(255, 255, 255, 0.12);
-  --amino-v3-shadow-xl: 0px 10px 10px 0px rgba(0, 0, 0, 0.6),
-    0px 20px 25px rgba(0, 0, 0, 0.7), 0px 0px 0px 1px rgba(255, 255, 255, 0.12);
-  --amino-v3-shadow-xxl: 0px 32px 50px 0px rgba(0, 0, 0, 0.7),
-    0px 0px 0px 1px rgba(255, 255, 255, 0.12);
+  --amino-v3-shadow-base: 0px 0px 0px 1px rgba(255, 255, 255, 0.16),
+    0px 1px 4px 0px rgba(0, 0, 0, 0.7), 0px 1px 3px rgba(0, 0, 0, 0.6);
+  --amino-v3-shadow-medium: 0px 0px 0px 1px rgba(255, 255, 255, 0.16),
+    0px 2px 4px 0px rgba(0, 0, 0, 0.6), 0px 4px 6px rgba(0, 0, 0, 0.7);
+  --amino-v3-shadow-large: 0px 0px 0px 1px rgba(255, 255, 255, 0.16),
+    0px 4px 6px 0px rgba(0, 0, 0, 0.6), 0px 10px 15px rgba(0, 0, 0, 0.7);
+  --amino-v3-shadow-xl: 0px 0px 0px 1px rgba(255, 255, 255, 0.16),
+    0px 10px 10px 0px rgba(0, 0, 0, 0.6), 0px 20px 25px rgba(0, 0, 0, 0.7);
+  --amino-v3-shadow-xxl: 0px 0px 0px 1px rgba(255, 255, 255, 0.16),
+    0px 32px 50px 0px rgba(0, 0, 0, 0.7);
   --amino-v3-shadow-inset: 0px 2px 4px rgba(0, 0, 0, 0.24),
     0px 1px 0px rgba(17, 17, 20, 1), inset 0px 0px 8px rgba(0, 0, 0, 0.16),
     inset 0px 0px 0px 0.5px rgba(0, 0, 0, 0.24),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/badge/Badge.module.scss
+++ b/src/components/badge/Badge.module.scss
@@ -14,7 +14,7 @@ $order: var(--amino-badge-order);
   font-size: theme.$amino-font-size-s;
   padding: 3px 4px;
   text-align: center;
-  background-color: theme.$amino-gray-100;
+  background-color: theme.$amino-gray-50;
   color: theme.$amino-gray-800;
   align-items: center;
   border-radius: $border-radius;

--- a/src/components/dialog/BaseDialog.module.scss
+++ b/src/components/dialog/BaseDialog.module.scss
@@ -17,7 +17,7 @@ $width: var(--amino-base-dialog-width);
 
 .popup {
   z-index: 1001;
-  background: theme.$amino-surface-color;
+  background: theme.$amino-page-background;
   max-height: 90vh;
   width: $width;
   border-radius: theme.$amino-radius-12;

--- a/src/components/filter/FilterWrapper.module.scss
+++ b/src/components/filter/FilterWrapper.module.scss
@@ -75,7 +75,7 @@ $border-right-color: var(--amino-filter-wrapper-border-right-color);
   min-width: 400px;
   position: absolute;
   border-radius: theme.$amino-radius-12;
-  background-color: theme.$amino-surface-color;
+  background-color: theme.$amino-page-background;
   box-shadow: theme.$amino-v3-shadow-xl;
   padding: theme.$amino-space-24;
   flex-direction: column;

--- a/src/components/slide-over/SlideOver.module.scss
+++ b/src/components/slide-over/SlideOver.module.scss
@@ -19,7 +19,7 @@
   height: 100%;
   margin: 8px;
   border-radius: 12px;
-  background: theme.$amino-surface-color;
+  background: theme.$amino-page-background;
 
   display: flex;
   flex-direction: column;
@@ -57,7 +57,7 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  background: theme.$amino-surface-color-secondary;
+  background: theme.$amino-page-background;
 
   & > div + div {
     margin-left: 8px;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -400,16 +400,16 @@
   --amino-transparent-white: #101116bb;
   --amino-transparent-black: #ffffffbb;
   --amino-transparent-gray-600: #94969e1f;
-  --amino-v3-shadow-base: 0px 1px 4px 0px rgba(0, 0, 0, 0.7),
-    0px 1px 3px rgba(0, 0, 0, 0.6), 0px 0px 0px 1px rgba(255, 255, 255, 0.12);
-  --amino-v3-shadow-medium: 0px 2px 4px 0px rgba(0, 0, 0, 0.6),
-    0px 4px 6px rgba(0, 0, 0, 0.7), 0px 0px 0px 1px rgba(255, 255, 255, 0.12);
-  --amino-v3-shadow-large: 0px 4px 6px 0px rgba(0, 0, 0, 0.6),
-    0px 10px 15px rgba(0, 0, 0, 0.7), 0px 0px 0px 1px rgba(255, 255, 255, 0.12);
-  --amino-v3-shadow-xl: 0px 10px 10px 0px rgba(0, 0, 0, 0.6),
-    0px 20px 25px rgba(0, 0, 0, 0.7), 0px 0px 0px 1px rgba(255, 255, 255, 0.12);
-  --amino-v3-shadow-xxl: 0px 32px 50px 0px rgba(0, 0, 0, 0.7),
-    0px 0px 0px 1px rgba(255, 255, 255, 0.12);
+  --amino-v3-shadow-base: 0px 0px 0px 1px rgba(255, 255, 255, 0.16),
+    0px 1px 4px 0px rgba(0, 0, 0, 0.7), 0px 1px 3px rgba(0, 0, 0, 0.6);
+  --amino-v3-shadow-medium: 0px 0px 0px 1px rgba(255, 255, 255, 0.16),
+    0px 2px 4px 0px rgba(0, 0, 0, 0.6), 0px 4px 6px rgba(0, 0, 0, 0.7);
+  --amino-v3-shadow-large: 0px 0px 0px 1px rgba(255, 255, 255, 0.16),
+    0px 4px 6px 0px rgba(0, 0, 0, 0.6), 0px 10px 15px rgba(0, 0, 0, 0.7);
+  --amino-v3-shadow-xl: 0px 0px 0px 1px rgba(255, 255, 255, 0.16),
+    0px 10px 10px 0px rgba(0, 0, 0, 0.6), 0px 20px 25px rgba(0, 0, 0, 0.7);
+  --amino-v3-shadow-xxl: 0px 0px 0px 1px rgba(255, 255, 255, 0.16),
+    0px 32px 50px 0px rgba(0, 0, 0, 0.7);
   --amino-v3-shadow-inset: 0px 2px 4px rgba(0, 0, 0, 0.24),
     0px 1px 0px rgba(17, 17, 20, 1), inset 0px 0px 8px rgba(0, 0, 0, 0.16),
     inset 0px 0px 0px 0.5px rgba(0, 0, 0, 0.24),


### PR DESCRIPTION
## Description

Adjusts "raised" elements that contain buttons to stay the page background color instead of a lighter surface color.

Adjusts dark mode shadows to have a lighter border to contrast from the background

Fixes gray badge not getting last update.


## Todo

- [x] Bump version
