### PR TITLE
Refactor/button group support menu button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.3.4",
+  "version": "5.3.5",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/button/MenuButton.tsx
+++ b/src/components/button/MenuButton.tsx
@@ -63,6 +63,7 @@ export const MenuButton = ({
     >
       <div
         ref={refs.setReference}
+        className="menu-button-action"
         onClick={e => {
           e.stopPropagation();
           setVisible(true);

--- a/src/components/button/__stories__/ButtonGroup.stories.tsx
+++ b/src/components/button/__stories__/ButtonGroup.stories.tsx
@@ -1,7 +1,11 @@
+import { Tooltip } from '@mui/material';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { Button } from 'src/components/button/Button';
 import { ButtonGroup } from 'src/components/button/button-group/ButtonGroup';
+import { MenuButton } from 'src/components/button/MenuButton';
+import { Menu } from 'src/components/menu/Menu';
+import { MenuItem } from 'src/components/menu/MenuItem';
 import { VStack } from 'src/components/stack/VStack';
 import { Text } from 'src/components/text/Text';
 import {
@@ -61,6 +65,42 @@ const createButtonStory = (numButtons: number): Story => ({
           {icons.slice(0, numButtons).map(icon => (
             <Button key={icon.key} icon={icon} />
           ))}
+        </ButtonGroup>
+
+        {/* Mixture of menu button and button */}
+        <ButtonGroup>
+          {Array.from({ length: numButtons }, (_, i) =>
+            i % 2 !== 0 ? (
+              <MenuButton action={<Button>Menu button</Button>}>
+                <Menu>
+                  <MenuItem>Menu 1</MenuItem>
+                  <MenuItem>Menu 2</MenuItem>
+                  <MenuItem>Menu 3</MenuItem>
+                </Menu>
+              </MenuButton>
+            ) : (
+              <Button key={i}>Button {i + 1}</Button>
+            ),
+          )}
+        </ButtonGroup>
+
+        {/* Mixture of tooltip button and menu button */}
+        <ButtonGroup>
+          {Array.from({ length: numButtons }, (_, i) =>
+            i % 2 !== 0 ? (
+              <MenuButton action={<Button>Menu button</Button>}>
+                <Menu>
+                  <MenuItem>Menu 1</MenuItem>
+                  <MenuItem>Menu 2</MenuItem>
+                  <MenuItem>Menu 3</MenuItem>
+                </Menu>
+              </MenuButton>
+            ) : (
+              <Tooltip title="Tooltip">
+                <Button key={i}>Tooltip Button {i + 1}</Button>
+              </Tooltip>
+            ),
+          )}
         </ButtonGroup>
       </VStack>
     </VStack>

--- a/src/components/button/button-group/ButtonGroup.module.scss
+++ b/src/components/button/button-group/ButtonGroup.module.scss
@@ -4,20 +4,29 @@
   border-radius: theme.$amino-radius-6;
   width: fit-content;
 
-  > * {
+  > *,
+  :global(.menu-button-action) *,
+  :global(.tooltip-wrapper) * {
     &:focus {
       z-index: 1;
     }
   }
 
   > *:not(:first-child) {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-    margin-left: -1px;
+    &,
+    :global(.menu-button-action) *,
+    :global(.tooltip-wrapper) * {
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+      margin-left: -1px;
+    }
   }
-  
   > *:not(:last-child) {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
+    &,
+    :global(.menu-button-action) *,
+    :global(.tooltip-wrapper) * {
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+    }
   }
 }

--- a/src/components/menu/MenuItem.module.scss
+++ b/src/components/menu/MenuItem.module.scss
@@ -1,5 +1,12 @@
 @use 'theme';
 
+.disabled {
+  .styledListItem {
+    cursor: not-allowed;
+    opacity: theme.$amino-opacity-disabled;
+  }
+}
+
 .styledListItem {
   display: flex;
   align-items: center;

--- a/src/components/menu/MenuItem.module.scss.d.ts
+++ b/src/components/menu/MenuItem.module.scss.d.ts
@@ -1,1 +1,2 @@
+export declare const disabled: string;
 export declare const styledListItem: string;

--- a/src/components/menu/MenuItem.tsx
+++ b/src/components/menu/MenuItem.tsx
@@ -1,11 +1,14 @@
 import type { MouseEventHandler, ReactNode } from 'react';
 
+import clsx from 'clsx';
+
 import type { BaseProps } from 'src/types/BaseProps';
 
 import styles from './MenuItem.module.scss';
 
 type MenuItemProps = BaseProps & {
   children: ReactNode;
+  disabled?: boolean;
   icon?: ReactNode;
   onClick?: MouseEventHandler;
 };
@@ -13,15 +16,16 @@ type MenuItemProps = BaseProps & {
 export const MenuItem = ({
   children,
   className,
+  disabled,
   icon,
   onClick,
   style,
 }: MenuItemProps) => (
-  <li className={className} style={style}>
+  <li className={clsx(className, disabled && styles.disabled)} style={style}>
     {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
     <div
       className={styles.styledListItem}
-      onClick={onClick}
+      onClick={e => !disabled && onClick?.(e)}
       role="button"
       tabIndex={0}
     >

--- a/src/components/menu/__stories__/MenuButton.stories.tsx
+++ b/src/components/menu/__stories__/MenuButton.stories.tsx
@@ -6,13 +6,14 @@ import {
   useState,
 } from 'react';
 
-import type { Meta, StoryFn } from '@storybook/react';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react';
 
 import { Button } from 'src/components/button/Button';
 import {
   type MenuButtonProps,
   MenuButton,
 } from 'src/components/button/MenuButton';
+import { Flex } from 'src/components/flex/Flex';
 import { Menu } from 'src/components/menu/Menu';
 import { MenuItem } from 'src/components/menu/MenuItem';
 import { CartIcon } from 'src/icons/CartIcon';
@@ -26,7 +27,7 @@ import { RemoveCircleIcon } from 'src/icons/RemoveCircleIcon';
 import { SearchIcon } from 'src/icons/SearchIcon';
 import { UserIcon } from 'src/icons/UserIcon';
 
-const MenuButtonMeta: Meta = {
+const MenuButtonMeta: Meta<typeof MenuButton> = {
   component: MenuButton,
   parameters: {
     design: {
@@ -37,6 +38,8 @@ const MenuButtonMeta: Meta = {
 };
 
 export default MenuButtonMeta;
+
+type Story = StoryObj<typeof MenuButton>;
 
 const Template: StoryFn<MenuButtonProps> = ({
   children,
@@ -54,136 +57,173 @@ const Template: StoryFn<MenuButtonProps> = ({
   </MenuButton>
 );
 
-export const WithIcon = Template.bind({});
-WithIcon.args = {
-  children: (
-    <Menu>
-      <MenuItem icon={<CodeIcon color="gray600" size={24} />}>
-        View API details
-      </MenuItem>
-      <MenuItem icon={<CartIcon color="gray600" size={24} />}>
-        Re-create customer cart
-      </MenuItem>
-      <MenuItem icon={<MailIcon color="gray600" size={24} />}>
-        Re-send confirmation email
-      </MenuItem>
-      <MenuItem icon={<UserIcon color="gray600" size={24} />}>
-        Blacklist customer
-      </MenuItem>
-      <MenuItem icon={<ExternalIcon color="gray600" size={24} />}>
-        Open fraud tools
-      </MenuItem>
-      <MenuItem icon={<CheckCircleIcon color="gray600" size={24} />}>
-        Approve
-      </MenuItem>
-      <MenuItem icon={<RemoveCircleIcon color="gray600" size={24} />}>
-        Deny
-      </MenuItem>
-      <MenuItem icon={<SearchIcon color="gray600" size={24} />}>
-        Investigate buyer
-      </MenuItem>
-      <MenuItem icon={<EyeIcon color="gray600" size={24} />}>
-        Request verification
-      </MenuItem>
-    </Menu>
-  ),
+export const WithIcon: Story = {
+  args: {
+    children: (
+      <Menu>
+        <MenuItem icon={<CodeIcon color="gray600" size={24} />}>
+          View API details
+        </MenuItem>
+        <MenuItem icon={<CartIcon color="gray600" size={24} />}>
+          Re-create customer cart
+        </MenuItem>
+        <MenuItem icon={<MailIcon color="gray600" size={24} />}>
+          Re-send confirmation email
+        </MenuItem>
+        <MenuItem icon={<UserIcon color="gray600" size={24} />}>
+          Blacklist customer
+        </MenuItem>
+        <MenuItem icon={<ExternalIcon color="gray600" size={24} />}>
+          Open fraud tools
+        </MenuItem>
+        <MenuItem icon={<CheckCircleIcon color="gray600" size={24} />}>
+          Approve
+        </MenuItem>
+        <MenuItem icon={<RemoveCircleIcon color="gray600" size={24} />}>
+          Deny
+        </MenuItem>
+        <MenuItem icon={<SearchIcon color="gray600" size={24} />}>
+          Investigate buyer
+        </MenuItem>
+        <MenuItem icon={<EyeIcon color="gray600" size={24} />}>
+          Request verification
+        </MenuItem>
+      </Menu>
+    ),
+  },
+  render: Template,
 };
 
-export const WithoutIcon = Template.bind({});
-WithoutIcon.args = {
-  children: (
-    <Menu>
-      <MenuItem>View API details</MenuItem>
-      <MenuItem>Re-create customer cart</MenuItem>
-      <MenuItem>Re-send confirmation email</MenuItem>
-      <MenuItem>Blacklist customer</MenuItem>
-      <MenuItem>Open fraud tools</MenuItem>
-      <MenuItem>Approve</MenuItem>
-      <MenuItem>Deny</MenuItem>
-      <MenuItem>Investigate buyer</MenuItem>
-      <MenuItem>Request verification</MenuItem>
-    </Menu>
-  ),
+export const WithoutIcon: Story = {
+  args: {
+    children: (
+      <Menu>
+        <MenuItem disabled>View API details</MenuItem>
+        <MenuItem>Re-create customer cart</MenuItem>
+        <MenuItem>Re-send confirmation email</MenuItem>
+        <MenuItem>Blacklist customer</MenuItem>
+        <MenuItem>Open fraud tools</MenuItem>
+        <MenuItem>Approve</MenuItem>
+        <MenuItem>Deny</MenuItem>
+        <MenuItem>Investigate buyer</MenuItem>
+        <MenuItem>Request verification</MenuItem>
+      </Menu>
+    ),
+  },
+  render: Template,
 };
 
-export const SmallerOptions = Template.bind({});
-SmallerOptions.args = {
-  children: (
-    <Menu>
-      <MenuItem>A</MenuItem>
-      <MenuItem>B</MenuItem>
-    </Menu>
-  ),
-  closeOnMouseLeave: false,
-};
-
-export const Draggable: StoryFn<MenuButtonProps> = props => {
-  const [isDragging, setIsDragging] = useState(false);
-  const [position, setPosition] = useState({ x: 300, y: 300 });
-  const [offset, setOffset] = useState({ x: 0, y: 0 });
-
-  const handleMouseDown: MouseEventHandler<HTMLDivElement> = e => {
-    if (e.button !== 0) return;
-    e.preventDefault();
-    e.stopPropagation();
-    setIsDragging(true);
-    setOffset({
-      x: e.clientX - position.x,
-      y: e.clientY - position.y,
-    });
-  };
-
-  // Wrap above in useCallback
-  const handleMouseMove = useCallback(
-    (e: MouseEvent) => {
-      if (!isDragging) return;
-      setPosition({
-        x: e.clientX - offset.x,
-        y: e.clientY - offset.y,
-      });
-    },
-    [isDragging, offset.x, offset.y],
-  );
-
-  const handleMouseUp = useCallback((e: MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setIsDragging(false);
-  }, []);
-
-  useEffect(() => {
-    window.addEventListener('mousemove', handleMouseMove);
-    window.addEventListener('mouseup', handleMouseUp);
-
-    return () => {
-      window.removeEventListener('mouseup', handleMouseUp);
-      window.removeEventListener('mousemove', handleMouseMove);
-    };
-  }, [handleMouseMove, handleMouseUp]);
-
-  return (
-    <div
-      onBlur={() => setIsDragging(false)}
-      onMouseDown={handleMouseDown}
-      role="button"
-      style={{
-        left: `${position.x}px`,
-        position: 'absolute',
-        top: `${position.y}px`,
-      }}
-      tabIndex={-1}
-    >
-      <MenuButton
-        {...props}
-        action={
-          <Button icon={<ChevronDownIcon size={24} />} iconRight>
-            More...
+export const HasDisabledItem: Story = {
+  render: () => {
+    const [isDisabled, setIsDisabled] = useState(true);
+    return (
+      <Flex flexDirection="column">
+        <div>
+          Click button below to disable first item in menu button
+          <Button onClick={() => setIsDisabled(!isDisabled)}>
+            Toggle Disabled
           </Button>
-        }
+        </div>
+        <MenuButton
+          action={
+            <Button>Menu button ({isDisabled ? 'Disabled' : 'Enabled'})</Button>
+          }
+          closeOnMouseLeave={false}
+        >
+          <Menu>
+            <MenuItem disabled={isDisabled} onClick={() => alert('Alert')}>
+              {isDisabled ? 'Disabled' : 'Enabled'} item (alert() on click)
+            </MenuItem>
+            <MenuItem>Normal item</MenuItem>
+          </Menu>
+        </MenuButton>
+      </Flex>
+    );
+  },
+};
+
+export const SmallerOptions: Story = {
+  args: {
+    children: (
+      <Menu>
+        <MenuItem>A</MenuItem>
+        <MenuItem>B</MenuItem>
+      </Menu>
+    ),
+    closeOnMouseLeave: false,
+  },
+  render: Template,
+};
+
+export const Draggable: Story = {
+  render: props => {
+    const [isDragging, setIsDragging] = useState(false);
+    const [position, setPosition] = useState({ x: 300, y: 300 });
+    const [offset, setOffset] = useState({ x: 0, y: 0 });
+
+    const handleMouseDown: MouseEventHandler<HTMLDivElement> = e => {
+      if (e.button !== 0) return;
+      e.preventDefault();
+      e.stopPropagation();
+      setIsDragging(true);
+      setOffset({
+        x: e.clientX - position.x,
+        y: e.clientY - position.y,
+      });
+    };
+
+    // Wrap above in useCallback
+    const handleMouseMove = useCallback(
+      (e: MouseEvent) => {
+        if (!isDragging) return;
+        setPosition({
+          x: e.clientX - offset.x,
+          y: e.clientY - offset.y,
+        });
+      },
+      [isDragging, offset.x, offset.y],
+    );
+
+    const handleMouseUp = useCallback((e: MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setIsDragging(false);
+    }, []);
+
+    useEffect(() => {
+      window.addEventListener('mousemove', handleMouseMove);
+      window.addEventListener('mouseup', handleMouseUp);
+
+      return () => {
+        window.removeEventListener('mouseup', handleMouseUp);
+        window.removeEventListener('mousemove', handleMouseMove);
+      };
+    }, [handleMouseMove, handleMouseUp]);
+
+    return (
+      <div
+        onBlur={() => setIsDragging(false)}
+        onMouseDown={handleMouseDown}
+        role="button"
+        style={{
+          left: `${position.x}px`,
+          position: 'absolute',
+          top: `${position.y}px`,
+        }}
+        tabIndex={-1}
       >
-        <MenuItem>View API details</MenuItem>
-        <MenuItem onClick={() => alert('ok')}>Something else</MenuItem>
-      </MenuButton>
-    </div>
-  );
+        <MenuButton
+          {...props}
+          action={
+            <Button icon={<ChevronDownIcon size={24} />} iconRight>
+              More...
+            </Button>
+          }
+        >
+          <MenuItem>View API details</MenuItem>
+          <MenuItem onClick={() => alert('ok')}>Something else</MenuItem>
+        </MenuButton>
+      </div>
+    );
+  },
 };

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -118,7 +118,7 @@ export const Tooltip = ({
         open={open}
         title={renderTooltip()}
       >
-        <div>{children}</div>
+        <div className="tooltip-wrapper">{children}</div>
       </StyledTooltip>
     );
   }


### PR DESCRIPTION
## Preview
- https://amino-git-refactor-button-group-support-menu-button-zonos.vercel.app/?path=%2Fstory%2Famino-button-buttongroup--two-buttons
  <img width="478" alt="image" src="https://github.com/user-attachments/assets/7905a66d-d0d4-4039-8fe7-46459c492f83">


## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR refactors the button group to support for menu button and tooltip buttons.

## Todo

- [x] Bump version and add tag
