### PR TITLE
feat(invertedButton): Inverted button variant and fix theme override

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.3.8",
+  "version": "5.3.9",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/button/Button.module.scss
+++ b/src/components/button/Button.module.scss
@@ -214,7 +214,7 @@ $text-button-disabled-color: var(--amino-button-text-button-disabled-color);
     }
   }
 
-  &.standardButton {
+  &.standardButton, &.invertedButton {
     box-shadow: theme.$amino-shadow-button-standard;
 
     &:not([disabled]) {

--- a/src/components/button/Button.module.scss.d.ts
+++ b/src/components/button/Button.module.scss.d.ts
@@ -5,6 +5,7 @@ export declare const dangerButton: string;
 export declare const hasIcon: string;
 export declare const iconRight: string;
 export declare const inlineLinkButton: string;
+export declare const invertedButton: string;
 export declare const linkButton: string;
 export declare const loading: string;
 export declare const onlyIcon: string;

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -141,7 +141,6 @@ export function Button<T extends GroupTag = typeof DEFAULT_TAG>({
     iconRight ? styles.iconRight : '',
     icon ? styles.hasIcon : '',
     loading ? styles.loading : '',
-    themeOverride,
   );
 
   const rippleRef = useRef<RippleActions>(null);
@@ -168,7 +167,16 @@ export function Button<T extends GroupTag = typeof DEFAULT_TAG>({
 
   const { aminoTheme } = useAminoTheme();
 
-  const isNightTheme = aminoTheme === 'night';
+  const getButtonTheme = () => {
+    const initialTheme = themeOverride || aminoTheme;
+    if (variant === 'inverted') {
+      return initialTheme === 'day' ? 'night' : 'day';
+    }
+    return initialTheme;
+  };
+
+  const currentTheme = getButtonTheme();
+  const isNightTheme = currentTheme === 'night';
 
   const getPadding = () => {
     switch (size) {
@@ -249,6 +257,7 @@ export function Button<T extends GroupTag = typeof DEFAULT_TAG>({
       case 'subtle':
       case 'text':
       case 'standard':
+      case 'inverted':
       default:
         return 'black';
     }
@@ -272,6 +281,7 @@ export function Button<T extends GroupTag = typeof DEFAULT_TAG>({
       case 'plain':
       case 'text':
       case 'standard':
+      case 'inverted':
       default:
         return theme.textColor;
     }
@@ -292,6 +302,7 @@ export function Button<T extends GroupTag = typeof DEFAULT_TAG>({
       case 'danger':
         return theme.buttonDangerHover;
       case 'standard':
+      case 'inverted':
         return theme.buttonStandardHover;
       case 'subtle':
         return theme.gray100;
@@ -317,6 +328,8 @@ export function Button<T extends GroupTag = typeof DEFAULT_TAG>({
         return theme.warning;
       case 'danger':
         return theme.danger;
+      case 'inverted':
+        return theme.gray0;
       case 'standard':
         return theme.raisedSurfaceColor;
       case 'subtle':
@@ -329,6 +342,7 @@ export function Button<T extends GroupTag = typeof DEFAULT_TAG>({
 
   return (
     <Tag
+      data-theme={currentTheme}
       style={{
         ...style,
         '--amino-button-background-color': getBackgroundColor(),

--- a/src/components/button/__stories__/Button.stories.tsx
+++ b/src/components/button/__stories__/Button.stories.tsx
@@ -96,11 +96,11 @@ const ButtonRow = ({
         Anchor tag Button
       </Button>
       <Button
+        {...props}
         disabled={disabled}
         loading={loading}
         themeOverride="night"
         variant={variant}
-        {...props}
       >
         Night
       </Button>
@@ -246,6 +246,12 @@ export const PlainButton = Template.bind({});
 PlainButton.args = {
   children: 'Plain button',
   variant: 'plain',
+};
+
+export const InvertedButton = Template.bind({});
+InvertedButton.args = {
+  children: 'Inverted button',
+  variant: 'inverted',
 };
 
 export const InlineLinkButtonStory: StoryFn<ButtonProps> = () => (

--- a/src/types/Variant.ts
+++ b/src/types/Variant.ts
@@ -1,6 +1,7 @@
 export type Variant =
   | 'danger'
   | 'inlineLink'
+  | 'inverted'
   | 'link'
   | 'plain'
   | 'primary'


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR adds a new button variant of `Inverted` which basically inverts the default button by changing the theme with a fixed `gray0` background color. It also fixes the `themeOverride` prop as it wasn't working properly on the story.

## Todo

- [x] Bump version and add tag
