### PR TITLE
FIX: Toast styling

### DIFF
--- a/src/components/toast/Toast.module.scss
+++ b/src/components/toast/Toast.module.scss
@@ -15,6 +15,7 @@
   font-weight: 500;
   user-select: none;
   flex: 1;
+  line-height: 24px;
 
   &.persistentToast {
     cursor: pointer;

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -118,7 +118,7 @@ export const Toast = ({
           <div>{children}</div>
         </Flex>
 
-        <Flex alignItems="flex-start" className="toast-actions" gap={12}>
+        <Flex alignItems="center" className="toast-actions" gap={12}>
           {actions}
 
           {isPersistent && (

--- a/src/styles/amino.css
+++ b/src/styles/amino.css
@@ -77,7 +77,7 @@ html {
 
 body {
   font-family: var(--amino-font-sans);
-  font-size: var(--amino-text-base);
+  font-size: var(--amino-font-size-base);
   background: var(--amino-page-background);
   height: 100%;
   width: 100%;
@@ -121,7 +121,7 @@ h4 {
 }
 
 h5 {
-  font-size: var(--amino-text-base);
+  font-size: var(--amino-font-size-base);
   font-weight: 400;
 }
 


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR fixes the styling on toasts in dashboard. The font-size in amino was different from dashboard, so I changed amino to match the dashboard font size as well. This new alignment was approved by Connor.

## Todo

- [ ] Bump version and add tag
