### PR TITLE
fix: collapse loading styles

### DIFF
--- a/src/components/simple-table/SimpleTable.module.scss
+++ b/src/components/simple-table/SimpleTable.module.scss
@@ -167,7 +167,8 @@ $cellMinWidth: var(--amino-cell-min-width);
       * {
         transition: theme.$amino-transition;
       }
-      > tr {
+
+      > tr:not(:has(.loading)) {
         height: unset;
 
         &:not(.collapsed) {

--- a/src/components/simple-table/SimpleTable.tsx
+++ b/src/components/simple-table/SimpleTable.tsx
@@ -339,6 +339,7 @@ export const SimpleTable = <T extends object>({
               </div>
             </td>
           ))}
+          {collapsible.enabled && <td />}
         </tr>
       ));
     }

--- a/src/components/simple-table/__stories__/SimpleTable.stories.module.scss
+++ b/src/components/simple-table/__stories__/SimpleTable.stories.module.scss
@@ -1,0 +1,12 @@
+.collapseTable {
+  margin-top: 12px;
+  width: 100%;
+
+  th {
+    padding: 0 16px;
+  }
+  td {
+    border: none !important;
+    padding: 0 16px;
+  }
+}

--- a/src/components/simple-table/__stories__/SimpleTable.stories.module.scss.d.ts
+++ b/src/components/simple-table/__stories__/SimpleTable.stories.module.scss.d.ts
@@ -1,0 +1,1 @@
+export declare const collapseTable: string;

--- a/src/components/simple-table/__stories__/SimpleTable.stories.tsx
+++ b/src/components/simple-table/__stories__/SimpleTable.stories.tsx
@@ -23,6 +23,8 @@ import { RemoveIcon } from 'src/icons/RemoveIcon';
 import { ThreeDotIcon } from 'src/icons/ThreeDotIcon';
 import { TrashCanDuotoneIcon } from 'src/icons/TrashCanDuotoneIcon';
 
+import styles from './SimpleTable.stories.module.scss';
+
 const meta: Meta = {
   component: SimpleTable,
 };
@@ -298,6 +300,13 @@ export const WithLink = () => {
 export const Loading = () => {
   const [loading, setLoading] = useState(true);
   const [selectedRowIndexes, setSelectedRowIndexes] = useState<number[]>([]);
+  const [expandedItemKeys, setExpandedItemKeys] = useState<string[]>([]);
+  const toggleItem = (id: string) =>
+    setExpandedItemKeys(
+      expandedItemKeys.includes(id)
+        ? expandedItemKeys.filter(x => x !== id)
+        : expandedItemKeys.concat(id),
+    );
 
   const checkboxAllValue = selectedRowIndexes.length === items.length;
 
@@ -327,6 +336,49 @@ export const Loading = () => {
     <>
       <Checkbox checked={loading} label="Loading" onChange={setLoading} />
       <SimpleTable
+        headers={tableHeaders}
+        items={items}
+        keyExtractor={item => String(item.id)}
+        loading={loading}
+        loadingItems={items.length}
+        selectable={{
+          anySelected: selectedRowIndexes.length > 0,
+          enabled: true,
+          headerCheckboxValue: checkboxAllValue,
+          isRowChecked: (_, index) => selectedRowIndexes.includes(index),
+          onHeaderCheckboxChange: handleCheckboxAllChange,
+          onRowCheckboxChange: handleCheckboxRowChange,
+        }}
+      />
+      <Divider />
+      <SimpleTable
+        bordered
+        collapsible={{
+          collapseContent: items.map(item => ({
+            content: (
+              <table className={styles.collapseTable}>
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Age</th>
+                    <th>Vegan</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>{item.name}</td>
+                    <td>{item.age}</td>
+                    <td>{item.vegan}</td>
+                  </tr>
+                </tbody>
+              </table>
+            ),
+            key: String(item.id),
+          })),
+          enabled: true,
+          expandedItemKeys,
+          toggleItem,
+        }}
         headers={tableHeaders}
         items={items}
         keyExtractor={item => String(item.id)}
@@ -409,7 +461,7 @@ export const Collapsible = () => {
   };
   const collapseContent = items.map(item => ({
     content: (
-      <table style={{ width: '100%' }}>
+      <table className={styles.collapseTable}>
         <thead>
           <tr>
             <th>Name</th>
@@ -419,9 +471,9 @@ export const Collapsible = () => {
         </thead>
         <tbody>
           <tr>
-            <td style={{ border: 'none' }}>{item.name}</td>
-            <td style={{ border: 'none' }}>{item.age}</td>
-            <td style={{ border: 'none' }}>{item.vegan}</td>
+            <td>{item.name}</td>
+            <td>{item.age}</td>
+            <td>{item.vegan}</td>
           </tr>
         </tbody>
       </table>
@@ -666,7 +718,7 @@ export const OnRowClick = () => {
     );
   const collapseContent = items.map(item => ({
     content: (
-      <table style={{ width: '100%' }}>
+      <table className={styles.collapseTable}>
         <thead>
           <tr>
             <th>Name</th>
@@ -676,9 +728,9 @@ export const OnRowClick = () => {
         </thead>
         <tbody>
           <tr>
-            <td style={{ border: 'none' }}>{item.name}</td>
-            <td style={{ border: 'none' }}>{item.age}</td>
-            <td style={{ border: 'none' }}>{item.vegan}</td>
+            <td>{item.name}</td>
+            <td>{item.age}</td>
+            <td>{item.vegan}</td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
## Linear issue

## Description
This PR adjusts the loading styles for the collapse functionality of the SimpleTable. Also adds some better styling to the collapse content in the stories.

## Todo

- [ ] Bump version and add tag
