### PR TITLE
FIX: Simple table styling and truncate text

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.4.8",
+  "version": "5.4.9",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/simple-table/SimpleTable.module.scss
+++ b/src/components/simple-table/SimpleTable.module.scss
@@ -2,7 +2,6 @@
 
 .tableContainer {
   width: 100%;
-  overflow: auto;
 }
 
 .tableStyled {
@@ -54,14 +53,15 @@
         border-bottom: theme.$amino-border-subtle;
         padding: 12px;
 
-        max-width: 0;        
+        max-width: 0;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
 
         &.noTruncate {
-          max-width: unset;
+          max-width: 100%;
           white-space: unset;
+          overflow: unset;
         }
 
         &.noPadding {

--- a/src/components/simple-table/SimpleTable.module.scss
+++ b/src/components/simple-table/SimpleTable.module.scss
@@ -54,6 +54,16 @@
         border-bottom: theme.$amino-border-subtle;
         padding: 12px;
 
+        max-width: 0;        
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+
+        &.noTruncate {
+          max-width: unset;
+          white-space: unset;
+        }
+
         &.noPadding {
           padding: 0;
         }

--- a/src/components/simple-table/SimpleTable.module.scss.d.ts
+++ b/src/components/simple-table/SimpleTable.module.scss.d.ts
@@ -2,6 +2,7 @@ export declare const cellLink: string;
 export declare const clickable: string;
 export declare const loading: string;
 export declare const noPadding: string;
+export declare const noTruncate: string;
 export declare const skeletonCellWrapper: string;
 export declare const styledCheckbox: string;
 export declare const tableContainer: string;

--- a/src/components/simple-table/SimpleTable.tsx
+++ b/src/components/simple-table/SimpleTable.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, Fragment } from 'react';
+import React, { type ReactNode, Fragment } from 'react';
 
 import clsx from 'clsx';
 
@@ -171,13 +171,27 @@ export const SimpleTable = <T extends object>({
     const value = item[header.key];
 
     const renderContent = (content: ReactNode) => {
+      // We want to truncate all cells except for the ones that have a row-hover-show child
+      const hasRowHoverShowChild = React.Children.toArray(content).some(
+        child => {
+          if (React.isValidElement(child)) {
+            return /row-hover-show|cell-hover-show/.test(child.props.className);
+          }
+          return false;
+        },
+      );
+
       if (getRowLink && !selectable.anySelected && !header.disabledLink) {
         const LinkComponent = CustomLinkComponent || 'a';
 
         return (
           <td className={styles.cellLink}>
             <LinkComponent
-              className={clsx(header.noPadding && styles.noPadding)}
+              className={clsx(
+                header.noPadding && styles.noPadding,
+                (header.disableTruncate || hasRowHoverShowChild) &&
+                  styles.noTruncate,
+              )}
               href={getRowLink(item)}
               style={{
                 textAlign: header.align || 'start',
@@ -193,7 +207,8 @@ export const SimpleTable = <T extends object>({
         <td
           className={clsx(
             header.noPadding && styles.noPadding,
-            header.disableTruncate && styles.noTruncate,
+            (header.disableTruncate || hasRowHoverShowChild) &&
+              styles.noTruncate,
           )}
           style={{
             textAlign: header.align || 'start',

--- a/src/components/simple-table/SimpleTable.tsx
+++ b/src/components/simple-table/SimpleTable.tsx
@@ -171,7 +171,7 @@ export const SimpleTable = <T extends object>({
     const value = item[header.key];
 
     const renderContent = (content: ReactNode) => {
-      // We want to truncate all cells except for the ones that have a row-hover-show child
+      // We want to truncate all cells except for the ones that have a row-hover-show child or disableTruncate
       const hasRowHoverShowChild = React.Children.toArray(content).some(
         child => {
           if (React.isValidElement(child)) {

--- a/src/components/simple-table/SimpleTable.tsx
+++ b/src/components/simple-table/SimpleTable.tsx
@@ -29,6 +29,11 @@ type SimpleTableHeaderBaseProps = {
    */
   align?: 'start' | 'center' | 'end';
   /**
+   * Disable truncating cell content
+   * @default false
+   */
+  disableTruncate?: boolean;
+  /**
    * @default false
    * Disable link routing on cells
    */
@@ -186,7 +191,10 @@ export const SimpleTable = <T extends object>({
 
       return (
         <td
-          className={clsx(header.noPadding && styles.noPadding)}
+          className={clsx(
+            header.noPadding && styles.noPadding,
+            header.disableTruncate && styles.noTruncate,
+          )}
           style={{
             textAlign: header.align || 'start',
           }}

--- a/src/components/simple-table/__stories__/SimpleTable.stories.tsx
+++ b/src/components/simple-table/__stories__/SimpleTable.stories.tsx
@@ -371,7 +371,6 @@ export const Custom = () => {
       dropdownOptions={{
         placement: 'bottom-end',
       }}
-      noCloseOnMouseLeave
     >
       <Menu>
         <MenuItem

--- a/src/components/simple-table/__stories__/SimpleTable.stories.tsx
+++ b/src/components/simple-table/__stories__/SimpleTable.stories.tsx
@@ -29,10 +29,11 @@ export default meta;
 
 type DummyData = {
   age: number;
-  disabledText?: string;
+  disabledText: string;
   id: number;
   name: string;
   optionalField?: string;
+  truncateText?: string;
   vegan: boolean;
 };
 
@@ -297,9 +298,14 @@ export const Loading = () => {
 };
 
 export const Custom = () => {
+  const [disableTruncate, setDisableTruncate] = useState(false);
   type AugmentedDummyData = DummyData & {
     hoverField: null;
+    truncateText?: string;
   };
+
+  const truncateText =
+    'This is a long string that should be truncated. '.repeat(5);
 
   const augmentedItems: AugmentedDummyData[] = items
     .flatMap(item => [
@@ -308,16 +314,19 @@ export const Custom = () => {
         ...item,
         id: item.id + 100,
         name: `${item.name} 2`,
+        truncateText,
       },
       {
         ...item,
         id: item.id + 200,
         name: `${item.name} 3`,
+        truncateText,
       },
       {
         ...item,
         id: item.id + 300,
         name: `${item.name} 4`,
+        truncateText,
       },
     ])
     .map(item => ({
@@ -385,6 +394,18 @@ export const Custom = () => {
 
   const augmentedHeaders: SimpleTableHeader<AugmentedDummyData>[] = [
     ...tableHeaders,
+    {
+      disableTruncate,
+      key: 'truncateText',
+      name: (
+        <Checkbox
+          checked={disableTruncate}
+          label="Disable truncate"
+          onChange={setDisableTruncate}
+        />
+      ),
+      width: 30,
+    },
     {
       key: 'hoverField',
       name: null,

--- a/src/components/simple-table/__stories__/SimpleTable.stories.tsx
+++ b/src/components/simple-table/__stories__/SimpleTable.stories.tsx
@@ -7,6 +7,7 @@ import type { Meta, StoryFn } from '@storybook/react';
 import { Button } from 'src/components/button/Button';
 import { MenuButton } from 'src/components/button/MenuButton';
 import { Checkbox } from 'src/components/checkbox/Checkbox';
+import { Divider } from 'src/components/divider/Divider';
 import { Menu } from 'src/components/menu/Menu';
 import { MenuItem } from 'src/components/menu/MenuItem';
 import {
@@ -299,6 +300,8 @@ export const Loading = () => {
 
 export const Custom = () => {
   const [disableTruncate, setDisableTruncate] = useState(false);
+  const [viewOneRow, setViewOneRow] = useState(false);
+
   type AugmentedDummyData = DummyData & {
     hoverField: null;
     truncateText?: string;
@@ -334,6 +337,10 @@ export const Custom = () => {
       hoverField: null,
     }));
 
+  const displayedItems = viewOneRow
+    ? augmentedItems.slice(0, 1)
+    : augmentedItems;
+
   const [selectedItemIds, setSelectedItemIds] = useState<number[]>([]);
 
   const nonCadeItems = items.filter(item => item.name !== 'Cade');
@@ -364,6 +371,7 @@ export const Custom = () => {
       dropdownOptions={{
         placement: 'bottom-end',
       }}
+      noCloseOnMouseLeave
     >
       <Menu>
         <MenuItem
@@ -407,9 +415,9 @@ export const Custom = () => {
       width: 30,
     },
     {
+      align: 'end',
       key: 'hoverField',
-      name: null,
-      noPadding: true,
+      name: '',
       renderCustom: (_, item) => (
         <div className="row-hover-show">
           <HoverMenu item={item} />
@@ -419,22 +427,32 @@ export const Custom = () => {
   ];
 
   return (
-    <SimpleTable
-      headers={augmentedHeaders}
-      items={augmentedItems}
-      keyExtractor={item => String(item.id)}
-      onRowClick={item => {
-        alert(`Clicked ${item.name}`);
-      }}
-      selectable={{
-        anySelected: selectedItemIds.length > 0,
-        enabled: true,
-        headerCheckboxValue: checkboxAllValue,
-        isRowCheckboxDisabled: item => item.name === 'Cade',
-        isRowChecked: item => selectedItemIds.includes(item.id),
-        onHeaderCheckboxChange: handleCheckboxAllChange,
-        onRowCheckboxChange: handleCheckboxRowChange,
-      }}
-    />
+    <>
+      <Checkbox
+        checked={viewOneRow}
+        label="View one row"
+        onChange={setViewOneRow}
+      />
+
+      <Divider />
+
+      <SimpleTable
+        headers={augmentedHeaders}
+        items={displayedItems}
+        keyExtractor={item => String(item.id)}
+        onRowClick={item => {
+          alert(`Clicked ${item.name}`);
+        }}
+        selectable={{
+          anySelected: selectedItemIds.length > 0,
+          enabled: true,
+          headerCheckboxValue: checkboxAllValue,
+          isRowCheckboxDisabled: item => item.name === 'Cade',
+          isRowChecked: item => selectedItemIds.includes(item.id),
+          onHeaderCheckboxChange: handleCheckboxAllChange,
+          onRowCheckboxChange: handleCheckboxRowChange,
+        }}
+      />
+    </>
   );
 };


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->

## Preview

https://amino-git-fix-components-zonos.vercel.app/?path=/story/amino-simpletable--custom

1. Click the `Disable truncate` checkbox
2. Click the `View one row` checkbox and then click the menu to see it's no longer cut off. 

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR makes table cells truncate by default with the option to to disable truncating by column. It will just truncate at the percentage width specified in the header columns.

It also removes `overflow: auto` from the table wrapper. I didn't see any repercussions, but maybe I missed something.

## Todo

- [ ] Bump version and add tag
