### PR TITLE
fix: dynamic import look for JS file

### DIFF
--- a/build-utils/build.ts
+++ b/build-utils/build.ts
@@ -63,7 +63,7 @@ const bundlePackage = async (
         include: ['**/FlagIcon.tsx'],
         preventAssignment: true,
         values: {
-          '.tsx': ``,
+          '.tsx': `.js`,
           'src/icons/flags/': '../flags/',
         },
       }),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",


### PR DESCRIPTION
## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR resolves an issue causing webpack to fail to compile the dynamic import. It ended up searching for the `.d.ts` files first.

```
./node_modules/.pnpm/@zonos+amino@5.5.1_@emotion+react@11.11.4_@emotion+styled@11.11.5_@types+react@18.3.12_dayjs@_bucgt74sijkpgdbgwbobd5v7h4/node_modules/@zonos/amino/icons/flags/AI.d.ts
Module parse failed: Unexpected token (2:5)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
| /// <reference types="react" />
> type Props = {
|     borderRadius?: number;
|     height: number;

Import trace for requested module:
./node_modules/.pnpm/@zonos+amino@5.5.1_@emotion+react@11.11.4_@emotion+styled@11.11.5_@types+react@18.3.12_dayjs@_bucgt74sijkpgdbgwbobd5v7h4/node_modules/@zonos/amino/icons/flags/AI.d.ts
./node_modules/.pnpm/@zonos+amino@5.5.1_@emotion+react@11.11.4_@emotion+styled@11.11.5_@types+react@18.3.12_dayjs@_bucgt74sijkpgdbgwbobd5v7h4/node_modules/@zonos/amino/icons/flags/ lazy ^\.\/.*$ namespace object
./node_modules/.pnpm/@zonos+amino@5.5.1_@emotion+react@11.11.4_@emotion+styled@11.11.5_@types+react@18.3.12_dayjs@_bucgt74sijkpgdbgwbobd5v7h4/node_modules/@zonos/amino/icons/flag-icon/FlagIcon.js
./src/components/orders/all/OrdersListPage.tsx
```

Builds in prod/dev for dashboarrd.

## Todo

- [ ] Bump version and add tag
