### PR TITLE
Feat: Textarea actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.3.5",
+  "version": "5.3.6",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/textarea/Textarea.module.scss
+++ b/src/components/textarea/Textarea.module.scss
@@ -111,6 +111,21 @@ $width: var(--amino-textarea-width);
   }
 }
 
+.actions {
+  background: theme.$amino-page-background;
+  // use radius 16 to allow expandable icon to show
+  border-bottom-right-radius: 16px;
+  border-bottom-left-radius: 16px;
+  bottom: 1px;
+  height: 58px;
+  left: 1px;
+  padding: 0 16px;
+  position: absolute;
+  right: 1px;
+  text-align: right;
+  z-index: 3;
+}
+
 .aminoInputWrapper {
   position: relative;
   width: $width;

--- a/src/components/textarea/Textarea.module.scss.d.ts
+++ b/src/components/textarea/Textarea.module.scss.d.ts
@@ -1,3 +1,4 @@
+export declare const actions: string;
 export declare const aminoInputWrapper: string;
 export declare const disabled: string;
 export declare const fields: string;

--- a/src/components/textarea/Textarea.tsx
+++ b/src/components/textarea/Textarea.tsx
@@ -7,6 +7,7 @@ import {
 
 import clsx from 'clsx';
 
+import { Flex } from 'src/components/flex/Flex';
 import { HelpText } from 'src/components/help-text/HelpText';
 import { useHeightAdjustTextarea } from 'src/utils/hooks/useHeightAdjustTextarea';
 
@@ -15,7 +16,7 @@ import styles from './Textarea.module.scss';
 type TextareaAdjustableHeightType = {
   /**
    * @param expandable
-   * @desc if set to true, the textarea will expand to fit the content
+   * @desc if set to true, the textarea will expand to fit the content. Always true if actions are passed.
    */
   expandable?: boolean;
   /**
@@ -27,6 +28,11 @@ type TextareaAdjustableHeightType = {
 };
 
 type TextareaType = {
+  /**
+   * @param actions
+   * @desc actions to be displayed in a footer within the textarea
+   */
+  actions?: ReactNode;
   error?: boolean;
   helpText?: ReactNode;
   label?: string;
@@ -40,6 +46,7 @@ export type TextareaProps = TextareaType &
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
   (
     {
+      actions,
       className,
       disabled,
       error,
@@ -57,11 +64,13 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
   ) => {
     const hasValue = !!value;
     const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+    const actionsRef = useRef<HTMLDivElement | null>(null);
 
     useHeightAdjustTextarea({
+      additionalHeight: actions ? actionsRef.current?.clientHeight : 0,
       maxRows,
       ref: textareaRef,
-      shouldExpand: !!expandable,
+      shouldExpand: !!expandable || !!actions,
       textareaValue: value?.toString() || '',
     });
 
@@ -115,6 +124,13 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
           <div className={styles.styledBorder} />
         </div>
         <HelpText error={error} helpText={helpText} />
+        {actions && (
+          <div ref={actionsRef} className={styles.actions}>
+            <Flex alignItems="center" fullHeight justifyContent="flex-end">
+              {actions}
+            </Flex>
+          </div>
+        )}
       </div>
     );
   },

--- a/src/components/textarea/Textarea.tsx
+++ b/src/components/textarea/Textarea.tsx
@@ -70,7 +70,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
       additionalHeight: actions ? actionsRef.current?.clientHeight : 0,
       maxRows,
       ref: textareaRef,
-      shouldExpand: !!expandable || !!actions,
+      shouldExpand: !!expandable,
       textareaValue: value?.toString() || '',
     });
 

--- a/src/components/textarea/Textarea.tsx
+++ b/src/components/textarea/Textarea.tsx
@@ -16,7 +16,7 @@ import styles from './Textarea.module.scss';
 type TextareaAdjustableHeightType = {
   /**
    * @param expandable
-   * @desc if set to true, the textarea will expand to fit the content. Always true if actions are passed.
+   * @desc if set to true, the textarea will expand to fit the content.
    */
   expandable?: boolean;
   /**

--- a/src/components/textarea/__stories__/Textarea.stories.tsx
+++ b/src/components/textarea/__stories__/Textarea.stories.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import type { Meta, StoryFn } from '@storybook/react';
 
+import { Button } from 'src/components/button/Button';
 import { Flex } from 'src/components/flex/Flex';
 import { Input } from 'src/components/input/Input';
 import { Text } from 'src/components/text/Text';
@@ -32,11 +33,13 @@ Basic.args = {
 };
 
 const Template: StoryFn<TextareaProps> = ({
+  actions,
   error,
   helpText,
   label,
   placeholder,
   value: _value,
+  ...rest
 }: TextareaProps) => {
   const [value, setValue] = useState(_value);
   const [autoAdjustContent, setAutoAdjustContent] = useState(longContent);
@@ -70,7 +73,9 @@ const Template: StoryFn<TextareaProps> = ({
 
         <Flex gap={10}>
           <Textarea
+            {...rest}
             ref={textareaRef}
+            actions={actions}
             error={error}
             helpText={helpText}
             onChange={() => {}}
@@ -85,6 +90,8 @@ const Template: StoryFn<TextareaProps> = ({
 
         <Flex gap={10}>
           <Textarea
+            {...rest}
+            actions={actions}
             error={error}
             helpText={helpText}
             onChange={e => setValue(e.target.value)}
@@ -101,6 +108,8 @@ const Template: StoryFn<TextareaProps> = ({
 
         <Flex gap={10}>
           <Textarea
+            {...rest}
+            actions={actions}
             error={error}
             helpText={helpText}
             label={label}
@@ -114,6 +123,8 @@ const Template: StoryFn<TextareaProps> = ({
         <Text type="bold-label">Long content:</Text>
         <Flex gap={10}>
           <Textarea
+            {...rest}
+            actions={actions}
             error={error}
             helpText={helpText}
             label={label}
@@ -128,6 +139,8 @@ const Template: StoryFn<TextareaProps> = ({
         <Text type="bold-label">Empty:</Text>
         <Flex gap={10}>
           <Textarea
+            {...rest}
+            actions={actions}
             error={error}
             helpText={helpText}
             label={label}
@@ -147,6 +160,8 @@ const Template: StoryFn<TextareaProps> = ({
         <Text type="bold-label">Editable:</Text>
         <Flex gap={10}>
           <Textarea
+            {...rest}
+            actions={actions}
             error={error}
             helpText={helpText}
             label={label}
@@ -165,6 +180,8 @@ const Template: StoryFn<TextareaProps> = ({
         <Text type="bold-label">Expandable (maxRow 5 | maxRow 3):</Text>
         <Flex gap={10}>
           <Textarea
+            {...rest}
+            actions={actions}
             error={error}
             expandable
             helpText={helpText}
@@ -174,6 +191,8 @@ const Template: StoryFn<TextareaProps> = ({
             value={autoAdjustContent}
           />
           <Textarea
+            {...rest}
+            actions={actions}
             error={error}
             expandable
             helpText={helpText}
@@ -189,6 +208,8 @@ const Template: StoryFn<TextareaProps> = ({
         <Text type="bold-label">Read only:</Text>
         <Flex gap={10}>
           <Textarea
+            {...rest}
+            actions={actions}
             error={error}
             helpText={helpText}
             label={label}
@@ -208,6 +229,8 @@ const Template: StoryFn<TextareaProps> = ({
         <Text type="bold-label">Disabled:</Text>
         <Flex gap={10}>
           <Textarea
+            {...rest}
+            actions={actions}
             disabled
             error={error}
             helpText={helpText}
@@ -239,6 +262,19 @@ Default.args = {
 export const WithHelpText = Template.bind({});
 WithHelpText.args = {
   helpText: '* This field is required',
+  label: 'Description',
+  placeholder: 'Please fill out the description',
+  value: 'HS code for Brazil',
+};
+
+export const WithActions = Template.bind({});
+WithActions.args = {
+  actions: (
+    <Flex>
+      <Button>Clear</Button>
+      <Button variant="primary">Save</Button>
+    </Flex>
+  ),
   label: 'Description',
   placeholder: 'Please fill out the description',
   value: 'HS code for Brazil',

--- a/src/utils/hooks/useHeightAdjustTextarea.ts
+++ b/src/utils/hooks/useHeightAdjustTextarea.ts
@@ -7,6 +7,7 @@ const getComputedStyle = (
 ) => window.getComputedStyle(element)[property] as string;
 
 type TextareaParams = {
+  additionalHeight?: number;
   initialRows?: number;
   // when expanding textarea, it will expand up to maxRows
   maxRows?: number;
@@ -20,6 +21,7 @@ type TextareaParams = {
  * expand the height of textarea up to `maxRows` and then it will add scroll bar.
  */
 export const useHeightAdjustTextarea = ({
+  additionalHeight = 0,
   initialRows = 2,
   maxRows = 5,
   ref,
@@ -52,14 +54,26 @@ export const useHeightAdjustTextarea = ({
     textarea.style.height = '0';
 
     // raise the textarea height when it's less max number of rows height
-    if (textarea.scrollHeight <= maxHeightToScroll) {
-      const adjustedHeight = Math.max(originalHeight, textarea.scrollHeight);
+    // raise the textarea height when it's less max number of rows height
+    if (textarea.scrollHeight + additionalHeight <= maxHeightToScroll) {
+      const adjustedHeight = Math.max(
+        originalHeight,
+        textarea.scrollHeight + additionalHeight,
+      );
 
       textarea.style.height = `${adjustedHeight}px`;
       textarea.style.overflow = 'hidden';
     } else {
-      textarea.style.height = `${maxHeightToScroll}px`;
+      textarea.style.height = `${maxHeightToScroll + additionalHeight}px`;
       textarea.style.overflow = 'auto';
     }
-  }, [ref, maxRows, textareaValue, shouldExpand, originalHeight, initialRows]);
+  }, [
+    ref,
+    maxRows,
+    textareaValue,
+    shouldExpand,
+    originalHeight,
+    initialRows,
+    additionalHeight,
+  ]);
 };


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR adds the ability for a text area to accept actions. The actions are positioned absolute in the bottom right corner of the textarea. For textarea where we expect larger text entries, it should be made `expandable` and have a greater `maxRows` count so it has a nice auto increase rather than the text getting cut off above the buttons. (I left this up to developer implementation)

https://amino-git-feat-textarea-actions-zonos.vercel.app/?path=%2Fstory%2Famino-textarea--with-actions&args=maxRows%3A15%3Bexpandable%3A%21true

## Todo

- [x] Bump version and add tag
