### PR TITLE
fix(toast): fix alignment for persisting toasts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.4.22",
+  "version": "5.4.23",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/toast/Toast.module.scss
+++ b/src/components/toast/Toast.module.scss
@@ -27,6 +27,7 @@
 
   .dismissButton {
     height: 24px;
+    align-self: flex-start;
   }
 
   & svg {

--- a/src/components/toast/Toast.module.scss
+++ b/src/components/toast/Toast.module.scss
@@ -17,6 +17,13 @@
   flex: 1;
   line-height: 24px;
 
+  .toastContent {
+    align-self: center;
+    .toastIcon {
+      align-self: flex-start;
+    }
+  }
+
   &.persistentToast {
     cursor: pointer;
 
@@ -27,7 +34,6 @@
 
   .dismissButton {
     height: 24px;
-    align-self: flex-start;
   }
 
   & svg {

--- a/src/components/toast/Toast.module.scss.d.ts
+++ b/src/components/toast/Toast.module.scss.d.ts
@@ -5,3 +5,5 @@ export declare const aminoToast: string;
 export declare const aminoWarningToast: string;
 export declare const dismissButton: string;
 export declare const persistentToast: string;
+export declare const toastContent: string;
+export declare const toastIcon: string;

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -112,9 +112,9 @@ export const Toast = ({
       {...baseProps}
       key={toastKey}
     >
-      <Flex alignItems="center" gap={12} justifyContent="space-between">
-        <Flex gap={12}>
-          <div>{intentValues.icon}</div>
+      <Flex alignItems="flex-start" gap={12} justifyContent="space-between">
+        <Flex alignItems="center" className={styles.toastContent} gap={12}>
+          <div className={styles.toastIcon}>{intentValues.icon}</div>
           <div>{children}</div>
         </Flex>
 

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -112,7 +112,7 @@ export const Toast = ({
       {...baseProps}
       key={toastKey}
     >
-      <Flex alignItems="flex-start" gap={12} justifyContent="space-between">
+      <Flex alignItems="center" gap={12} justifyContent="space-between">
         <Flex gap={12}>
           <div>{intentValues.icon}</div>
           <div>{children}</div>

--- a/src/components/toast/__stories__/ToastConsumer.tsx
+++ b/src/components/toast/__stories__/ToastConsumer.tsx
@@ -66,6 +66,21 @@ export const ToastConsumer = () => {
         </Button>
         <Button
           onClick={() =>
+            notify('Short persisting with error', {
+              actions: (
+                <Button outline variant="danger">
+                  Request support
+                </Button>
+              ),
+              intent: 'error',
+              isPersistent: true,
+            })
+          }
+        >
+          Short persisting with error
+        </Button>
+        <Button
+          onClick={() =>
             notify(
               `Long persisting example: Error: Field "userProfl" does not exist
                 on type "Query". Did you mean "userProfile"? [Location: line 3,


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR fixes the alignment for toasts one last time. Just set the dismiss icon to align to top. Everything else is centered.

https://amino-git-fix-components-zonos.vercel.app/?path=%2Fdocs%2Famino-toast--docs
To preview, click the different persistent toasts.

## Todo

- [x] Bump version and add tag
