### PR TITLE
FEAT: Toast dismiss function

### DIFF
--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -23,6 +23,10 @@ export type ToastProps = BaseProps & {
   direction?: Direction;
   /** Dismiss delay (default 6000 ms) */
   duration?: number;
+  /** Pass a unique identifier for the toast (used for dismissing)
+   * @default uuid created in Amino
+   */
+  id?: string;
   intent?: Extract<Intent, 'success' | 'warning' | 'error' | 'info'>;
   /** If true, toast will be shown in the persistent stack */
   isPersistent?: boolean;

--- a/src/components/toast/__stories__/ToastConsumer.tsx
+++ b/src/components/toast/__stories__/ToastConsumer.tsx
@@ -12,7 +12,7 @@ import styles from './ToastConsumer.stories.module.scss';
 const useNotify = () => useContext(ToastContext);
 
 export const ToastConsumer = () => {
-  const notify = useNotify();
+  const { dismissToast, notify } = useNotify();
 
   const [message, setMessage] = useState('Your custom message');
   const [duration, setDuration] = useState(6000);
@@ -87,10 +87,15 @@ export const ToastConsumer = () => {
                 column 5].`,
               {
                 actions: (
-                  <Button outline variant="danger">
-                    Request support
+                  <Button
+                    onClick={() => dismissToast('long-persisting')}
+                    outline
+                    variant="danger"
+                  >
+                    External dismiss
                   </Button>
                 ),
+                id: 'long-persisting',
                 intent: 'error',
                 isPersistent: true,
               },


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR adds a way for consumers to dismiss the toast manually. This logic should work well in dashboard.

## Todo

- [ ] Bump version and add tag
