### PR TITLE
Feat/simple table collapsible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.4.21",
+  "version": "5.4.22",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@graphiql/plugin-explorer": "^0.3.1",
     "@graphiql/react": "^0.19.0",
     "@graphiql/toolkit": "^0.8.4",
-    "@playwright/test": "^1.40.1",
+    "@playwright/test": "^1.48",
     "@rollup/plugin-alias": "^5.1.0",
     "@rollup/plugin-buble": "^1.0.2",
     "@rollup/plugin-image": "^3.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,8 +92,8 @@ devDependencies:
     specifier: ^0.8.4
     version: 0.8.4(@types/node@20.4.2)(graphql-ws@4.5.0)(graphql@16.7.1)
   '@playwright/test':
-    specifier: ^1.40.1
-    version: 1.40.1
+    specifier: ^1.48
+    version: 1.48.2
   '@rollup/plugin-alias':
     specifier: ^5.1.0
     version: 5.1.0(rollup@3.29.5)
@@ -3605,12 +3605,12 @@ packages:
       tslib: 2.6.0
     dev: true
 
-  /@playwright/test@1.40.1:
-    resolution: {integrity: sha512-EaaawMTOeEItCRvfmkI9v6rBkF1svM8wjl/YPRrg2N2Wmp+4qJYkWtJsbew1szfKKDm6fPLy4YAanBhIlf9dWw==}
-    engines: {node: '>=16'}
+  /@playwright/test@1.48.2:
+    resolution: {integrity: sha512-54w1xCWfXuax7dz4W2M9uw0gDyh+ti/0K/MxcCUxChFh37kkdxPdfZDw5QBbuPUJHr1CiHJ1hXgSs+GgeQc5Zw==}
+    engines: {node: '>=18'}
     hasBin: true
     dependencies:
-      playwright: 1.40.1
+      playwright: 1.48.2
     dev: true
 
   /@popperjs/core@2.11.8:
@@ -9943,18 +9943,18 @@ packages:
       pathe: 1.1.1
     dev: true
 
-  /playwright-core@1.40.1:
-    resolution: {integrity: sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==}
-    engines: {node: '>=16'}
+  /playwright-core@1.48.2:
+    resolution: {integrity: sha512-sjjw+qrLFlriJo64du+EK0kJgZzoQPsabGF4lBvsid+3CNIZIYLgnMj9V6JY5VhM2Peh20DJWIVpVljLLnlawA==}
+    engines: {node: '>=18'}
     hasBin: true
     dev: true
 
-  /playwright@1.40.1:
-    resolution: {integrity: sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==}
-    engines: {node: '>=16'}
+  /playwright@1.48.2:
+    resolution: {integrity: sha512-NjYvYgp4BPmiwfe31j4gHLa3J7bD2WiBz8Lk2RoSsmX38SVIARZ18VYjxLjAcDsAhA+F4iSEXTSGgjua0rrlgQ==}
+    engines: {node: '>=18'}
     hasBin: true
     dependencies:
-      playwright-core: 1.40.1
+      playwright-core: 1.48.2
     optionalDependencies:
       fsevents: 2.3.2
     dev: true

--- a/src/components/simple-table/SimpleTable.module.scss
+++ b/src/components/simple-table/SimpleTable.module.scss
@@ -12,6 +12,42 @@ $cellMinWidth: var(--amino-cell-min-width);
   border-spacing: 0;
   font-size: theme.$amino-font-size-base;
 
+  &.noHeaders {
+    thead {
+      display: none;
+      max-height: 0;
+    }
+  }
+
+  &.bordered {
+    th {
+      border: none;
+    }
+    tr:first-child {
+      td {
+        border-top: theme.$amino-border-subtle;
+      }
+      td:first-child {
+        border-top-left-radius: 12px;
+      }
+    }
+    tr:first-child td:last-child {
+      border-top-right-radius: 12px;
+    }
+    tr:last-child td:first-child {
+      border-bottom-left-radius: 12px;
+    }
+    tr:last-child td:last-child {
+      border-bottom-right-radius: 12px;
+    }
+    td:first-child {
+      border-left: theme.$amino-border-subtle;
+    }
+    td:last-child {
+      border-right: theme.$amino-border-subtle;
+    }
+  }
+
   > thead {
     text-transform: none;
 
@@ -95,6 +131,35 @@ $cellMinWidth: var(--amino-cell-min-width);
             overflow: hidden;
             text-overflow: ellipsis;
           }
