### PR TITLE
FEAT: Dismiss all toasts 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.4.24",
+  "version": "5.4.25",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/toast/ToastContext.tsx
+++ b/src/components/toast/ToastContext.tsx
@@ -34,8 +34,12 @@ type ToastType = {
 };
 export const ToastContext = createContext<{
   notify: ToastContextFunctionType;
+  dismissAllToasts: () => void;
   dismissToast: (toastId: string) => void;
 }>({
+  dismissAllToasts: () => {
+    // This function is for the context type definition purpose.
+  },
   dismissToast: _toastId => {
     // This function is for the context type definition purpose.
   },
@@ -112,10 +116,11 @@ export const ToastContextProvider = ({ children }: Props) => {
     dismissToast(toastId);
   };
 
-  const clearAllClicked = () => {
+  const dismissAllToasts = useCallback(() => {
     setPersistentToasts([]);
+    setToasts([]);
     setExpandedToasts(false);
-  };
+  }, [setPersistentToasts, setToasts, setExpandedToasts]);
 
   const toggleExpanded = (e: React.MouseEvent | React.KeyboardEvent) => {
     const actionsElement = e.currentTarget.querySelector('.toast-actions');
@@ -136,8 +141,8 @@ export const ToastContextProvider = ({ children }: Props) => {
   }, [firstToast]); // Only re-measure when first toast changes
 
   const contextValue = useMemo(
-    () => ({ dismissToast, notify: setupToasts }),
-    [dismissToast, setupToasts],
+    () => ({ dismissAllToasts, dismissToast, notify: setupToasts }),
+    [dismissAllToasts, dismissToast, setupToasts],
   );
 
   return (
@@ -188,7 +193,7 @@ export const ToastContextProvider = ({ children }: Props) => {
             <Button
               className={styles.clearAllButton}
               icon={<RemoveIcon />}
-              onClick={clearAllClicked}
+              onClick={dismissAllToasts}
               variant="text"
             >
               Clear all

--- a/src/components/toast/__stories__/ToastConsumer.tsx
+++ b/src/components/toast/__stories__/ToastConsumer.tsx
@@ -1,6 +1,9 @@
 import { useContext, useState } from 'react';
 
+import { v4 as uuidv4 } from 'uuid';
+
 import { Button } from 'src/components/button/Button';
+import { Flex } from 'src/components/flex/Flex';
 import { Input } from 'src/components/input/Input';
 import { Select } from 'src/components/select/Select';
 import { VStack } from 'src/components/stack/VStack';
@@ -12,7 +15,7 @@ import styles from './ToastConsumer.stories.module.scss';
 const useNotify = () => useContext(ToastContext);
 
 export const ToastConsumer = () => {
-  const { dismissToast, notify } = useNotify();
+  const { dismissAllToasts, dismissToast, notify } = useNotify();
 
   const [message, setMessage] = useState('Your custom message');
   const [duration, setDuration] = useState(6000);
@@ -80,27 +83,34 @@ export const ToastConsumer = () => {
           Short persisting with error
         </Button>
         <Button
-          onClick={() =>
+          onClick={() => {
+            const uniqueId = uuidv4();
             notify(
               `Long persisting example: Error: Field "userProfl" does not exist
                 on type "Query". Did you mean "userProfile"? [Location: line 3,
                 column 5].`,
               {
                 actions: (
-                  <Button
-                    onClick={() => dismissToast('long-persisting')}
-                    outline
-                    variant="danger"
-                  >
-                    External dismiss
-                  </Button>
+                  <Flex flexDirection="column">
+                    <Button
+                      onClick={() => dismissToast(uniqueId)}
+                      outline
+                      variant="danger"
+                    >
+                      External dismiss
+                    </Button>
+
+                    <Button onClick={dismissAllToasts} outline variant="danger">
+                      Dismiss all
+                    </Button>
+                  </Flex>
                 ),
-                id: 'long-persisting',
+                id: uniqueId,
                 intent: 'error',
                 isPersistent: true,
               },
-            )
-          }
+            );
+          }}
         >
           Long persisting
         </Button>


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR exposes a new function from ToastContext to dismiss all toasts. Product wants to dismiss all toasts when a user clicks the request support button.

## Todo

- [x] Bump version and add tag
