### PR TITLE
fix(table): add disabled link feature for certain columns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.3.14",
+  "version": "5.3.15",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/simple-table/SimpleTable.tsx
+++ b/src/components/simple-table/SimpleTable.tsx
@@ -30,6 +30,11 @@ type SimpleTableHeaderBaseProps = {
   align?: 'start' | 'center' | 'end';
   /**
    * @default false
+   * Disable link routing on cells
+   */
+  disabledLink?: boolean;
+  /**
+   * @default false
    * Disable padding on cells
    */
   noPadding?: boolean;
@@ -155,7 +160,7 @@ export const SimpleTable = <T extends object>({
     const value = item[header.key];
 
     const renderContent = (content: ReactNode) => {
-      if (getRowLink && !selectable.anySelected) {
+      if (getRowLink && !selectable.anySelected && !header.disabledLink) {
         const LinkComponent = CustomLinkComponent || 'a';
 
         return (

--- a/src/components/simple-table/__stories__/SimpleTable.stories.tsx
+++ b/src/components/simple-table/__stories__/SimpleTable.stories.tsx
@@ -29,6 +29,7 @@ export default meta;
 
 type DummyData = {
   age: number;
+  disabledText?: string;
   id: number;
   name: string;
   optionalField?: string;
@@ -38,6 +39,7 @@ type DummyData = {
 const items: DummyData[] = [
   {
     age: 24,
+    disabledText: 'Disabled link',
     id: 1,
     name: 'John',
     optionalField: 'optional',
@@ -45,18 +47,21 @@ const items: DummyData[] = [
   },
   {
     age: 25,
+    disabledText: 'Disabled link',
     id: 2,
     name: 'Jane',
     vegan: true,
   },
   {
     age: 26,
+    disabledText: 'Disabled link',
     id: 3,
     name: 'Joe',
     vegan: false,
   },
   {
     age: 27,
+    disabledText: 'Disabled link',
     id: 4,
     name: 'Joan',
     optionalField: 'idk',
@@ -64,12 +69,14 @@ const items: DummyData[] = [
   },
   {
     age: 28,
+    disabledText: 'Disabled link',
     id: 5,
     name: 'Jim',
     vegan: false,
   },
   {
     age: 26,
+    disabledText: 'Disabled link',
     id: 29,
     name: 'Cade',
     optionalField: 'optional',
@@ -88,7 +95,6 @@ const tableHeaders: SimpleTableHeader<DummyData>[] = [
     name: 'Age',
     width: 10,
   },
-
   {
     align: 'center',
     key: 'vegan',
@@ -102,6 +108,11 @@ const tableHeaders: SimpleTableHeader<DummyData>[] = [
         )}
       </div>
     ),
+  },
+  {
+    disabledLink: true,
+    key: 'disabledText',
+    name: 'Disabled Text',
   },
   {
     key: 'optionalField',


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->
https://linear.app/zonos/issue/ONB-667/frontend-add-copiable-order-numbers-in-order-search

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR adds a prop to simple table headers that disables link clicks for that specific column. My use case is for the order list page. Product wants the `accountOrderNumber` to have a copy ability. But copying triggers the Iink.

PREVIEW: https://amino-git-fix-table-zonos.vercel.app/?path=%2Fstory%2Famino-simpletable--with-link

## Todo

- [ ] Bump version and add tag
