### PR TITLE
fix: storage lifetime allow more granularity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/dialog/DismissableDialog.module.scss
+++ b/src/components/dialog/DismissableDialog.module.scss
@@ -12,16 +12,7 @@
 }
 
 .footer {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-
-  & > button + button {
-    margin-left: theme.$amino-space-8;
-  }
-
-  button {
-    flex: 1;
-  }
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
 }

--- a/src/components/dialog/alert/AlertDialog.tsx
+++ b/src/components/dialog/alert/AlertDialog.tsx
@@ -21,6 +21,7 @@ export const AlertDialog = ({
       <Button
         onClick={dismissAction}
         size="lg"
+        style={{ gridColumn: 'span 2' }}
         variant={_dismissableDialogGetButtonVariant(props.intent)}
       >
         {dismissText}

--- a/src/components/dialog/alert/__stories__/AlertConsumer.tsx
+++ b/src/components/dialog/alert/__stories__/AlertConsumer.tsx
@@ -16,6 +16,7 @@ export const AlertConsumer = () => {
             label: 'Heads up',
             onDismiss: () => {},
             subtitle: 'You look nice today',
+            width: 500,
           })
         }
         variant="primary"
@@ -31,6 +32,7 @@ export const AlertConsumer = () => {
             label: 'Heads up',
             onDismiss: () => {},
             subtitle: 'There was an error or something',
+            width: 800,
           })
         }
         variant="danger"

--- a/src/components/dialog/confirm/__stories__/ConfirmConsumer.tsx
+++ b/src/components/dialog/confirm/__stories__/ConfirmConsumer.tsx
@@ -41,11 +41,12 @@ export const ConfirmConsumer = () => {
         onClick={() =>
           confirm({
             confirmText: 'Do action',
-            dismissText: "Don't do action",
+            dismissText: "Don't do action (for real!)",
             intent: 'danger',
             label: 'Are you sure?',
             onConfirm: setDangerConfirmOk,
             subtitle: 'This is the descriptive text about what just happened',
+            width: 800,
           })
         }
         variant="danger"

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -91,7 +91,7 @@ export const setStorageItemWithLifetime = <Value extends unknown>({
 
   if (valueIsTruthy) {
     storage.setItem(key, valueToSet);
-    storage.setItem(`${key}_update_after`, lifetime.format('YYYY-MM-DD'));
+    storage.setItem(`${key}_update_after`, lifetime.format());
   } else {
     // Remove the item
     storage.removeItem(key);


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR fixes an issue with the storage lifetime util where it was formatting the data only to the day, preventing any finer time ranges.

Also makes dismissable dialogs actions width consistent.

Also apparently `dismissable` is not a real word and it is is `dismissible`... but the truth is whatever we make it.

## Todo

- [ ] Bump version and add tag
