### PR TITLE
select label updates for md and sm

### DIFF
--- a/src/components/select/CountrySelect.tsx
+++ b/src/components/select/CountrySelect.tsx
@@ -24,7 +24,7 @@ export const CountrySelect = <T extends string>({
   filter = Boolean,
   label = 'Select country',
   onChange,
-  placeholder,
+  placeholder = 'Select country',
   value,
   ...props
 }: CountrySelectProps<T>) => {

--- a/src/components/select/_StyledReactSelect.module.scss
+++ b/src/components/select/_StyledReactSelect.module.scss
@@ -7,8 +7,8 @@ $color: var(--amino-styled-react-select-color);
   justify-content: space-evenly;
   align-items: center;
   color: theme.$amino-gray-700;
-  margin-left: var(--amino-space-8);
-  margin-right: -2px;
+  margin-left: 0px;
+  margin-right: 0px;
   height: 24px;
   width: 24px;
 }
@@ -19,11 +19,12 @@ $color: var(--amino-styled-react-select-color);
   font-size: theme.$amino-font-size-base;
   line-height: theme.$amino-font-size-base;
   transform-origin: left top;
-  left: 14px;
+  left: 12px;
   .hasIcon & {
     left: 44px;
   }
   top: calc(50% - theme.$amino-font-size-base / 2);
+
   .hasLabel & {
     & + div {
       align-self: flex-end;
@@ -37,32 +38,18 @@ $color: var(--amino-styled-react-select-color);
 
   // Size modify
 
-  // sm
-  .sm.hasLabel & {
-    & + div {
-      margin-bottom: -6px;
+  // Hide floating label for sm and md sizes
+  .sm,
+  .md {
+    .styledFloatedLabel {
+      display: none;
     }
-  }
-  .sm.hasValue &,
-  .sm.isFocused & {
-    top: 2px;
-  }
-
-  // md
-  .md.hasLabel & {
-    & + div {
-      margin-bottom: -2px;
-    }
-  }
-  .md.hasValue &,
-  .md.isFocused & {
-    top: 6px;
   }
 
   // lg
   .lg.hasValue &,
   .lg.isFocused & {
-    top: 10px;
+    top: 9px;
   }
 
   // xl
@@ -73,7 +60,7 @@ $color: var(--amino-styled-react-select-color);
   }
   .xl.hasValue &,
   .xl.isFocused & {
-    top: 11px;
+    top: 10px;
   }
 }
 

--- a/src/components/select/_StyledReactSelect.tsx
+++ b/src/components/select/_StyledReactSelect.tsx
@@ -101,6 +101,8 @@ const Control = <
     selectProps as (typeof props)['selectProps'] &
       AdditionalProps<Option['value']>;
 
+  const showLabel = size === 'lg' || size === 'xl';
+
   return (
     <div
       ref={innerRef}
@@ -110,9 +112,7 @@ const Control = <
         icon && styles.hasIcon,
         isFocused && styles.isFocused,
         isDisabled && styles.isDisabled,
-        label || (Array.isArray(value) && value.length > 1)
-          ? styles.hasLabel
-          : '',
+        showLabel && label ? styles.hasLabel : '',
         size && styles[size],
         styles.reactSelectControl,
         'react-select-control',
@@ -122,14 +122,16 @@ const Control = <
     >
       {icon && <div className={styles.iconWrapper}>{icon}</div>}
 
-      <div className={styles.styledFloatedLabel}>
-        {label}{' '}
-        {Array.isArray(value) && value.length > 1 && (
-          <strong className={styles.strongLabel}>
-            ({value.length} selected)
-          </strong>
-        )}
-      </div>
+      {showLabel && label && (
+        <div className={styles.styledFloatedLabel}>
+          {label}{' '}
+          {Array.isArray(value) && value.length > 1 && (
+            <strong className={styles.strongLabel}>
+              ({value.length} selected)
+            </strong>
+          )}
+        </div>
+      )}
       {children}
     </div>
   );
@@ -258,8 +260,8 @@ const localStyles: StylesConfig<
   clearIndicator: provided => ({
     ...provided,
     color: theme.gray700,
-    paddingLeft: 14,
-    paddingRight: 4,
+    paddingLeft: 0,
+    paddingRight: 0,
   }),
   // container
   control: (provided, state) => {
@@ -277,15 +279,17 @@ const localStyles: StylesConfig<
       color: theme.gray800,
       cursor: 'pointer',
       flexWrap: 'inherit',
+      gap: 8,
       height: `var(--amino-size-${size})`,
       minHeight: `var(--amino-size-${size})`,
+      padding: '0 8px',
     };
   },
   dropdownIndicator: provided => ({
     ...provided,
     color: theme.gray900,
     paddingLeft: 4,
-    paddingRight: 10,
+    paddingRight: 0,
   }),
   group: provided => ({
     ...provided,
@@ -298,7 +302,11 @@ const localStyles: StylesConfig<
   input: provided => ({
     ...provided,
     color: theme.textColor,
-    opacity: 0.8,
+    fontSize: theme.fontSizeBase,
+    fontWeight: 500,
+    marginLeft: 0,
+    marginRight: 0,
+    paddingLeft: 4,
   }),
   // loadingIndicator
   // loadingMessage
@@ -344,25 +352,42 @@ const localStyles: StylesConfig<
     paddingRight: 12,
     paddingTop: 7,
   }),
-  placeholder: provided => ({
-    ...provided,
-    '.has-label.is-focused &': {
-      opacity: 1,
-    },
-    opacity: 0,
-  }),
+  placeholder: (provided, state) => {
+    const { size } = state.selectProps as (typeof state)['selectProps'] &
+      AdditionalProps<SelectOption['value']>;
+    return {
+      ...provided,
+      color: theme.textColorSecondary,
+      fontSize: theme.fontSizeBase,
+      marginLeft: 0,
+      marginRight: 0,
+      opacity: size === 'lg' || size === 'xl' ? 0 : 1,
+      paddingLeft: 4,
+      paddingRight: 4,
+    };
+  },
   singleValue: provided => ({
     ...provided,
     color: theme.textColor,
+    fontSize: theme.fontSizeBase,
     fontWeight: 500,
+    marginLeft: 0,
+    marginRight: 0,
+    paddingLeft: 4,
+    paddingRight: 4,
   }),
-  valueContainer: provided => ({
-    ...provided,
-    '.has-icon &': { paddingLeft: 0 },
-    flexWrap: 'nowrap',
-    padding: 'unset',
-    paddingLeft: 12,
-  }),
+  valueContainer: (provided, state) => {
+    const { size } = state.selectProps as (typeof state)['selectProps'] &
+      AdditionalProps<SelectOption['value']>;
+    return {
+      ...provided,
+      '.has-icon &': { paddingLeft: 0 },
+      flexWrap: 'nowrap',
+      padding: 'unset',
+      paddingBottom: size === 'lg' || size === 'xl' ? 2 : 0,
+      width: '100%',
+    };
+  },
 };
 
 export type StyledReactSelectProps<

