### PR TITLE
refactor: improve input date type sm size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.4.17",
+  "version": "5.4.18",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/input/input-type/_FloatLabelInput.module.scss
+++ b/src/components/input/input-type/_FloatLabelInput.module.scss
@@ -7,6 +7,7 @@ $height: var(--amino-float-label-input-height);
   position: relative;
   display: flex;
   flex-direction: row;
+  align-items: center;
   width: 100%;
   background: theme.$amino-input-background;
   border-radius: $border-radius;
@@ -182,7 +183,7 @@ $height: var(--amino-float-label-input-height);
       }
 
       &:global(.has-content),
-      :focus-within {
+      &:focus-within {
         .floatingLabel span {
           top: 2px;
         }
@@ -202,7 +203,7 @@ $height: var(--amino-float-label-input-height);
       }
 
       &:global(.has-content),
-      :focus-within {
+      &:focus-within {
         .floatingLabel span {
           top: 6px;
         }
@@ -221,7 +222,7 @@ $height: var(--amino-float-label-input-height);
       }
 
       &:global(.has-content),
-      :focus-within {
+      &:focus-within {
         .floatingLabel span {
           top: 6px;
         }


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->
[TS-1545: Improve date input small size focus state](https://linear.app/zonos/issue/TS-1545/improve-date-input-small-size-focus-state)

## Preview
Click on the second input
Before:
https://amino.zonos.com/?path=/story/amino-input--date-input&args=size:sm
<img width="1192" alt="image" src="https://github.com/user-attachments/assets/d32e0e99-fb4d-4702-bda8-c6ecd78bcaac">


After: 
https://amino-git-refactor-improve-date-input-sm-size-zonos.vercel.app/?path=/story/amino-input--date-input&args=size:sm
<img width="1198" alt="image" src="https://github.com/user-attachments/assets/1d3876c8-b417-4641-88f6-ca1ba57a6386">


## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

Resolved TS-1545
This PR fixes css for small input on focus state

## Todo

- [ ] Bump version and add tag
