### PR TITLE
fix: lock collapse button to end of row

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.4.29",
+  "version": "5.4.30",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/simple-table/SimpleTable.module.scss
+++ b/src/components/simple-table/SimpleTable.module.scss
@@ -137,6 +137,12 @@ $cellMinWidth: var(--amino-cell-min-width);
   }
 
   &.collapsible {
+    tr > td:last-child {
+      width: 40px;
+      > div {
+        padding: 0;
+      }
+    }
     &.bordered {
       tr:nth-last-child(2).collapsed td:first-child {
         border-bottom-left-radius: 12px;


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR makes a small fix to lock the collapse chevron to the end of the row, rather than acting like a normal <td> element

## Todo

- [ ] Bump version and add tag
