### PR TITLE
FEAT: persisting toasts

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test_setup:
     name: Test setup
-    runs-on: macos-14
+    runs-on: macos-latest
     outputs:
       preview_url: ${{ steps.waitForVercelPreviewDeployment.outputs.url }}
     steps:
@@ -23,7 +23,7 @@ jobs:
   test_e2e:
     needs: test_setup
     timeout-minutes: 60
-    runs-on: macos-14
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test_setup:
     name: Test setup
-    runs-on: macos-12
+    runs-on: macos-14
     outputs:
       preview_url: ${{ steps.waitForVercelPreviewDeployment.outputs.url }}
     steps:
@@ -23,7 +23,7 @@ jobs:
   test_e2e:
     needs: test_setup
     timeout-minutes: 60
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ snapshots
 _private_*
 
 !.vscode
+.cursorignore

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.4.18",
+  "version": "5.4.19",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.4.19",
+  "version": "5.4.18",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/flex/Flex.tsx
+++ b/src/components/flex/Flex.tsx
@@ -66,8 +66,10 @@ export const Flex = ({
   justifyContent = 'flex-start',
   padding = 0,
   style,
+  ...rest
 }: FlexProps) => (
   <div
+    {...rest}
     className={clsx(
       className,
       styles.flexWrapper,

--- a/src/components/flex/Flex.tsx
+++ b/src/components/flex/Flex.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties, ReactNode } from 'react';
+import type { CSSProperties, HTMLAttributes, ReactNode } from 'react';
 
 import clsx from 'clsx';
 
@@ -6,51 +6,52 @@ import type { BaseProps } from 'src/types/BaseProps';
 
 import styles from './Flex.module.scss';
 
-export type FlexProps = BaseProps & {
-  /**
-   * @default 'stretch'
-   */
-  alignItems?: CSSProperties['alignItems'];
-  children: ReactNode;
-  /**
-   * @default 'initial'
-   * @description This is a shorthand for flex-grow, flex-shrink, and flex-basis.
-   */
-  childrenFlex?:
-    | 'auto'
-    | '1 0'
-    | '0 1'
-    | 'initial'
-    | 'inherit'
-    | 'unset'
-    // Combine with never to make sure string doesn't override the union
-    | (string & { _?: never });
-  /**
-   * @default 'row'
-   */
-  flexDirection?: CSSProperties['flexDirection'];
-  flexWrap?: CSSProperties['flexWrap'];
-  /**
-   * @default false
-   */
-  fullHeight?: boolean;
-  /**
-   * @default false
-   */
-  fullWidth?: boolean;
-  /**
-   * @default 8
-   */
-  gap?: number;
-  /**
-   * @default 'flex-start'
-   */
-  justifyContent?: CSSProperties['justifyContent'];
-  /**
-   * @default 0
-   */
-  padding?: number;
-};
+export type FlexProps = BaseProps &
+  HTMLAttributes<HTMLDivElement> & {
+    /**
+     * @default 'stretch'
+     */
+    alignItems?: CSSProperties['alignItems'];
+    children: ReactNode;
+    /**
+     * @default 'initial'
+     * @description This is a shorthand for flex-grow, flex-shrink, and flex-basis.
+     */
+    childrenFlex?:
+      | 'auto'
+      | '1 0'
+      | '0 1'
+      | 'initial'
+      | 'inherit'
+      | 'unset'
+      // Combine with never to make sure string doesn't override the union
+      | (string & { _?: never });
+    /**
+     * @default 'row'
+     */
+    flexDirection?: CSSProperties['flexDirection'];
+    flexWrap?: CSSProperties['flexWrap'];
+    /**
+     * @default false
+     */
+    fullHeight?: boolean;
+    /**
+     * @default false
+     */
+    fullWidth?: boolean;
+    /**
+     * @default 8
+     */
+    gap?: number;
+    /**
+     * @default 'flex-start'
+     */
+    justifyContent?: CSSProperties['justifyContent'];
+    /**
+     * @default 0
+     */
+    padding?: number;
+  };
 
 export const Flex = ({
   alignItems = 'stretch',

--- a/src/components/toast/Toast.module.scss
+++ b/src/components/toast/Toast.module.scss
@@ -17,6 +17,15 @@
   gap: 12px;
   font-weight: 500;
   user-select: none;
+  flex: 1;
+
+  &.persistentToast {
+    cursor: pointer;
+
+    &:hover {
+      transform: scale(0.95);
+    }
+  }
 
   & svg {
     color: theme.$amino-gray-500;

--- a/src/components/toast/Toast.module.scss
+++ b/src/components/toast/Toast.module.scss
@@ -12,9 +12,6 @@
   color: theme.$amino-gray-0;
   box-shadow: theme.$amino-v3-shadow-large;
   padding: 16px;
-  display: flex;
-  align-items: center;
-  gap: 12px;
   font-weight: 500;
   user-select: none;
   flex: 1;

--- a/src/components/toast/Toast.module.scss
+++ b/src/components/toast/Toast.module.scss
@@ -24,6 +24,10 @@
     }
   }
 
+  .dismissButton {
+    height: 24px;
+  }
+
   & svg {
     color: theme.$amino-gray-500;
   }

--- a/src/components/toast/Toast.module.scss.d.ts
+++ b/src/components/toast/Toast.module.scss.d.ts
@@ -3,4 +3,5 @@ export declare const aminoInfoToast: string;
 export declare const aminoSuccessToast: string;
 export declare const aminoToast: string;
 export declare const aminoWarningToast: string;
+export declare const dismissButton: string;
 export declare const persistentToast: string;

--- a/src/components/toast/Toast.module.scss.d.ts
+++ b/src/components/toast/Toast.module.scss.d.ts
@@ -3,3 +3,4 @@ export declare const aminoInfoToast: string;
 export declare const aminoSuccessToast: string;
 export declare const aminoToast: string;
 export declare const aminoWarningToast: string;
+export declare const persistentToast: string;

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -123,9 +123,10 @@ export const Toast = ({
 
           {isPersistent && (
             <Button
-              icon={<RemoveIcon size={28} />}
+              icon={<RemoveIcon />}
               onClick={e => onDismiss?.(e)}
               variant="plain"
+              className={styles.dismissButton}
             />
           )}
         </Flex>

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -123,10 +123,10 @@ export const Toast = ({
 
           {isPersistent && (
             <Button
+              className={styles.dismissButton}
               icon={<RemoveIcon />}
               onClick={e => onDismiss?.(e)}
               variant="plain"
-              className={styles.dismissButton}
             />
           )}
         </Flex>

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -3,9 +3,12 @@ import type { ReactNode } from 'react';
 import clsx from 'clsx';
 import { motion } from 'framer-motion';
 
+import { Button } from 'src/components/button/Button';
+import { Flex } from 'src/components/flex/Flex';
 import { CheckCircleIcon } from 'src/icons/CheckCircleIcon';
 import { InfoIcon } from 'src/icons/InfoIcon';
 import { RemoveCircleIcon } from 'src/icons/RemoveCircleIcon';
+import { RemoveIcon } from 'src/icons/RemoveIcon';
 import { WarningIcon } from 'src/icons/WarningIcon';
 import type { Intent } from 'src/types';
 import type { BaseProps } from 'src/types/BaseProps';
@@ -15,6 +18,7 @@ import styles from './Toast.module.scss';
 export type Direction = 'top' | 'right' | 'bottom' | 'left';
 
 export type ToastProps = BaseProps & {
+  actions?: ReactNode;
   children: ReactNode;
   direction?: Direction;
   /** Dismiss delay (default 6000 ms) */
@@ -23,13 +27,17 @@ export type ToastProps = BaseProps & {
   /** If true, toast will be shown in the persistent stack */
   isPersistent?: boolean;
   toastKey: string;
+  /** Only used for persistent toasts */
+  onDismiss?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 };
 
 export const Toast = ({
+  actions,
   children,
   direction,
   intent,
   isPersistent,
+  onDismiss,
   style,
   toastKey,
 }: ToastProps) => {
@@ -104,8 +112,24 @@ export const Toast = ({
       {...baseProps}
       key={toastKey}
     >
-      {intentValues.icon}
-      {children}
+      <Flex alignItems="flex-start" gap={12} justifyContent="space-between">
+        <Flex gap={12}>
+          <div>{intentValues.icon}</div>
+          <div>{children}</div>
+        </Flex>
+
+        <Flex alignItems="flex-start" gap={12}>
+          {actions}
+
+          {isPersistent && (
+            <Button
+              icon={<RemoveIcon size={28} />}
+              onClick={e => onDismiss?.(e)}
+              variant="plain"
+            />
+          )}
+        </Flex>
+      </Flex>
     </motion.div>
   );
 };

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -20,6 +20,8 @@ export type ToastProps = BaseProps & {
   /** Dismiss delay (default 6000 ms) */
   duration?: number;
   intent?: Extract<Intent, 'success' | 'warning' | 'error' | 'info'>;
+  /** If true, toast will be shown in the persistent stack */
+  isPersistent?: boolean;
   toastKey: string;
 };
 
@@ -27,6 +29,7 @@ export const Toast = ({
   children,
   direction,
   intent,
+  isPersistent,
   style,
   toastKey,
 }: ToastProps) => {
@@ -89,9 +92,15 @@ export const Toast = ({
 
   return (
     <motion.div
-      className={clsx(styles.aminoToast, intentValues.class)}
+      className={clsx(
+        styles.aminoToast,
+        intentValues.class,
+        isPersistent && styles.persistentToast,
+      )}
       layout
-      style={style}
+      style={{
+        ...style,
+      }}
       {...baseProps}
       key={toastKey}
     >

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -118,7 +118,7 @@ export const Toast = ({
           <div>{children}</div>
         </Flex>
 
-        <Flex alignItems="flex-start" gap={12}>
+        <Flex alignItems="flex-start" className="toast-actions" gap={12}>
           {actions}
 
           {isPersistent && (

--- a/src/components/toast/ToastContext.module.scss
+++ b/src/components/toast/ToastContext.module.scss
@@ -1,12 +1,77 @@
 $bottom: var(--amino-toast-context-bottom);
 $left: var(--amino-toast-context-left);
-
-.toastsWrapper {
+$persistentHeight: var(--amino-toast-persistent-height);
+.toastContainer {
   bottom: $bottom;
   left: $left;
+}
 
+.toastsWrapper {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 24px;
+  gap: 16px;
+}
+
+.persistentToastsWrapper {
+  z-index: 1000;
+  height: $persistentHeight;
+  max-width: 400px;
+  width: 100%;
+  margin: 0 auto;
+  position: relative;
+
+  // Add hover effect for persistent toasts
+  &:hover {
+    cursor: pointer;
+  }
+
+  .clearAllButton {
+    margin-left: auto;
+  }
+
+  &.expanded {
+    position: relative;
+    width: 100%;
+
+    .clearAllButton{
+      margin-bottom: -8px;
+    }
+  }
+
+  .persistentToast {
+    width: 100%;
+  }
+
+  &:not(.expanded) {
+    .persistentToast {
+      position: absolute;
+      bottom: 16px;
+      z-index: 8;
+      scale: 0.5;
+      opacity: 0;
+      filter: brightness(2);
+      transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+
+      &:nth-of-type(1) {
+        bottom: 0;
+        z-index: 10;
+        scale: 1;
+        opacity: 1;
+        filter: brightness(1);
+      }
+      &:nth-of-type(2) {
+        bottom: 8px;
+        z-index: 9;
+        scale: 0.9;
+        opacity: 1;
+        filter: brightness(1.5);
+      }
+      &:nth-of-type(3) {
+        scale: 0.8;
+        opacity: 0.8;
+        filter: brightness(2);
+      }
+    }
+  }
 }

--- a/src/components/toast/ToastContext.module.scss
+++ b/src/components/toast/ToastContext.module.scss
@@ -58,12 +58,19 @@ $persistentHeight: var(--amino-toast-persistent-height);
 
   .persistentToast {
     width: 100%;
+    z-index: 8;
+
+    &:nth-of-type(1) {
+      z-index: 10;
+    }
+    &:nth-of-type(2) {
+      z-index: 9;
+    }
   }
 
   &:not(.expanded) {
     .persistentToast {
       position: absolute;
-      z-index: 8;
       scale: 0.5;
       opacity: 0;
       filter: brightness(2);
@@ -72,14 +79,12 @@ $persistentHeight: var(--amino-toast-persistent-height);
 
       &:nth-of-type(1) {
         bottom: 0;
-        z-index: 10;
         scale: 1;
         opacity: 1;
         filter: brightness(1);
       }
       &:nth-of-type(2) {
         bottom: -8px;
-        z-index: 9;
         scale: 0.9;
         opacity: 1;
         filter: brightness(1.5);

--- a/src/components/toast/ToastContext.module.scss
+++ b/src/components/toast/ToastContext.module.scss
@@ -41,8 +41,7 @@ $persistentHeight: var(--amino-toast-persistent-height);
 
   .clearAllButton {
     margin-left: auto;
-    // Black with 6% opacity
-    background-color: #00000011;
+    background-color: rgba(0, 0, 0, 0.06);
     border-radius: theme.$amino-radius-4;
     backdrop-filter: blur(5px);
   }

--- a/src/components/toast/ToastContext.module.scss
+++ b/src/components/toast/ToastContext.module.scss
@@ -3,10 +3,15 @@
 $bottom: var(--amino-toast-context-bottom);
 $left: var(--amino-toast-context-left);
 $persistentHeight: var(--amino-toast-persistent-height);
-
 .toastContainer {
   bottom: $bottom;
   left: $left;
+  display: flex;
+  justify-content: flex-end;
+  flex-direction: column;
+  position: fixed;
+  z-index: 9999999;
+  width: 100%;
 }
 
 .toastsWrapper {
@@ -16,13 +21,18 @@ $persistentHeight: var(--amino-toast-persistent-height);
   gap: 16px;
 }
 
+.regularToastsWrapper {
+  margin-bottom: 16px;
+}
+
 .persistentToastsWrapper {
   z-index: 1000;
-  height: $persistentHeight;
-  max-width: 400px;
+  max-width: 600px;
   width: 100%;
   margin: 0 auto;
   position: relative;
+  max-height: 60vh;
+  min-height: $persistentHeight;
 
   // Add hover effect for persistent toasts
   &:hover {
@@ -58,6 +68,7 @@ $persistentHeight: var(--amino-toast-persistent-height);
       opacity: 0;
       filter: brightness(2);
       transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+      transform-origin: bottom center;
 
       &:nth-of-type(1) {
         bottom: 0;

--- a/src/components/toast/ToastContext.module.scss
+++ b/src/components/toast/ToastContext.module.scss
@@ -1,6 +1,9 @@
+@use 'theme';
+
 $bottom: var(--amino-toast-context-bottom);
 $left: var(--amino-toast-context-left);
 $persistentHeight: var(--amino-toast-persistent-height);
+
 .toastContainer {
   bottom: $bottom;
   left: $left;
@@ -28,13 +31,17 @@ $persistentHeight: var(--amino-toast-persistent-height);
 
   .clearAllButton {
     margin-left: auto;
+    // Black with 6% opacity
+    background-color: #00000011;
+    border-radius: theme.$amino-radius-4;
+    backdrop-filter: blur(5px);
   }
 
   &.expanded {
     position: relative;
     width: 100%;
 
-    .clearAllButton{
+    .clearAllButton {
       margin-bottom: -8px;
     }
   }
@@ -46,7 +53,6 @@ $persistentHeight: var(--amino-toast-persistent-height);
   &:not(.expanded) {
     .persistentToast {
       position: absolute;
-      bottom: 16px;
       z-index: 8;
       scale: 0.5;
       opacity: 0;
@@ -61,7 +67,7 @@ $persistentHeight: var(--amino-toast-persistent-height);
         filter: brightness(1);
       }
       &:nth-of-type(2) {
-        bottom: 8px;
+        bottom: -8px;
         z-index: 9;
         scale: 0.9;
         opacity: 1;
@@ -70,6 +76,7 @@ $persistentHeight: var(--amino-toast-persistent-height);
       &:nth-of-type(3) {
         scale: 0.8;
         opacity: 0.8;
+        bottom: -16px;
         filter: brightness(2);
       }
     }

--- a/src/components/toast/ToastContext.module.scss.d.ts
+++ b/src/components/toast/ToastContext.module.scss.d.ts
@@ -1,1 +1,6 @@
+export declare const clearAllButton: string;
+export declare const expanded: string;
+export declare const persistentToast: string;
+export declare const persistentToastsWrapper: string;
+export declare const toastContainer: string;
 export declare const toastsWrapper: string;

--- a/src/components/toast/ToastContext.module.scss.d.ts
+++ b/src/components/toast/ToastContext.module.scss.d.ts
@@ -2,5 +2,6 @@ export declare const clearAllButton: string;
 export declare const expanded: string;
 export declare const persistentToast: string;
 export declare const persistentToastsWrapper: string;
+export declare const regularToastsWrapper: string;
 export declare const toastContainer: string;
 export declare const toastsWrapper: string;

--- a/src/components/toast/ToastContext.tsx
+++ b/src/components/toast/ToastContext.tsx
@@ -1,9 +1,11 @@
 import { type ReactNode, createContext, useCallback, useState } from 'react';
 
+import { CloseIcon } from '@graphiql/react';
 import clsx from 'clsx';
 import { AnimatePresence } from 'framer-motion';
 import { v4 as uuidv4 } from 'uuid';
 
+import { Button } from 'src/components/button/Button';
 import { Flex } from 'src/components/flex/Flex';
 import { type ToastProps, Toast } from 'src/components/toast/Toast';
 
@@ -16,6 +18,7 @@ export type ToastContextFunctionType = (
   location?: { bottom?: string; left?: string },
 ) => void;
 type ToastType = {
+  isPersistent?: boolean;
   props?: Parameters<ToastContextFunctionType>[1];
   toast: Parameters<ToastContextFunctionType>[0];
   uuid: string;
@@ -37,6 +40,9 @@ type Props = {
 
 export const ToastContextProvider = ({ children }: Props) => {
   const [toasts, setToasts] = useState<ToastType[]>([]);
+  const [persistentToasts, setPersistentToasts] = useState<ToastType[]>([]);
+  const [expandedToasts, setExpandedToasts] = useState(false);
+
   const [toastLocation, setToastLocation] = useState<{
     bottom: string;
     left: string;
@@ -47,18 +53,22 @@ export const ToastContextProvider = ({ children }: Props) => {
 
   const addToast = useCallback<ToastContextFunctionType>(
     (toast, props) => {
-      setToasts(t => [
-        ...t,
-        {
-          props,
-          toast,
-          uuid: uuidv4(),
-        },
-      ]);
-      // Each toast has a default lifetime of 6 seconds
-      setTimeout(() => setToasts(t => t.slice(1)), props?.duration || 6000);
+      const newToast = {
+        isPersistent: props?.isPersistent,
+        props,
+        toast,
+        uuid: uuidv4(),
+      };
+
+      if (props?.isPersistent) {
+        setPersistentToasts(t => [newToast, ...t]);
+      } else {
+        setToasts(t => [...t, newToast]);
+        // Only set timeout for non-persistent toasts
+        setTimeout(() => setToasts(t => t.slice(1)), props?.duration || 6000);
+      }
     },
-    [setToasts],
+    [setToasts, setPersistentToasts],
   );
 
   const setupToasts = useCallback<ToastContextFunctionType>(
@@ -74,16 +84,31 @@ export const ToastContextProvider = ({ children }: Props) => {
     [addToast],
   );
 
+  const dismissPersistentToast = useCallback((toastId: string) => {
+    setPersistentToasts(current => current.filter(t => t.uuid !== toastId));
+  }, []);
+
+  const dismissClicked = useCallback(
+    (e: React.MouseEvent, toastId: string) => {
+      e.stopPropagation();
+      dismissPersistentToast(toastId);
+    },
+    [dismissPersistentToast],
+  );
+
   return (
     <ToastContext.Provider value={setupToasts}>
       {children}
       <div
-        className="toast-container"
+        className={clsx('toast-container', styles.toastContainer)}
         style={{
           '--amino-toast-context-bottom': toastLocation.bottom || '40px',
           '--amino-toast-context-left': toastLocation.left || 'auto',
+          '--amino-toast-persistent-height':
+            persistentToasts.length > 0 && !expandedToasts ? '102px' : 'unset',
         }}
       >
+        {/* Non-persistent toasts */}
         <div className={clsx(styles.toastsWrapper, 'toasts-wrapper')}>
           <AnimatePresence>
             {toasts.map(({ props, toast, uuid }) => {
@@ -98,6 +123,68 @@ export const ToastContextProvider = ({ children }: Props) => {
                     {toast}
                   </Toast>
                 </Flex>
+              );
+            })}
+          </AnimatePresence>
+        </div>
+
+        {/* Persistent toasts */}
+        <div
+          className={clsx(
+            styles.toastsWrapper,
+            styles.persistentToastsWrapper,
+            expandedToasts && styles.expanded,
+            'toasts-wrapper',
+          )}
+        >
+          {!!persistentToasts.length && (
+            <Button
+              className={styles.clearAllButton}
+              icon={<CloseIcon />}
+              onClick={() => setPersistentToasts([])}
+              variant="text"
+            >
+              Clear all
+            </Button>
+          )}
+          <AnimatePresence>
+            {persistentToasts.map(({ props, toast, uuid }) => {
+              const key = `persistent-toast-${toast}-${uuid}`;
+              return (
+                <div
+                  key={key}
+                  className={styles.persistentToast}
+                  onClick={() => setExpandedToasts(!expandedToasts)}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      setExpandedToasts(!expandedToasts);
+                    }
+                  }}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <Flex fullWidth>
+                    <Toast
+                      direction={props?.direction}
+                      intent={props?.intent}
+                      isPersistent
+                      toastKey={key}
+                    >
+                      <Flex
+                        alignItems="center"
+                        fullWidth
+                        justifyContent="space-between"
+                      >
+                        <div>{toast}</div>
+                        <Button
+                          icon={<CloseIcon />}
+                          onClick={e => dismissClicked(e, uuid)}
+                          variant="plain"
+                        />
+                      </Flex>
+                    </Toast>
+                  </Flex>
+                </div>
               );
             })}
           </AnimatePresence>

--- a/src/components/toast/ToastContext.tsx
+++ b/src/components/toast/ToastContext.tsx
@@ -201,7 +201,7 @@ export const ToastContextProvider = ({ children }: Props) => {
                       toastKey={key}
                       {...props}
                     >
-                      {toast}
+                      {index === 0 || expandedToasts ? toast : ''}
                     </Toast>
                   </Flex>
                 </div>

--- a/src/components/toast/ToastContext.tsx
+++ b/src/components/toast/ToastContext.tsx
@@ -91,22 +91,26 @@ export const ToastContextProvider = ({ children }: Props) => {
     [addToast],
   );
 
-  const dismissPersistentToast = useCallback((toastId: string) => {
+  const dismissPersistentToast = (toastId: string) => {
     setPersistentToasts(current => current.filter(t => t.uuid !== toastId));
-  }, []);
+  };
 
-  const dismissClicked = useCallback(
-    (e: React.MouseEvent, toastId: string) => {
-      e.stopPropagation();
-      dismissPersistentToast(toastId);
-    },
-    [dismissPersistentToast],
-  );
+  const dismissClicked = (e: React.MouseEvent, toastId: string) => {
+    e.stopPropagation();
+    dismissPersistentToast(toastId);
+  };
 
-  const clearAllClicked = useCallback(() => {
+  const clearAllClicked = () => {
     setPersistentToasts([]);
     setExpandedToasts(false);
-  }, [setPersistentToasts, setExpandedToasts]);
+  };
+
+  const toggleExpanded = (e: React.MouseEvent | React.KeyboardEvent) => {
+    const actionsElement = e.currentTarget.querySelector('.toast-actions');
+    if (actionsElement && !actionsElement.contains(e.target as Node)) {
+      setExpandedToasts(prev => !prev);
+    }
+  };
 
   const firstToastRef = useRef<HTMLDivElement>(null);
   const [firstToastHeight, setFirstToastHeight] = useState(0);
@@ -123,7 +127,7 @@ export const ToastContextProvider = ({ children }: Props) => {
     <ToastContext.Provider value={setupToasts}>
       {children}
       <div
-        className={clsx('toast-container', styles.toastContainer)}
+        className={styles.toastContainer}
         style={{
           '--amino-toast-context-bottom': toastLocation.bottom || '40px',
           '--amino-toast-context-left': toastLocation.left || 'auto',
@@ -161,7 +165,6 @@ export const ToastContextProvider = ({ children }: Props) => {
             styles.toastsWrapper,
             styles.persistentToastsWrapper,
             expandedToasts && styles.expanded,
-            'toasts-wrapper',
           )}
         >
           {!!persistentToasts.length && (
@@ -182,10 +185,10 @@ export const ToastContextProvider = ({ children }: Props) => {
                   key={key}
                   ref={index === 0 ? firstToastRef : null} // Only ref the first toast
                   className={styles.persistentToast}
-                  onClick={() => setExpandedToasts(!expandedToasts)}
+                  onClick={toggleExpanded}
                   onKeyDown={e => {
                     if (e.key === 'Enter' || e.key === ' ') {
-                      setExpandedToasts(!expandedToasts);
+                      toggleExpanded(e);
                     }
                   }}
                   role="button"

--- a/src/components/toast/__stories__/ToastConsumer.tsx
+++ b/src/components/toast/__stories__/ToastConsumer.tsx
@@ -59,10 +59,17 @@ export const ToastConsumer = () => {
         </Button>
         <Button
           onClick={() =>
+            notify('Short persisting', { duration, isPersistent: true })
+          }
+        >
+          Short persisting
+        </Button>
+        <Button
+          onClick={() =>
             notify(
               <>
                 {
-                  'Some vague error happened: Error: Field "userProfl" does not exist on type "Query". Did you mean "userProfile"? [Location: line 3, column 5]. To learn more,'
+                  'Long persisting example: Error: Field "userProfl" does not exist on type "Query". Did you mean "userProfile"? [Location: line 3, column 5]. To learn more,'
                 }{' '}
                 <a href="https://www.google.com">Click here</a>
               </>,
@@ -78,7 +85,7 @@ export const ToastConsumer = () => {
             )
           }
         >
-          Add Persistent Toast
+          Long persisting
         </Button>
         <div className={styles.customWrapper}>
           <textarea

--- a/src/components/toast/__stories__/ToastConsumer.tsx
+++ b/src/components/toast/__stories__/ToastConsumer.tsx
@@ -57,6 +57,17 @@ export const ToastConsumer = () => {
         >
           Information
         </Button>
+        <Button
+          onClick={() =>
+            notify('Persistent toast', {
+              duration: Infinity,
+              intent: 'error',
+              isPersistent: true,
+            })
+          }
+        >
+          Add Persistent Toast
+        </Button>
         <div className={styles.customWrapper}>
           <textarea
             cols={30}

--- a/src/components/toast/__stories__/ToastConsumer.tsx
+++ b/src/components/toast/__stories__/ToastConsumer.tsx
@@ -59,11 +59,23 @@ export const ToastConsumer = () => {
         </Button>
         <Button
           onClick={() =>
-            notify('Persistent toast', {
-              duration: Infinity,
-              intent: 'error',
-              isPersistent: true,
-            })
+            notify(
+              <>
+                {
+                  'Some vague error happened: Error: Field "userProfl" does not exist on type "Query". Did you mean "userProfile"? [Location: line 3, column 5]. To learn more,'
+                }{' '}
+                <a href="https://www.google.com">Click here</a>
+              </>,
+              {
+                actions: (
+                  <Button outline variant="danger">
+                    Request support
+                  </Button>
+                ),
+                intent: 'error',
+                isPersistent: true,
+              },
+            )
           }
         >
           Add Persistent Toast

--- a/src/components/toast/__stories__/ToastConsumer.tsx
+++ b/src/components/toast/__stories__/ToastConsumer.tsx
@@ -67,12 +67,9 @@ export const ToastConsumer = () => {
         <Button
           onClick={() =>
             notify(
-              <>
-                {
-                  'Long persisting example: Error: Field "userProfl" does not exist on type "Query". Did you mean "userProfile"? [Location: line 3, column 5]. To learn more,'
-                }{' '}
-                <a href="https://www.google.com">Click here</a>
-              </>,
+              `Long persisting example: Error: Field "userProfl" does not exist
+                on type "Query". Did you mean "userProfile"? [Location: line 3,
+                column 5].`,
               {
                 actions: (
                   <Button outline variant="danger">

--- a/src/styles/amino.css
+++ b/src/styles/amino.css
@@ -180,9 +180,10 @@ h6 {
 .toast-container {
   display: flex;
   justify-content: center;
-}
-.toasts-wrapper {
+  flex-direction: column;
   position: fixed;
+  left: 0;
+  right: 0;
   z-index: 9999999;
   bottom: var(--amino-space-40);
 }

--- a/src/styles/amino.css
+++ b/src/styles/amino.css
@@ -176,14 +176,3 @@ h6 {
 .no-scroll {
   overflow: hidden;
 }
-
-.toast-container {
-  display: flex;
-  justify-content: center;
-  flex-direction: column;
-  position: fixed;
-  left: 0;
-  right: 0;
-  z-index: 9999999;
-  bottom: var(--amino-space-40);
-}


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->

## Preview

https://amino-git-fix-components-zonos.vercel.app/?path=%2Fdocs%2Famino-toast--docs&vercelToolbarCode=Gl4S6TvQK-wtTjA

Click to show persistent and non-persistent toasts to see how they work. Clear one at a time or clear all.

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR adds a new type of persisting toasts that layer over the top of one another. In dashboard, we will make a proxy the `useNotify` hook to make all error notifications be persisting toasts for a subset of users to implement error support requests. The persistent toast stack can be cleared with a "clear all" button.

The regular toasts that do not persist, will stack on top and disappear as they have been.

## Todo

- [ ] Bump version and add tag
