### PR TITLE
FIX: Simple table min width in pixels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.4.10",
+  "version": "5.4.11",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/simple-table/SimpleTable.tsx
+++ b/src/components/simple-table/SimpleTable.tsx
@@ -344,11 +344,12 @@ export const SimpleTable = <T extends object>({
           {headers.map(header => (
             <col
               key={header.key}
-              width={
-                header.minWidth !== undefined
-                  ? `${header.minWidth}px`
-                  : undefined
-              }
+              style={{
+                minWidth:
+                  header.minWidth !== undefined
+                    ? `${header.minWidth}px`
+                    : undefined,
+              }}
             />
           ))}
         </colgroup>

--- a/src/components/simple-table/SimpleTable.tsx
+++ b/src/components/simple-table/SimpleTable.tsx
@@ -35,6 +35,11 @@ type SimpleTableHeaderBaseProps = {
    */
   disabledLink?: boolean;
   /**
+   * @default 0
+   * Minimum width of column in pixels
+   */
+  minWidth?: number;
+  /**
    * @default false
    * Disable padding on cells
    */
@@ -44,11 +49,6 @@ type SimpleTableHeaderBaseProps = {
    * @default 'nowrap'
    */
   textWrapMethod?: 'truncate' | 'normal' | 'nowrap';
-  /**
-   * Minimum width of column in percent
-   * @default undefined
-   */
-  width?: number;
 };
 
 export type SimpleTableHeader<T extends object> = {
@@ -345,7 +345,9 @@ export const SimpleTable = <T extends object>({
             <col
               key={header.key}
               width={
-                header.width !== undefined ? `${header.width}%` : undefined
+                header.minWidth !== undefined
+                  ? `${header.minWidth}px`
+                  : undefined
               }
             />
           ))}

--- a/src/components/simple-table/__stories__/SimpleTable.stories.tsx
+++ b/src/components/simple-table/__stories__/SimpleTable.stories.tsx
@@ -35,6 +35,7 @@ type DummyData = {
   name: string;
   optionalField?: string;
   truncateText?: string;
+  truncateText2?: string;
   vegan: boolean;
 };
 
@@ -105,7 +106,6 @@ const tableHeaders: SimpleTableHeader<DummyData>[] = [
     align: 'end',
     key: 'age',
     name: 'Age',
-    width: 10,
   },
   {
     align: 'center',
@@ -123,7 +123,14 @@ const tableHeaders: SimpleTableHeader<DummyData>[] = [
   },
   {
     key: 'truncateText',
-    name: 'Truncate Text',
+    minWidth: 300,
+    name: 'Truncate Text (min 300px)',
+    textWrapMethod: 'truncate',
+  },
+  {
+    key: 'truncateText2',
+    name: 'Truncate Text 2',
+    renderCustom: (_, item) => item.truncateText,
     textWrapMethod: 'truncate',
   },
   {

--- a/src/components/simple-table/__stories__/SimpleTable.stories.tsx
+++ b/src/components/simple-table/__stories__/SimpleTable.stories.tsx
@@ -123,8 +123,8 @@ const tableHeaders: SimpleTableHeader<DummyData>[] = [
   },
   {
     key: 'truncateText',
-    minWidth: 300,
-    name: 'Truncate Text (min 300px)',
+    minWidth: 150,
+    name: 'Truncate Text (min 150px)',
     textWrapMethod: 'truncate',
   },
   {


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR changes the min width to be in pixels rather than percentage. Now that we are more commonly truncating, percentage min width doesn't work. Min width in pixels will allow us to truncate up to a certain point so it's not too small.

PREVIEW: 

## Todo

- [ ] Bump version and add tag
