### PR TITLE
FIX: Simple table tooltip hover

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.4.15",
+  "version": "5.4.16",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/simple-table/SimpleTable.tsx
+++ b/src/components/simple-table/SimpleTable.tsx
@@ -230,8 +230,9 @@ export const SimpleTable = <T extends object>({
         return (
           <td className={tdClassNames} style={containerStyle}>
             <Tooltip
-              delay={tooltipDelay}
               disabled={header.textWrapMethod !== 'truncate'}
+              enterDelay={tooltipDelay}
+              enterNextDelay={tooltipDelay}
               placement={tooltipPlacement}
               subtitle={content}
             >
@@ -250,8 +251,9 @@ export const SimpleTable = <T extends object>({
       return (
         <td className={tdClassNames} style={containerStyle}>
           <Tooltip
-            delay={tooltipDelay}
             disabled={header.textWrapMethod !== 'truncate'}
+            enterDelay={tooltipDelay}
+            enterNextDelay={tooltipDelay}
             placement={tooltipPlacement}
             subtitle={content}
           >

--- a/src/components/simple-table/SimpleTable.tsx
+++ b/src/components/simple-table/SimpleTable.tsx
@@ -37,6 +37,8 @@ const getTooltipPlacement = (
   }
 };
 
+const tooltipDelay = 800;
+
 type SimpleTableHeaderBaseProps = {
   /**
    * Text alignment for a column
@@ -228,6 +230,7 @@ export const SimpleTable = <T extends object>({
         return (
           <td className={tdClassNames} style={containerStyle}>
             <Tooltip
+              delay={tooltipDelay}
               disabled={header.textWrapMethod !== 'truncate'}
               placement={tooltipPlacement}
               subtitle={content}
@@ -247,7 +250,9 @@ export const SimpleTable = <T extends object>({
       return (
         <td className={tdClassNames} style={containerStyle}>
           <Tooltip
+            delay={tooltipDelay}
             disabled={header.textWrapMethod !== 'truncate'}
+            placement={tooltipPlacement}
             subtitle={content}
           >
             {/* Child div required for proper truncating */}

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -19,6 +19,11 @@ export type TooltipProps = BaseProps & {
    */
   children: ReactNode;
   /**
+   * The delay in milliseconds before showing the tooltip.
+   * @default 0
+   */
+  delay?: number;
+  /**
    * Whether the tooltip should be shown.
    *
    * Leave as undefined to remain uncontrolled.
@@ -45,7 +50,6 @@ export type TooltipProps = BaseProps & {
    */
   title?: ReactNode;
 } & Partial<Omit<MuiTooltipProps, 'children'>>;
-
 const StyledTooltip = muiStyled(
   ({
     className,
@@ -59,14 +63,12 @@ const StyledTooltip = muiStyled(
         {
           ...props.PopperProps,
           'data-theme': dataTheme,
-          // PopperProps by default, would not allow the data-theme attribute to be passed
         } as PopperProps
       }
     />
   ),
 )(() => ({
   [`& .${tooltipClasses.tooltip}`]: {
-    // Reset MUI styles
     all: 'revert',
     backgroundColor: theme.gray0,
     borderRadius: theme.radius10,
@@ -84,6 +86,7 @@ const StyledTooltip = muiStyled(
 export const Tooltip = ({
   children,
   className,
+  delay = 0,
   disabled = false,
   open,
   subtitle,
@@ -112,6 +115,8 @@ export const Tooltip = ({
         {...rest}
         className={className}
         dataTheme={themeOverride}
+        enterDelay={delay}
+        enterNextDelay={delay}
         open={open}
         title={renderTooltip()}
       >

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -19,11 +19,6 @@ export type TooltipProps = BaseProps & {
    */
   children: ReactNode;
   /**
-   * The delay in milliseconds before showing the tooltip.
-   * @default 0
-   */
-  delay?: number;
-  /**
    * Whether the tooltip should be shown.
    *
    * Leave as undefined to remain uncontrolled.
@@ -86,7 +81,6 @@ const StyledTooltip = muiStyled(
 export const Tooltip = ({
   children,
   className,
-  delay = 0,
   disabled = false,
   open,
   subtitle,
@@ -115,8 +109,6 @@ export const Tooltip = ({
         {...rest}
         className={className}
         dataTheme={themeOverride}
-        enterDelay={delay}
-        enterNextDelay={delay}
         open={open}
         title={renderTooltip()}
       >

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -45,6 +45,7 @@ export type TooltipProps = BaseProps & {
    */
   title?: ReactNode;
 } & Partial<Omit<MuiTooltipProps, 'children'>>;
+
 const StyledTooltip = muiStyled(
   ({
     className,
@@ -58,12 +59,14 @@ const StyledTooltip = muiStyled(
         {
           ...props.PopperProps,
           'data-theme': dataTheme,
+          // PopperProps by default, would not allow the data-theme attribute to be passed
         } as PopperProps
       }
     />
   ),
 )(() => ({
   [`& .${tooltipClasses.tooltip}`]: {
+    // Reset MUI styles
     all: 'revert',
     backgroundColor: theme.gray0,
     borderRadius: theme.radius10,


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR sets table tooltip hover delays to 800 miliseconds. I want to get it to hide tooltips if the text isn't actually being truncated, but will attempt that at a future date since there's not an easy way to do that.

## Todo

- [x] Bump version and add tag
