### PR TITLE
fix(simpleTable): use width percentage and min width in pixels together

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.4.11",
+  "version": "5.4.12",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/simple-table/SimpleTable.module.scss
+++ b/src/components/simple-table/SimpleTable.module.scss
@@ -1,5 +1,7 @@
 @use 'theme';
 
+$cellMinWidth: var(--amino-cell-min-width);
+
 .tableContainer {
   width: 100%;
 }
@@ -85,7 +87,8 @@
         }
 
         &.shouldTruncate {
-          max-width: 0;
+          max-width: $cellMinWidth;
+          min-width: $cellMinWidth;
           > :first-child {
             // Truncating the first child will cover most cases.
             // For custom rendered cells, these 3 properties may need to be apply to deeply nested children on a per need basis.

--- a/src/components/simple-table/SimpleTable.tsx
+++ b/src/components/simple-table/SimpleTable.tsx
@@ -23,6 +23,20 @@ const getFlexAlignment = (alignment: SimpleTableHeaderBaseProps['align']) => {
   }
 };
 
+const getTooltipPlacement = (
+  alignment: SimpleTableHeaderBaseProps['align'],
+) => {
+  switch (alignment) {
+    case 'center':
+      return 'bottom';
+    case 'end':
+      return 'bottom-end';
+    case 'start':
+    default:
+      return 'bottom-start';
+  }
+};
+
 type SimpleTableHeaderBaseProps = {
   /**
    * Text alignment for a column
@@ -49,6 +63,11 @@ type SimpleTableHeaderBaseProps = {
    * @default 'nowrap'
    */
   textWrapMethod?: 'truncate' | 'normal' | 'nowrap';
+  /**
+   * Width of column in percent
+   * @default undefined
+   */
+  width?: number;
 };
 
 export type SimpleTableHeader<T extends object> = {
@@ -188,6 +207,10 @@ export const SimpleTable = <T extends object>({
           styles.shouldTruncate,
       );
 
+      const containerStyle = {
+        '--amino-cell-min-width': `${header.minWidth || 0}px`,
+      };
+
       const cellClassNames = clsx(
         header.noPadding && styles.noPadding,
         header.textWrapMethod === 'normal' && styles.allowTextWrap,
@@ -197,13 +220,16 @@ export const SimpleTable = <T extends object>({
         textAlign: header.align || 'start',
       };
 
+      const tooltipPlacement = getTooltipPlacement(header.align);
+
       if (getRowLink && !selectable.anySelected && !header.disabledLink) {
         const LinkComponent = CustomLinkComponent || 'a';
 
         return (
-          <td className={tdClassNames}>
+          <td className={tdClassNames} style={containerStyle}>
             <Tooltip
               disabled={header.textWrapMethod !== 'truncate'}
+              placement={tooltipPlacement}
               subtitle={content}
             >
               <LinkComponent
@@ -219,7 +245,7 @@ export const SimpleTable = <T extends object>({
       }
 
       return (
-        <td className={tdClassNames}>
+        <td className={tdClassNames} style={containerStyle}>
           <Tooltip
             disabled={header.textWrapMethod !== 'truncate'}
             subtitle={content}
@@ -350,6 +376,9 @@ export const SimpleTable = <T extends object>({
                     ? `${header.minWidth}px`
                     : undefined,
               }}
+              width={
+                header.width !== undefined ? `${header.width}%` : undefined
+              }
             />
           ))}
         </colgroup>

--- a/src/components/simple-table/__stories__/SimpleTable.stories.tsx
+++ b/src/components/simple-table/__stories__/SimpleTable.stories.tsx
@@ -101,6 +101,7 @@ const tableHeaders: SimpleTableHeader<DummyData>[] = [
   {
     key: 'name',
     name: 'Name',
+    width: 1,
   },
   {
     align: 'end',


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR restores width percentage to work in tandem with min width in pixels. Also adds alignment of the tooltip to not just be center all the time.

## Todo

- [x] Bump version and add tag
