### PR TITLE
fix: falsy storage values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/simple-table/SimpleTable.tsx
+++ b/src/components/simple-table/SimpleTable.tsx
@@ -293,12 +293,13 @@ export const SimpleTable = <T extends object>({
 
   return (
     <div
-      className={styles.tableContainer}
+      className={clsx(styles.tableContainer, className)}
       style={{
         maxHeight,
+        ...style,
       }}
     >
-      <table className={clsx(className, styles.tableStyled)} style={style}>
+      <table className={styles.tableStyled}>
         <colgroup>
           {!!selectable.onHeaderCheckboxChange && <col width={0} />}
           {headers.map(header => (

--- a/src/components/simple-table/__stories__/SimpleTable.stories.tsx
+++ b/src/components/simple-table/__stories__/SimpleTable.stories.tsx
@@ -301,10 +301,29 @@ export const Custom = () => {
     hoverField: null;
   };
 
-  const augmentedItems: AugmentedDummyData[] = items.map(item => ({
-    ...item,
-    hoverField: null,
-  }));
+  const augmentedItems: AugmentedDummyData[] = items
+    .flatMap(item => [
+      item,
+      {
+        ...item,
+        id: item.id + 100,
+        name: `${item.name} 2`,
+      },
+      {
+        ...item,
+        id: item.id + 200,
+        name: `${item.name} 3`,
+      },
+      {
+        ...item,
+        id: item.id + 300,
+        name: `${item.name} 4`,
+      },
+    ])
+    .map(item => ({
+      ...item,
+      hoverField: null,
+    }));
 
   const [selectedItemIds, setSelectedItemIds] = useState<number[]>([]);
 

--- a/src/utils/hooks/__tests__/useStorage.test.ts
+++ b/src/utils/hooks/__tests__/useStorage.test.ts
@@ -119,7 +119,7 @@ describe('useStorage', () => {
     expect(getCurrentValue()).toBe('apple');
   });
 
-  test('Should parse a boolean without a schema', () => {
+  test('Should parse a boolean', () => {
     const boolean = z.boolean();
 
     const { result } = renderHook(() =>
@@ -151,6 +151,40 @@ describe('useStorage', () => {
     });
 
     expect(getCurrentValue()).toBe(false);
+  });
+
+  test.only('Should parse a boolean with default value true', () => {
+    const boolean = z.boolean();
+
+    const { result } = renderHook(() =>
+      useStorage({
+        defaultValue: true,
+        key: 'boolean',
+        schema: boolean,
+        type: 'session',
+      }),
+    );
+
+    const getCurrentValue = () => result.current.value;
+
+    // Assert initial state
+    const { setValue, value: initialValue } = result.current;
+
+    expect(initialValue).toBe(true);
+
+    act(() => {
+      setValue(false);
+    });
+
+    // Assert the updated state
+    expect(getCurrentValue()).toBe(false);
+
+    // Manually mangle local storage
+    act(() => {
+      setValue('ooga-booga' as unknown as boolean);
+    });
+
+    expect(getCurrentValue()).toBe(true);
   });
 });
 

--- a/src/utils/hooks/__tests__/useStorage.test.ts
+++ b/src/utils/hooks/__tests__/useStorage.test.ts
@@ -153,7 +153,7 @@ describe('useStorage', () => {
     expect(getCurrentValue()).toBe(false);
   });
 
-  test.only('Should parse a boolean with default value true', () => {
+  test('Should parse a boolean with default value true', () => {
     const boolean = z.boolean();
 
     const { result } = renderHook(() =>

--- a/src/utils/hooks/useStorage.ts
+++ b/src/utils/hooks/useStorage.ts
@@ -71,7 +71,7 @@ export const useStorage = <
     () => JSON.stringify(defaultValue),
   );
 
-  const currentValue = getStorageItem<TValue>({ key, schema, type }) || null;
+  const currentValue = getStorageItem<TValue>({ key, schema, type }) ?? null;
 
   const setValue = useCallback(
     (value: TValue) => setStorageItem({ key, type, value }),
@@ -113,7 +113,7 @@ export const useStorageWithLifetime = <
 
   const currentValue = shouldUpdate
     ? null
-    : getStorageItem<TValue>({ key, schema, type }) || null;
+    : getStorageItem<TValue>({ key, schema, type }) ?? null;
 
   const setValue = useCallback(
     (value: TValue) =>


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR:
- allows falsy storage values
- `SimpleTable` moves CSS props to wrapper (I understand dashboard styles it in a few places and I will verify those)

## Todo

- [x] Bump version and add tag
