### PR TITLE
fix(button): link override color

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.4.19",
+  "version": "5.4.20",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/button/Button.module.scss
+++ b/src/components/button/Button.module.scss
@@ -382,7 +382,6 @@ $text-button-disabled-color: var(--amino-button-text-button-disabled-color);
   }
 
   &.linkButton {
-    color: theme.$amino-blue-600;
     &:not([disabled]) {
       &:active {
         background: theme.$amino-blue-100;
@@ -404,7 +403,6 @@ $text-button-disabled-color: var(--amino-button-text-button-disabled-color);
   &.inlineLinkButton {
     padding: 0;
     display: inline-flex;
-    color: theme.$amino-blue-600;
     line-height: inherit;
 
     &:not([disabled]) {

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -251,7 +251,7 @@ export function Button<T extends GroupTag = typeof DEFAULT_TAG>({
         return theme.gray0;
       case 'link':
       case 'inlineLink':
-        return theme.primary;
+        return theme.blue600;
       case 'subtle':
         return theme.textColorSecondary;
       case 'plain':

--- a/src/components/button/__stories__/Button.stories.tsx
+++ b/src/components/button/__stories__/Button.stories.tsx
@@ -66,6 +66,7 @@ const ButtonRow = ({
       <Button
         /*  eslint-disable-next-line react/no-children-prop */
         children=""
+        color={props.color}
         disabled={disabled}
         icon={<CubeIcon size={24} />}
         loading={loading}
@@ -75,6 +76,7 @@ const ButtonRow = ({
         variant={variant}
       />
       <Button
+        color={props.color}
         disabled={disabled}
         loading={loading}
         onClick={e => e.preventDefault()}
@@ -85,6 +87,7 @@ const ButtonRow = ({
         Div Button
       </Button>
       <Button
+        color={props.color}
         disabled={disabled}
         href="#"
         loading={loading}
@@ -154,8 +157,8 @@ const ButtonRow = ({
 const Template: StoryFn<ButtonProps> = props => (
   <div className={styles.vWrapper}>
     <ButtonRow {...props} label="Default" />
-    <ButtonRow {...props} disabled label="Disabled" />
-    <ButtonRow {...props} label="Loading" loading />
+    {/* <ButtonRow {...props} disabled label="Disabled" />
+    <ButtonRow {...props} label="Loading" loading /> */}
   </div>
 );
 

--- a/src/components/button/__stories__/Button.stories.tsx
+++ b/src/components/button/__stories__/Button.stories.tsx
@@ -157,8 +157,8 @@ const ButtonRow = ({
 const Template: StoryFn<ButtonProps> = props => (
   <div className={styles.vWrapper}>
     <ButtonRow {...props} label="Default" />
-    {/* <ButtonRow {...props} disabled label="Disabled" />
-    <ButtonRow {...props} label="Loading" loading /> */}
+    <ButtonRow {...props} disabled label="Disabled" />
+    <ButtonRow {...props} label="Loading" loading />
   </div>
 );
 


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR fixes an issue with the `linkButton` where we no longer were allowing a color override. I didn't see any other issues from the [PR](https://github.com/Zonos/amino/pull/728) that introduced the issue.

## Todo

- [x] Bump version and add tag
