### PR TITLE
Fix: Final button fix for themes and inverted variant

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.3.11",
+  "version": "5.3.12",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/button/Button.module.scss
+++ b/src/components/button/Button.module.scss
@@ -214,7 +214,7 @@ $text-button-disabled-color: var(--amino-button-text-button-disabled-color);
     }
   }
 
-  &.standardButton, &.invertedButton {
+  &.standardButton {
     box-shadow: theme.$amino-shadow-button-standard;
 
     &:not([disabled]) {
@@ -243,6 +243,27 @@ $text-button-disabled-color: var(--amino-button-text-button-disabled-color);
           background: theme.$amino-gray-200;
         }
       }
+    }
+  }
+
+  &.invertedButton {
+    background: theme.$amino-gray-1000;
+    color: theme.$amino-gray-0;
+    box-shadow: theme.$amino-shadow-button-standard;
+
+    &:not([disabled]) {
+      &:active {
+        background: theme.$amino-gray-100;
+      }
+      &:focus {
+        box-shadow: theme.$amino-focus-button;
+      }
+    }
+    &[disabled] {
+      box-shadow: theme.$amino-shadow-button-disabled;
+    }
+    & .spinnerWrapper {
+      background: theme.$amino-gray-1000;
     }
   }
 

--- a/src/components/button/Button.module.scss
+++ b/src/components/button/Button.module.scss
@@ -252,8 +252,11 @@ $text-button-disabled-color: var(--amino-button-text-button-disabled-color);
     box-shadow: theme.$amino-shadow-button-standard;
 
     &:not([disabled]) {
+      &:hover {
+        background: theme.$amino-gray-900;
+      }
       &:active {
-        background: theme.$amino-gray-100;
+        background: theme.$amino-gray-600;
       }
       &:focus {
         box-shadow: theme.$amino-focus-button;

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -21,7 +21,6 @@ import type { Size } from 'src/types/Size';
 import type { Theme } from 'src/types/Theme';
 import type { Variant } from 'src/types/Variant';
 import { getAminoColor } from 'src/utils/getAminoColor';
-import { useAminoTheme } from 'src/utils/hooks/useAminoTheme';
 
 import styles from './Button.module.scss';
 
@@ -165,13 +164,6 @@ export function Button<T extends GroupTag = typeof DEFAULT_TAG>({
     ...getRippleHandlers(props),
   };
 
-  const { aminoTheme } = useAminoTheme({ override: themeOverride });
-  const invertedTheme = aminoTheme === 'day' ? 'night' : 'day';
-
-  const currentTheme =
-    themeOverride || (variant === 'inverted' && invertedTheme) || aminoTheme;
-  const isNightTheme = currentTheme === 'night';
-
   const getPadding = () => {
     switch (size) {
       case 'sm':
@@ -216,33 +208,23 @@ export function Button<T extends GroupTag = typeof DEFAULT_TAG>({
         if (outline) {
           return 'info';
         }
-        if (isNightTheme) {
-          return 'black';
-        }
         return 'white';
       case 'success':
         if (outline) {
           return 'success';
-        }
-        if (isNightTheme) {
-          return 'black';
         }
         return 'white';
       case 'warning':
         if (outline) {
           return 'warning';
         }
-        if (isNightTheme) {
-          return 'black';
-        }
         return 'white';
       case 'danger':
         if (outline) {
           return 'danger';
         }
-        if (isNightTheme) {
-          return 'black';
-        }
+        return 'white';
+      case 'inverted':
         return 'white';
       case 'link':
       case 'inlineLink':
@@ -251,7 +233,6 @@ export function Button<T extends GroupTag = typeof DEFAULT_TAG>({
       case 'subtle':
       case 'text':
       case 'standard':
-      case 'inverted':
       default:
         return 'black';
     }
@@ -266,6 +247,7 @@ export function Button<T extends GroupTag = typeof DEFAULT_TAG>({
       case 'success':
       case 'warning':
       case 'danger':
+      case 'inverted':
         return theme.gray0;
       case 'link':
       case 'inlineLink':
@@ -275,7 +257,6 @@ export function Button<T extends GroupTag = typeof DEFAULT_TAG>({
       case 'plain':
       case 'text':
       case 'standard':
-      case 'inverted':
       default:
         return theme.textColor;
     }
@@ -296,7 +277,6 @@ export function Button<T extends GroupTag = typeof DEFAULT_TAG>({
       case 'danger':
         return theme.buttonDangerHover;
       case 'standard':
-      case 'inverted':
         return theme.buttonStandardHover;
       case 'subtle':
         return theme.gray100;
@@ -304,6 +284,8 @@ export function Button<T extends GroupTag = typeof DEFAULT_TAG>({
         return theme.blue100;
       case 'text':
         return theme.gray500;
+      case 'inverted':
+        return theme.gray100;
       default:
         return '';
     }
@@ -336,7 +318,7 @@ export function Button<T extends GroupTag = typeof DEFAULT_TAG>({
 
   return (
     <Tag
-      data-theme={currentTheme}
+      data-theme={themeOverride}
       style={{
         ...style,
         '--amino-button-background-color': getBackgroundColor(),

--- a/src/components/spinner/Spinner.module.scss
+++ b/src/components/spinner/Spinner.module.scss
@@ -30,13 +30,15 @@ $width: var(--amino-spinner-width);
       stroke: theme.$amino-spinner-track-black;
     }
   }
-  &.white {
+  &.white,
+  &.inverted {
     stroke: theme.$amino-spinner-stroke-white;
 
     circle.track {
       stroke: theme.$amino-spinner-track-white;
     }
-
+  }
+  &.inverted {
     [data-theme='night'] & {
       stroke: theme.$amino-spinner-stroke-black;
 

--- a/src/components/spinner/Spinner.module.scss
+++ b/src/components/spinner/Spinner.module.scss
@@ -36,6 +36,14 @@ $width: var(--amino-spinner-width);
     circle.track {
       stroke: theme.$amino-spinner-track-white;
     }
+
+    [data-theme='night'] & {
+      stroke: theme.$amino-spinner-stroke-black;
+
+      circle.track {
+        stroke: theme.$amino-spinner-track-black;
+      }
+    }
   }
   &.info {
     stroke: theme.$amino-blue-600;

--- a/src/components/spinner/Spinner.module.scss.d.ts
+++ b/src/components/spinner/Spinner.module.scss.d.ts
@@ -2,6 +2,7 @@ export declare const black: string;
 export declare const danger: string;
 export declare const dash: string;
 export declare const info: string;
+export declare const inverted: string;
 export declare const rotate: string;
 export declare const styledSvg: string;
 export declare const success: string;

--- a/src/components/spinner/Spinner.tsx
+++ b/src/components/spinner/Spinner.tsx
@@ -10,6 +10,7 @@ export type SpinnerColor =
   | 'success'
   | 'danger'
   | 'warning'
+  | 'inverted'
   | 'black'
   | 'white';
 


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR officially fixes the button themes and variants. It also removes the use of the amino theme hook on the button and just uses CSS to transform the white spinners for the appropriate buttons. Screenshots of running zonos.com locally against the change.

I have learned that using the `useAminoTheme` hook within amino is something we should mostly steer away from because in instances like zonos.com we hard code the `data-theme` attribute to `night` which doesn't change what value `useAminoTheme` pulls from local storage.

<img width="296" alt="Screenshot 2024-08-28 at 3 28 51 PM" src="https://github.com/user-attachments/assets/b8b0ded6-2713-4d08-82ff-9693eb67baf1">
<img width="1397" alt="Screenshot 2024-08-28 at 3 28 33 PM" src="https://github.com/user-attachments/assets/7788bc56-acfa-488e-aa17-3df59aad3d49">
<img width="345" alt="Screenshot 2024-08-28 at 3 28 03 PM" src="https://github.com/user-attachments/assets/81033958-791a-440f-924f-0b87b02971ae">
<img width="1494" alt="Screenshot 2024-08-28 at 3 27 46 PM" src="https://github.com/user-attachments/assets/335524b9-9916-4559-8986-c35757859514">


## Todo

- [x] Bump version and add tag
