### PR TITLE
FIX: Disallow duplicate toast ID's

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.4.34",
+  "version": "5.4.35",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/simple-table/__stories__/SimpleTable.spec.ts
+++ b/src/components/simple-table/__stories__/SimpleTable.spec.ts
@@ -27,7 +27,7 @@ test.describe('SimpleTable', () => {
   test.describe('Ensure Selectable works', () => {
     test('Selectable', async () => {
       const checkbox1 = framePage
-        .getByRole('row', { name: 'John 24 This is a long string' })
+        .getByRole('row', { name: 'John 24 Not long enough' })
         .locator('label');
       await checkbox1.click();
       await expect(checkbox1).toBeChecked();

--- a/src/components/toast/ToastContext.module.scss
+++ b/src/components/toast/ToastContext.module.scss
@@ -11,10 +11,12 @@ $persistentHeight: var(--amino-toast-persistent-height);
   flex-direction: column;
   position: fixed;
   z-index: 9999999;
+  pointer-events: none;
   width: 100%;
 }
 
 .toastsWrapper {
+  pointer-events: auto;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/components/toast/ToastContext.module.scss
+++ b/src/components/toast/ToastContext.module.scss
@@ -19,7 +19,6 @@ $persistentHeight: var(--amino-toast-persistent-height);
   flex-direction: column;
   align-items: center;
   gap: 16px;
-  width: 100%;
 }
 
 .toastWrapperAdjust {

--- a/src/components/toast/ToastContext.module.scss
+++ b/src/components/toast/ToastContext.module.scss
@@ -19,6 +19,7 @@ $persistentHeight: var(--amino-toast-persistent-height);
   flex-direction: column;
   align-items: center;
   gap: 16px;
+  width: 100%;
 }
 
 .toastWrapperAdjust {

--- a/src/components/toast/ToastContext.tsx
+++ b/src/components/toast/ToastContext.tsx
@@ -72,6 +72,14 @@ export const ToastContextProvider = ({ children }: Props) => {
 
   const addToast = useCallback<ToastContextFunctionType>(
     (toast, props) => {
+      // Skip if an ID is provided that already exists in either toast list
+      if (
+        props?.id &&
+        [...toasts, ...persistentToasts].some(t => t.uuid === props.id)
+      ) {
+        return;
+      }
+
       const newToast = {
         isPersistent: props?.isPersistent,
         props,
@@ -87,7 +95,7 @@ export const ToastContextProvider = ({ children }: Props) => {
         setTimeout(() => setToasts(t => t.slice(1)), props?.duration || 6000);
       }
     },
-    [setToasts, setPersistentToasts],
+    [setToasts, setPersistentToasts, toasts, persistentToasts],
   );
 
   const setupToasts = useCallback<ToastContextFunctionType>(

--- a/src/components/toast/ToastContext.tsx
+++ b/src/components/toast/ToastContext.tsx
@@ -215,6 +215,7 @@ export const ToastContextProvider = ({ children }: Props) => {
           <AnimatePresence>
             {persistentToasts.map(({ props, toast, uuid }, index) => {
               const key = `persistent-toast-${toast}-${uuid}`;
+              const showContent = index === 0 || expandedToasts;
               return (
                 <div
                   key={key}
@@ -231,15 +232,16 @@ export const ToastContextProvider = ({ children }: Props) => {
                 >
                   <Flex fullWidth>
                     <Toast
+                      {...props}
+                      actions={showContent ? props?.actions : undefined}
                       isPersistent
                       onDismiss={e => {
                         props?.onDismiss?.(e);
                         dismissClicked(e, uuid);
                       }}
                       toastKey={key}
-                      {...props}
                     >
-                      {index === 0 || expandedToasts ? toast : ''}
+                      {showContent ? toast : ''}
                     </Toast>
                   </Flex>
                 </div>


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR makes it so duplicate toasts can easily be stopped by passing an id. No duplicate IDs allowed.

This PR also:
* removes pointer events from the container and only allows them on the toasts wrappers (allows clicks behind the container)
* hides actions in addition to content when not the first toast
* fixes simple table test
* fixes a bug when a second toast with tall actions makes it taller than the first (hide the actions just like we were hiding the content)

## Todo

- [ ] Bump version and add tag