+        }
+      }
+    }
+  }
+
+  &.collapsible {
+    &.bordered {
+      tr:nth-last-child(2).collapsed td:first-child {
+        border-bottom-left-radius: 12px;
+      }
+      tr:nth-last-child(2).collapsed td:last-child {
+        border-bottom-right-radius: 12px;
+      }
+    }
+    > tbody {
+      * {
+        transition: theme.$amino-transition;
+      }
+      > tr {
+        height: unset;
+
+        &.collapsed {
+          + tr > td > :first-child {
+            padding: 0;
+          }
+        }
+
+        &:not(.collapsed) + tr {
+          border-bottom: theme.$amino-border-subtle;
         }
       }
     }

--- a/src/components/simple-table/SimpleTable.module.scss
+++ b/src/components/simple-table/SimpleTable.module.scss
@@ -152,14 +152,18 @@ $cellMinWidth: var(--amino-cell-min-width);
       > tr {
         height: unset;
 
+        &:not(.collapsed) {
+          td {
+            border-bottom: theme.$amino-border-subtle;
+          }
+        }
         &.collapsed {
+          & + tr > td {
+            border: 0;
+          }
           + tr > td > :first-child {
             padding: 0;
           }
-        }
-
-        &:not(.collapsed) + tr {
-          border-bottom: theme.$amino-border-subtle;
         }
       }
     }

--- a/src/components/simple-table/SimpleTable.module.scss.d.ts
+++ b/src/components/simple-table/SimpleTable.module.scss.d.ts
@@ -1,6 +1,10 @@
 export declare const allowTextWrap: string;
+export declare const bordered: string;
 export declare const clickable: string;
+export declare const collapsed: string;
+export declare const collapsible: string;
 export declare const loading: string;
+export declare const noHeaders: string;
 export declare const noPadding: string;
 export declare const shouldTruncate: string;
 export declare const skeletonCellWrapper: string;

