### PR TITLE
FIX: Inline button link line height

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.4.16",
+  "version": "5.4.17",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/button/Button.module.scss
+++ b/src/components/button/Button.module.scss
@@ -405,6 +405,8 @@ $text-button-disabled-color: var(--amino-button-text-button-disabled-color);
     padding: 0;
     display: inline-flex;
     color: theme.$amino-blue-600;
+    line-height: inherit;
+
     &:not([disabled]) {
       &:hover,
       &:active {


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR makes the `inlineLink` button inherit line height from the parent rather than the classic button line height. (32px down to 24px)

NOW: https://amino-git-fix-components-zonos.vercel.app/?path=/story/amino-button--inline-link-button-story&vercelToolbarCode=cZdcr2nqTdrXBZA

PREVIOUS: https://amino.zonos.com/?path=%2Fstory%2Famino-button--inline-link-button-story

## Todo

- [x] Bump version and add tag
