### PR TITLE
Fix/simple table collapse

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.4.32",
+  "version": "5.4.33",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/simple-table/SimpleTable.module.scss
+++ b/src/components/simple-table/SimpleTable.module.scss
@@ -163,7 +163,7 @@ $cellMinWidth: var(--amino-cell-min-width);
             border-bottom: theme.$amino-border-subtle;
           }
         }
-        &.collapsed {
+        &.collapsed.hasContent {
           & + tr > td {
             border: 0;
           }

--- a/src/components/simple-table/SimpleTable.module.scss.d.ts
+++ b/src/components/simple-table/SimpleTable.module.scss.d.ts
@@ -3,6 +3,7 @@ export declare const bordered: string;
 export declare const clickable: string;
 export declare const collapsed: string;
 export declare const collapsible: string;
+export declare const hasContent: string;
 export declare const loading: string;
 export declare const noHeaders: string;
 export declare const noPadding: string;

--- a/src/components/simple-table/SimpleTable.tsx
+++ b/src/components/simple-table/SimpleTable.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactNode, Fragment, useState } from 'react';
+import React, { type ReactNode, Fragment } from 'react';
 
 import clsx from 'clsx';
 
@@ -99,7 +99,6 @@ export type SimpleTableProps<T extends object> = BaseProps & {
   bordered?: boolean;
   /**
    * @default false
-   * @note Setting collapsible with onRowClick could result in unexpected behavior
    * Enable rows to collapse and expand with more information
    */
   collapsible?: {
@@ -114,6 +113,8 @@ export type SimpleTableProps<T extends object> = BaseProps & {
       key: string;
     }[];
     enabled: boolean;
+    expandedItemKeys: string[];
+    toggleItem: (key: string) => void;
   };
   headers: SimpleTableHeader<T>[];
   items: T[];
@@ -180,7 +181,6 @@ export type SimpleTableProps<T extends object> = BaseProps & {
    * Callback for clicking anywhere on row.
    *
    * If having buttons in the table, remember to call e.stopPropagation() to prevent this from firing.
-   * @note Setting onRowClick with collapsible will result in unexpected behavior
    */
   onRowClick?: (item: T) => void;
   /** Callback for hovering anywhere on row */
@@ -199,6 +199,8 @@ export const SimpleTable = <T extends object>({
   className,
   collapsible = {
     enabled: false,
+    expandedItemKeys: [],
+    toggleItem: () => {},
   },
   CustomLinkComponent,
   getRowLink,
@@ -218,13 +220,6 @@ export const SimpleTable = <T extends object>({
   },
   style,
 }: SimpleTableProps<T>) => {
-  const [expandedItemIds, setExpandedItemIds] = useState<string[]>([]);
-  const toggleItem = (id: string) =>
-    setExpandedItemIds(
-      expandedItemIds.includes(id)
-        ? expandedItemIds.filter(x => x !== id)
-        : expandedItemIds.concat(id),
-    );
   const renderHeader = (header: SimpleTableHeader<T>, item: T) => {
     const value = item[header.key];
 
@@ -349,18 +344,25 @@ export const SimpleTable = <T extends object>({
     }
 
     if (collapsible.enabled && collapsible.collapseContent?.length) {
+      const { collapseContent, expandedItemKeys, toggleItem } = collapsible;
       return items.map((item, index) => {
         const key = keyExtractor(item);
-        const collapsed = !expandedItemIds.includes(key);
+        const collapsed = !expandedItemKeys.includes(key);
+        const rowCollapseContent = collapseContent?.find(x => x.key === key)
+          ?.content;
         return (
           <TableRowCollapse
             key={key}
             className={clsx(
               !noHoverBackground && styles.withHover,
               collapsed && styles.collapsed,
+              collapseContent && styles.hasContent,
             )}
             collapsed={collapsed}
-            onToggleCollapse={() => toggleItem(key)}
+            onToggleCollapse={() => {
+              toggleItem(key);
+              onRowClick?.(item);
+            }}
             rowContent={
               <>
                 {selectable.enabled && (
@@ -389,7 +391,7 @@ export const SimpleTable = <T extends object>({
               </>
             }
           >
-            {collapsible.collapseContent?.find(x => x.key === key)?.content}
+            {rowCollapseContent}
           </TableRowCollapse>
         );
       });

--- a/src/components/simple-table/SimpleTable.tsx
+++ b/src/components/simple-table/SimpleTable.tsx
@@ -356,7 +356,7 @@ export const SimpleTable = <T extends object>({
             className={clsx(
               !noHoverBackground && styles.withHover,
               collapsed && styles.collapsed,
-              collapseContent && styles.hasContent,
+              rowCollapseContent && styles.hasContent,
             )}
             collapsed={collapsed}
             onToggleCollapse={() => {

--- a/src/components/simple-table/__stories__/SimpleTable.spec.ts
+++ b/src/components/simple-table/__stories__/SimpleTable.spec.ts
@@ -94,7 +94,11 @@ test.describe('SimpleTable', () => {
         .first()
         .click();
       await expect(
-        framePage.locator('table > tr:nth-child(2) > td:nth-child(2)').first(),
+        framePage
+          .locator(
+            'div.normal-table > table > tbody > tr:nth-child(2) > td table > thead > tr ',
+          )
+          .first(),
       ).toBeVisible();
       await framePage
         .locator('tr:nth-child(7) > td:nth-child(4) > .tooltip-wrapper')
@@ -103,7 +107,7 @@ test.describe('SimpleTable', () => {
       await expect(
         framePage
           .locator(
-            'tr:nth-child(8) .MuiCollapse-wrapper > .MuiCollapse-wrapperInner > table > tr:nth-child(2) > td:nth-child(2)',
+            'tr:nth-child(8) .MuiCollapse-wrapper > .MuiCollapse-wrapperInner > table > thead > tr',
           )
           .first(),
       ).toBeVisible();
@@ -115,7 +119,7 @@ test.describe('SimpleTable', () => {
         .click();
       await expect(
         framePage.locator(
-          '.bordered-table tbody > tr:nth-child(2) .MuiCollapse-root > .MuiCollapse-wrapper > .MuiCollapse-wrapperInner > table > tr:nth-child(2) > td:nth-child(2)',
+          '.bordered-table tbody > tr:nth-child(2) .MuiCollapse-root > .MuiCollapse-wrapper > .MuiCollapse-wrapperInner > table > thead > tr',
         ),
       ).toBeVisible();
 
@@ -126,7 +130,7 @@ test.describe('SimpleTable', () => {
         .click();
       await expect(
         framePage.locator(
-          '.bordered-table tbody > tr:nth-child(6) .MuiCollapse-root > .MuiCollapse-wrapper > .MuiCollapse-wrapperInner > table > tr:nth-child(2) > td:nth-child(2)',
+          '.bordered-table tbody > tr:nth-child(6) .MuiCollapse-root > .MuiCollapse-wrapper > .MuiCollapse-wrapperInner > table > thead > tr',
         ),
       ).toBeVisible();
 
@@ -136,7 +140,7 @@ test.describe('SimpleTable', () => {
         .click();
       await expect(
         framePage.locator(
-          '.selectable-table tbody > tr:nth-child(12) .MuiCollapse-root > .MuiCollapse-wrapper > .MuiCollapse-wrapperInner > table > tr:nth-child(2) > td:nth-child(2)',
+          '.selectable-table tbody > tr:nth-child(12) .MuiCollapse-root > .MuiCollapse-wrapper > .MuiCollapse-wrapperInner > table > thead > tr',
         ),
       ).toBeVisible();
       await framePage
@@ -146,7 +150,7 @@ test.describe('SimpleTable', () => {
         .click();
       await expect(
         framePage.locator(
-          '.selectable-table tbody > tr:nth-child(4) .MuiCollapse-root > .MuiCollapse-wrapper > .MuiCollapse-wrapperInner > table > tr:nth-child(2) > td:nth-child(2)',
+          '.selectable-table tbody > tr:nth-child(4) .MuiCollapse-root > .MuiCollapse-wrapper > .MuiCollapse-wrapperInner > table > thead > tr',
         ),
       ).toBeVisible();
       await framePage
@@ -165,7 +169,7 @@ test.describe('SimpleTable', () => {
         .click();
       await expect(
         framePage.locator(
-          '.selectable-table tbody > tr:nth-child(8) .MuiCollapse-root > .MuiCollapse-wrapper > .MuiCollapse-wrapperInner > table > tr:nth-child(2) > td:nth-child(2)',
+          '.selectable-table tbody > tr:nth-child(8) .MuiCollapse-root > .MuiCollapse-wrapper > .MuiCollapse-wrapperInner > table > thead > tr',
         ),
       ).toBeVisible();
     });
@@ -179,6 +183,47 @@ test.describe('SimpleTable', () => {
           .first(),
       ).toBeVisible();
       await expect(framePage.locator('thead').nth(1)).toBeVisible();
+    });
+  });
+
+  test.describe('Ensure onRowClick works with Collapsible', () => {
+    test('On Row Click', async () => {
+      framePage.once('dialog', dialog => {
+        expect(dialog.message()).toBe('Clicked John');
+        dialog.dismiss().catch(() => {});
+      });
+      await framePage.locator('.tooltip-wrapper').first().click();
+      framePage.once('dialog', dialog => {
+        expect(dialog.message()).toBe('Clicked John');
+        dialog.dismiss().catch(() => {});
+      });
+      await framePage
+        .locator('.collapsible tbody > tr > td:nth-child(4) > .tooltip-wrapper')
+        .first()
+        .click();
+      await expect(
+        framePage
+          .getByRole('cell', { name: 'Name Age Vegan John' })
+          ?.locator('div')
+          ?.nth(2),
+      ).toBeVisible();
+    });
+  });
+
+  test.describe('Ensure Collapse chevron is fixed width', () => {
+    test('Collapsible', async () => {
+      await expect(
+        framePage.locator('.normal-table tr > td:last-child').first(),
+      ).toHaveCSS('width', '48px');
+
+      await expect(
+        framePage.locator('.bordered-table tr > td:last-child').first(),
+        // bordered will have 1px border on the right
+      ).toHaveCSS('width', '49px');
+
+      await expect(
+        framePage.locator('.selectable-table tr > td:last-child').first(),
+      ).toHaveCSS('width', '49px');
     });
   });
 });

--- a/src/components/simple-table/__stories__/SimpleTable.stories.tsx
+++ b/src/components/simple-table/__stories__/SimpleTable.stories.tsx
@@ -365,6 +365,13 @@ export const Bordered = () => {
 
 export const Collapsible = () => {
   const [selectedRowIndexes, setSelectedRowIndexes] = useState<number[]>([]);
+  const [expandedItemKeys, setExpandedItemKeys] = useState<string[]>([]);
+  const toggleItem = (id: string) =>
+    setExpandedItemKeys(
+      expandedItemKeys.includes(id)
+        ? expandedItemKeys.filter(x => x !== id)
+        : expandedItemKeys.concat(id),
+    );
 
   const checkboxAllValue = selectedRowIndexes.length === items.length;
 
@@ -392,20 +399,28 @@ export const Collapsible = () => {
   const collapseContent = items.map(item => ({
     content: (
       <table style={{ width: '100%' }}>
-        <tr>
-          <th>Name</th>
-          <th>Age</th>
-          <th>Vegan</th>
-        </tr>
-        <tr>
-          <td style={{ border: 'none' }}>{item.name}</td>
-          <td style={{ border: 'none' }}>{item.age}</td>
-          <td style={{ border: 'none' }}>{item.vegan}</td>
-        </tr>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Age</th>
+            <th>Vegan</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td style={{ border: 'none' }}>{item.name}</td>
+            <td style={{ border: 'none' }}>{item.age}</td>
+            <td style={{ border: 'none' }}>{item.vegan}</td>
+          </tr>
+        </tbody>
       </table>
     ),
     key: String(item.id),
   }));
+
+  const adjustedCollapseContent = collapseContent.filter(
+    (_, index) => index !== 3,
+  );
 
   return (
     <>
@@ -415,6 +430,8 @@ export const Collapsible = () => {
         collapsible={{
           collapseContent,
           enabled: true,
+          expandedItemKeys,
+          toggleItem,
         }}
         headers={tableHeaders}
         items={items}
@@ -426,8 +443,10 @@ export const Collapsible = () => {
         bordered
         className="bordered-table"
         collapsible={{
-          collapseContent,
+          collapseContent: adjustedCollapseContent,
           enabled: true,
+          expandedItemKeys,
+          toggleItem,
         }}
         headers={tableHeaders}
         items={items}
@@ -441,6 +460,8 @@ export const Collapsible = () => {
         collapsible={{
           collapseContent,
           enabled: true,
+          expandedItemKeys,
+          toggleItem,
         }}
         headers={tableHeaders}
         items={items}
@@ -604,6 +625,66 @@ export const Custom = () => {
           onHeaderCheckboxChange: handleCheckboxAllChange,
           onRowCheckboxChange: handleCheckboxRowChange,
         }}
+      />
+    </>
+  );
+};
+
+export const OnRowClick = () => {
+  const [expandedItemKeys, setExpandedItemKeys] = useState<string[]>([]);
+  const toggleItem = (id: string) =>
+    setExpandedItemKeys(
+      expandedItemKeys.includes(id)
+        ? expandedItemKeys.filter(x => x !== id)
+        : expandedItemKeys.concat(id),
+    );
+  const collapseContent = items.map(item => ({
+    content: (
+      <table style={{ width: '100%' }}>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Age</th>
+            <th>Vegan</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td style={{ border: 'none' }}>{item.name}</td>
+            <td style={{ border: 'none' }}>{item.age}</td>
+            <td style={{ border: 'none' }}>{item.vegan}</td>
+          </tr>
+        </tbody>
+      </table>
+    ),
+    key: String(item.id),
+  }));
+
+  return (
+    <>
+      <Text type="header">Normal table</Text>
+      <SimpleTable
+        headers={tableHeaders}
+        items={items}
+        keyExtractor={item => String(item.id)}
+        onRowClick={item => {
+          alert(`Clicked ${item.name}`);
+        }}
+      />
+      <Divider />
+      <Text type="header">Collapsible table</Text>
+      <SimpleTable
+        className="collapsible"
+        collapsible={{
+          collapseContent,
+          enabled: true,
+          expandedItemKeys,
+          toggleItem,
+        }}
+        headers={tableHeaders}
+        items={items}
+        keyExtractor={item => String(item.id)}
+        onRowClick={item => alert(`Clicked ${item.name}`)}
       />
     </>
   );


### PR DESCRIPTION
## Linear issue

## Description

This PR adjusts some functionality for the SimpleTable, especially around the Collapsible feature:
- handle items with no collapsible content better with CSS
- fix onRowClick functionality with collapsible
- lift collapsed items state out of the component so consumers have more flexibility with how it works
 - ie make network calls or watch state for style changes
- write tests to handle these changes 

## Todo

- [x] Bump version and add tag