--- a/src/components/simple-table/SimpleTable.tsx
+++ b/src/components/simple-table/SimpleTable.tsx
@@ -99,7 +99,7 @@ export type SimpleTableProps<T extends object> = BaseProps & {
   bordered?: boolean;
   /**
    * @default false
-   * @note Setting collapsible with selectable will result in unexpected behavior
+   * @note Setting collapsible with onRowClick could result in unexpected behavior
    * Enable rows to collapse and expand with more information
    */
   collapsible?: {
@@ -148,7 +148,6 @@ export type SimpleTableProps<T extends object> = BaseProps & {
   renderFooter?: ReactNode;
   /**
    * @default false
-   * @note Setting collapsible with selectable will result in unexpected behavior
    * Show checkbox on each row, and checkbox for toggling all in header
    */
   selectable?: {

--- a/src/components/simple-table/SimpleTable.tsx
+++ b/src/components/simple-table/SimpleTable.tsx
@@ -1,9 +1,10 @@
-import React, { type ReactNode, Fragment } from 'react';
+import React, { type ReactNode, Fragment, useState } from 'react';
 
 import clsx from 'clsx';
 
 import { Checkbox } from 'src/components/checkbox/Checkbox';
 import { Skeleton } from 'src/components/skeleton/Skeleton';
+import { TableRowCollapse } from 'src/components/table/TableRowCollapse';
 import { Text } from 'src/components/text/Text';
 import { Tooltip } from 'src/components/tooltip/Tooltip';
 import type { BaseProps } from 'src/types/BaseProps';
@@ -91,6 +92,28 @@ export type SimpleTableProps<T extends object> = BaseProps & {
     children: ReactNode;
     href: string;
   }>;
+  /**
+   * @default false
+   * Use bordered variant of table
+   */
+  bordered?: boolean;
+  /**
+   * @default false
+   * Enable rows to collapse and expand with more information
+   */
+  collapsible?: {
+    /**
+     * Content to show when row is expanded
+     */
+    collapseContent?: {
+      content: ReactNode;
+      /**
+       * @note Key must match the key of the item it is expanding from
+       */
+      key: string;
+    }[];
+    enabled: boolean;
+  };
   headers: SimpleTableHeader<T>[];
   items: T[];
   /**
@@ -170,7 +193,11 @@ export type SimpleTableProps<T extends object> = BaseProps & {
  * - 'cell-hover-show': Shows only when the cell is hovered
  */
 export const SimpleTable = <T extends object>({
+  bordered = false,
   className,
+  collapsible = {
+    enabled: false,
+  },
   CustomLinkComponent,
   getRowLink,
   headers,
@@ -189,6 +216,13 @@ export const SimpleTable = <T extends object>({
   },
   style,
 }: SimpleTableProps<T>) => {
+  const [expandedItemIds, setExpandedItemIds] = useState<string[]>([]);
+  const toggleItem = (id: string) =>
+    setExpandedItemIds(
+      expandedItemIds.includes(id)
+        ? expandedItemIds.filter(x => x !== id)
+        : expandedItemIds.concat(id),
+    );
   const renderHeader = (header: SimpleTableHeader<T>, item: T) => {
     const value = item[header.key];
 
@@ -312,6 +346,53 @@ export const SimpleTable = <T extends object>({
       ));
     }
 
+    if (collapsible.enabled && collapsible.collapseContent?.length) {
+      return items.map((item, index) => {
+        const key = keyExtractor(item);
+        const collapsed = !expandedItemIds.includes(key);
+        return (
+          <TableRowCollapse
+            key={key}
+            className={clsx(
+              !noHoverBackground && styles.withHover,
+              collapsed && styles.collapsed,
+            )}
+            collapsed={collapsed}
+            onToggleCollapse={() => toggleItem(key)}
+            rowContent={
+              <>
+                {selectable.enabled && (
+                  <td>
+                    {selectable.renderCustomRowCheckbox?.(item, index) || (
+                      <Checkbox
+                        checked={
+                          selectable.isRowChecked?.(item, index) || false
+                        }
+                        disabled={
+                          selectable.isRowCheckboxDisabled?.(item, index) ||
+                          false
+                        }
+                        onChange={checked =>
+                          selectable.onRowCheckboxChange?.(checked, item, index)
+                        }
+                      />
+                    )}
+                  </td>
+                )}
+                {headers.map(header => (
+                  <Fragment key={header.key}>
+                    {renderHeader(header, item)}
+                  </Fragment>
+                ))}
+              </>
+            }
+          >
+            {collapsible.collapseContent?.find(x => x.key === key)?.content}
+          </TableRowCollapse>
+        );
+      });
+    }
+
     return items.map((item, index) => {
       const clickable =
         !!onRowClick ||
@@ -371,7 +452,14 @@ export const SimpleTable = <T extends object>({
         ...style,
       }}
     >
-      <table className={styles.tableStyled}>
+      <table
+        className={clsx(
+          collapsible.enabled && styles.collapsible,
+          styles.tableStyled,
+          bordered && styles.bordered,
+          headers.every(header => !header.name) && styles.noHeaders,
+        )}
+      >
         <colgroup>
           {!!selectable.onHeaderCheckboxChange && <col width={0} />}
           {headers.map(header => (
@@ -388,6 +476,7 @@ export const SimpleTable = <T extends object>({
               }
             />
           ))}
+          {collapsible.enabled && <col />}
         </colgroup>
         <thead>
           <tr>
@@ -422,6 +511,7 @@ export const SimpleTable = <T extends object>({
                 )}
               </th>
             ))}
+            {collapsible.enabled && <th />}
           </tr>
         </thead>
         <tbody>{renderRows()}</tbody>

--- a/src/components/simple-table/SimpleTable.tsx
+++ b/src/components/simple-table/SimpleTable.tsx
@@ -99,6 +99,7 @@ export type SimpleTableProps<T extends object> = BaseProps & {
   bordered?: boolean;
   /**
    * @default false
+   * @note Setting collapsible with selectable will result in unexpected behavior
    * Enable rows to collapse and expand with more information
    */
   collapsible?: {
@@ -147,6 +148,7 @@ export type SimpleTableProps<T extends object> = BaseProps & {
   renderFooter?: ReactNode;
   /**
    * @default false
+   * @note Setting collapsible with selectable will result in unexpected behavior
    * Show checkbox on each row, and checkbox for toggling all in header
    */
   selectable?: {
@@ -179,6 +181,7 @@ export type SimpleTableProps<T extends object> = BaseProps & {
    * Callback for clicking anywhere on row.
    *
    * If having buttons in the table, remember to call e.stopPropagation() to prevent this from firing.
+   * @note Setting onRowClick with collapsible will result in unexpected behavior
    */
   onRowClick?: (item: T) => void;
   /** Callback for hovering anywhere on row */

--- a/src/components/simple-table/__stories__/SimpleTable.spec.ts
+++ b/src/components/simple-table/__stories__/SimpleTable.spec.ts
@@ -1,0 +1,184 @@
+import test, { type Page, expect } from '@playwright/test';
+
+test.describe('SimpleTable', () => {
+  let framePage: Page;
+  test.beforeEach(async ({ page }) => {
+    const testTitle = test.info().title;
+    page.goto('/');
+    await page
+      .getByRole('button', { exact: true, name: 'SimpleTable' })
+      .click();
+    await page.getByRole('link', { name: testTitle }).click();
+
+    /** Open popup since interact with `iframe` doesn't give much insight when debuging */
+    const framePagePromise = page.waitForEvent('popup');
+    await page.getByRole('link', { name: 'Open canvas in new tab' }).click();
+    framePage = await framePagePromise;
+    /** Wait for the DOM to fully load */
+    await framePage.waitForEvent('load');
+  });
+
+  test.afterEach(() => {
+    /** Close the popup after finishing testing it */
+    framePage.close();
+  });
+
+  test.describe('Ensure Selectable works', () => {
+    test('Selectable', async () => {
+      const checkbox1 = framePage
+        .getByRole('row', { name: 'John 24 This is a long string' })
+        .locator('label');
+      await checkbox1.click();
+      await expect(checkbox1).toBeChecked();
+
+      const checkbox2 = framePage
+        .getByRole('row', { name: 'Joan 27 This is a long string' })
+        .locator('label');
+      await checkbox2.click();
+      await expect(checkbox2).toBeChecked();
+
+      await checkbox1.click();
+      await expect(checkbox1).not.toBeChecked();
+
+      const checkboxAll = framePage
+        .getByRole('row', { name: 'Name Age Vegan Truncate Text' })
+        .locator('label');
+      await checkboxAll.click();
+
+      await expect(checkbox1).toBeChecked();
+      await expect(checkbox2).toBeChecked();
+      await expect(
+        framePage
+          .getByRole('row', { name: 'Cade 26 This is a long string' })
+          .locator('label'),
+      ).toBeChecked();
+    });
+  });
+
+  test.describe('Ensure CustomLink works', () => {
+    test('With Link', async () => {
+      await framePage
+        .getByRole('row', { name: 'Joe 26 This is a long string' })
+        .locator('td')
+        .nth(3)
+        .click();
+      expect(framePage.url()).toBe('https://letmegooglethat.com/?q=Joe');
+    });
+  });
+
+  test.describe('Ensure hover and noHoverBackground works', () => {
+    test('Basic', async () => {
+      const row1 = framePage.locator('.with-hover tbody > tr').first();
+      const row2 = framePage.locator('.no-hover tbody > tr').first();
+
+      await expect(row1).toHaveClass(/_withHover_.+/);
+      await expect(row2).not.toHaveClass(/_withHover_.+/);
+    });
+  });
+
+  test.describe('Ensure onRowClick works', () => {
+    test('Custom', async () => {
+      await framePage.locator('.tooltip-wrapper').first().click();
+      framePage.once('dialog', dialog => {
+        expect(dialog.message()).toBe('Clicked John');
+        dialog.dismiss().catch(() => {});
+      });
+    });
+  });
+
+  test.describe('Ensure collapsible works', () => {
+    test('Collapsible', async () => {
+      // Normal table
+      await framePage
+        .locator('td:nth-child(5) > .tooltip-wrapper')
+        .first()
+        .click();
+      await expect(
+        framePage.locator('table > tr:nth-child(2) > td:nth-child(2)').first(),
+      ).toBeVisible();
+      await framePage
+        .locator('tr:nth-child(7) > td:nth-child(4) > .tooltip-wrapper')
+        .first()
+        .click();
+      await expect(
+        framePage
+          .locator(
+            'tr:nth-child(8) .MuiCollapse-wrapper > .MuiCollapse-wrapperInner > table > tr:nth-child(2) > td:nth-child(2)',
+          )
+          .first(),
+      ).toBeVisible();
+
+      // Bordered table
+      await framePage
+        .locator('.bordered-table  tbody > tr > td:nth-child(4)')
+        .first()
+        .click();
+      await expect(
+        framePage.locator(
+          '.bordered-table tbody > tr:nth-child(2) .MuiCollapse-root > .MuiCollapse-wrapper > .MuiCollapse-wrapperInner > table > tr:nth-child(2) > td:nth-child(2)',
+        ),
+      ).toBeVisible();
+
+      await framePage
+        .locator(
+          '.bordered-table tbody > tr:nth-child(5) > td:nth-child(4) > .tooltip-wrapper',
+        )
+        .click();
+      await expect(
+        framePage.locator(
+          '.bordered-table tbody > tr:nth-child(6) .MuiCollapse-root > .MuiCollapse-wrapper > .MuiCollapse-wrapperInner > table > tr:nth-child(2) > td:nth-child(2)',
+        ),
+      ).toBeVisible();
+
+      // Selectable table
+      await framePage
+        .locator('.selectable-table tbody > tr:nth-child(11) > td:nth-child(4)')
+        .click();
+      await expect(
+        framePage.locator(
+          '.selectable-table tbody > tr:nth-child(12) .MuiCollapse-root > .MuiCollapse-wrapper > .MuiCollapse-wrapperInner > table > tr:nth-child(2) > td:nth-child(2)',
+        ),
+      ).toBeVisible();
+      await framePage
+        .locator(
+          '.selectable-table tbody > tr:nth-child(3) > td:nth-child(5) > .tooltip-wrapper',
+        )
+        .click();
+      await expect(
+        framePage.locator(
+          '.selectable-table tbody > tr:nth-child(4) .MuiCollapse-root > .MuiCollapse-wrapper > .MuiCollapse-wrapperInner > table > tr:nth-child(2) > td:nth-child(2)',
+        ),
+      ).toBeVisible();
+      await framePage
+        .locator('.selectable-table tr:nth-child(3) > td')
+        .first()
+        .click();
+      await expect(
+        framePage
+          .locator('.selectable-table tr:nth-child(3) > td > label')
+          .first(),
+      ).toBeChecked();
+      await framePage
+        .locator(
+          '.selectable-table tbody > tr:nth-child(7) > td:nth-child(5) > .tooltip-wrapper',
+        )
+        .click();
+      await expect(
+        framePage.locator(
+          '.selectable-table tbody > tr:nth-child(8) .MuiCollapse-root > .MuiCollapse-wrapper > .MuiCollapse-wrapperInner > table > tr:nth-child(2) > td:nth-child(2)',
+        ),
+      ).toBeVisible();
+    });
+  });
+
+  test.describe('Ensure noHeaders works', () => {
+    test('Bordered', async () => {
+      await expect(
+        framePage
+          .getByRole('cell', { name: 'Truncate Text (min 150px)' })
+          .first(),
+      ).toBeVisible();
+      await expect(framePage.locator('thead').nth(1)).toBeVisible();
+    });
+  });
+});

--- a/src/components/simple-table/__stories__/SimpleTable.stories.tsx
+++ b/src/components/simple-table/__stories__/SimpleTable.stories.tsx
@@ -386,7 +386,7 @@ export const Collapsible = () => {
         </tr>
         <tr>
           <td style={{ border: 'none' }}>{item.name}</td>
-          <td>{item.age}</td>
+          <td style={{ border: 'none' }}>{item.age}</td>
           <td style={{ border: 'none' }}>{item.vegan}</td>
         </tr>
       </table>

--- a/src/components/simple-table/__stories__/SimpleTable.stories.tsx
+++ b/src/components/simple-table/__stories__/SimpleTable.stories.tsx
@@ -351,6 +351,31 @@ export const Bordered = () => {
 };
 
 export const Collapsible = () => {
+  const [selectedRowIndexes, setSelectedRowIndexes] = useState<number[]>([]);
+
+  const checkboxAllValue = selectedRowIndexes.length === items.length;
+
+  const handleCheckboxAllChange = () => {
+    if (selectedRowIndexes.length === items.length) {
+      setSelectedRowIndexes([]);
+    } else {
+      setSelectedRowIndexes(items.map((_, index) => index));
+    }
+  };
+
+  const handleCheckboxRowChange = (
+    value: boolean,
+    item: DummyData,
+    index: number,
+  ) => {
+    if (value) {
+      setSelectedRowIndexes([...selectedRowIndexes, index]);
+    } else {
+      setSelectedRowIndexes(
+        selectedRowIndexes.filter(selectedIndex => selectedIndex !== index),
+      );
+    }
+  };
   const collapseContent = items.map(item => ({
     content: (
       <table style={{ width: '100%' }}>
@@ -392,6 +417,26 @@ export const Collapsible = () => {
         headers={tableHeaders}
         items={items}
         keyExtractor={item => String(item.id)}
+      />
+      <Divider />
+      <Text type="header">Selectable</Text>
+      <SimpleTable
+        bordered
+        collapsible={{
+          collapseContent,
+          enabled: true,
+        }}
+        headers={tableHeaders}
+        items={items}
+        keyExtractor={item => String(item.id)}
+        selectable={{
+          anySelected: selectedRowIndexes.length > 0,
+          enabled: true,
+          headerCheckboxValue: checkboxAllValue,
+          isRowChecked: (_, index) => selectedRowIndexes.includes(index),
+          onHeaderCheckboxChange: handleCheckboxAllChange,
+          onRowCheckboxChange: handleCheckboxRowChange,
+        }}
       />
     </>
   );

--- a/src/components/simple-table/__stories__/SimpleTable.stories.tsx
+++ b/src/components/simple-table/__stories__/SimpleTable.stories.tsx
@@ -321,6 +321,82 @@ export const Loading = () => {
   );
 };
 
+export const Bordered = () => {
+  const augmentedHeaders: SimpleTableHeader<DummyData>[] = tableHeaders
+    .filter(Boolean)
+    .map(header => ({
+      ...header,
+      minWidth: header.minWidth || 50,
+      name: null,
+    }));
+  return (
+    <>
+      <Text type="header">With headers</Text>
+      <SimpleTable
+        bordered
+        headers={tableHeaders}
+        items={items}
+        keyExtractor={item => String(item.id)}
+      />
+      <Divider />
+      <Text type="header">Without headers</Text>
+      <SimpleTable
+        bordered
+        headers={augmentedHeaders}
+        items={items}
+        keyExtractor={item => String(item.id)}
+      />
+    </>
+  );
+};
+
+export const Collapsible = () => {
+  const collapseContent = items.map(item => ({
+    content: (
+      <table style={{ width: '100%' }}>
+        <tr>
+          <th>Name</th>
+          <th>Age</th>
+          <th>Vegan</th>
+        </tr>
+        <tr>
+          <td style={{ border: 'none' }}>{item.name}</td>
+          <td>{item.age}</td>
+          <td style={{ border: 'none' }}>{item.vegan}</td>
+        </tr>
+      </table>
+    ),
+    key: String(item.id),
+  }));
+
+  return (
+    <>
+      <Text type="header">Normal</Text>
+      <SimpleTable
+        collapsible={{
+          collapseContent,
+          enabled: true,
+        }}
+        headers={tableHeaders}
+        items={items}
+        keyExtractor={item => String(item.id)}
+      />
+      <Divider />
+      <Text type="header">Bordered</Text>
+      <SimpleTable
+        bordered
+        collapsible={{
+          collapseContent,
+          enabled: true,
+        }}
+        headers={tableHeaders}
+        items={items}
+        keyExtractor={item => String(item.id)}
+      />
+    </>
+  );
+};
+
 export const Custom = () => {
   const [shouldTruncate, setShouldTruncate] = useState(true);
   const [viewOneRow, setViewOneRow] = useState(false);

--- a/src/components/simple-table/__stories__/SimpleTable.stories.tsx
+++ b/src/components/simple-table/__stories__/SimpleTable.stories.tsx
@@ -147,11 +147,24 @@ const tableHeaders: SimpleTableHeader<DummyData>[] = [
 ];
 
 export const Basic = () => (
-  <SimpleTable
-    headers={tableHeaders}
-    items={items}
-    keyExtractor={item => String(item.id)}
-  />
+  <>
+    <Text type="header">With hover</Text>
+    <SimpleTable
+      className="with-hover"
+      headers={tableHeaders}
+      items={items}
+      keyExtractor={item => String(item.id)}
+    />
+    <Divider />
+    <Text type="header">Without hover</Text>
+    <SimpleTable
+      className="no-hover"
+      headers={tableHeaders}
+      items={items}
+      keyExtractor={item => String(item.id)}
+      noHoverBackground
+    />
+  </>
 );
 
 export const Long = () => (
@@ -398,6 +411,7 @@ export const Collapsible = () => {
     <>
       <Text type="header">Normal</Text>
       <SimpleTable
+        className="normal-table"
         collapsible={{
           collapseContent,
           enabled: true,
@@ -410,6 +424,7 @@ export const Collapsible = () => {
       <Text type="header">Bordered</Text>
       <SimpleTable
         bordered
+        className="bordered-table"
         collapsible={{
           collapseContent,
           enabled: true,
@@ -422,6 +437,7 @@ export const Collapsible = () => {
       <Text type="header">Selectable</Text>
       <SimpleTable
         bordered
+        className="selectable-table"
         collapsible={{
           collapseContent,
           enabled: true,


### PR DESCRIPTION
## Linear issue
Facilitates this task:
[CXT-1064: Frontend - Add filters to Invoices UI and update side nav bar](https://linear.app/zonos/issue/CXT-1064/frontend-add-filters-to-invoices-ui-and-update-side-nav-bar)

Figma for SimpleTable designs:
<https://www.figma.com/design/sq4q6XA4CjrQWSdnh3vnXM/Billing?node-id=2532-33802&m=dev>

## Preview
Collapsible SimpleTable
<https://simple-table.amino.zonos.com/?path=/story/amino-simpletable--collapsible>

Bordered SimpleTable
<https://simple-table.amino.zonos.com/?path=/story/amino-simpletable--bordered>

## Description

This PR adds new functionality to SimpleTable:
- enable rows to be collapsible/expandable
- enables removal of the headers (for some new designs)
- enables shift of design from "normal" to "bordered" (for some new designs)

## Todo

- [x] Bump version and add tag