--- a/src/components/select/__stories__/Select.stories.tsx
+++ b/src/components/select/__stories__/Select.stories.tsx
@@ -69,8 +69,9 @@ const currencyOptions = [
 
 export const BasicSelect: StoryObj<SelectProps> = {
   args: {
-    label: 'Currencies',
+    label: 'Currency',
     options: currencyOptions,
+    placeholder: 'Select currency',
     value: {
       label: 'US Dollar (USD)',
       value: 'USD',
@@ -83,8 +84,9 @@ export const BasicSelectWithIcon: StoryObj<SelectProps> = {
     error: true,
     helpText: 'This input is required',
     icon: <FileIcon size={24} />,
-    label: 'Currencies',
+    label: 'Currency',
     options: currencyOptions,
+    placeholder: 'Select a currency',
     value: {
       label: 'US Dollar (USD)',
       value: 'USD',
@@ -95,7 +97,7 @@ export const BasicSelectWithIcon: StoryObj<SelectProps> = {
 export const BasicSelectWithOptionIcon: StoryObj<SelectProps> = {
   args: {
     icon: <FlagIcon code="AE" iconScale="medium" />,
-    label: 'Currencies',
+    label: 'Currency',
     options: [
       {
         icon: <FlagIcon code="AE" iconScale="small" />,
@@ -113,6 +115,7 @@ export const BasicSelectWithOptionIcon: StoryObj<SelectProps> = {
         value: 'EUR',
       },
     ],
+    placeholder: 'Select currency',
     value: {
       label: 'US Dollar (USD)',
       value: 'USD',
@@ -151,6 +154,7 @@ export const Customized: StoryObj<SelectProps> = {
         value: 'EUR',
       },
     ],
+    placeholder: 'Select currency',
     value: [
       {
         icon: <FileIcon size={24} />,
@@ -235,12 +239,14 @@ export const ScrollableDialogSelect = () => {
             label="Close on scroll"
             onChange={setValue}
             options={currencyOptions}
+            placeholder="Select currency"
             value={value}
           />
           <Select
             label="Normal"
             onChange={setValue}
             options={currencyOptions}
+            placeholder="Select currency"
             value={value}
           />
         </VStack>


### PR DESCRIPTION
## Description

-Hides the floating label on small and medium sized selects.

-Reveals and styles the placeholder and input text on the small and medium sizes

-Other styling updates to match the design sizing and spacing.

## Note

This might break some instances in Dashboard that use the small and medium size selects and don't have placeholder text or manual labels above the selects. 

Labels and create order are the 2 main ones to check but there will be more. 


## Todo

- [ ] Bump version and add tag
