### PR TITLE
FIX: Checkbox label

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/checkbox/Checkbox.module.scss
+++ b/src/components/checkbox/Checkbox.module.scss
@@ -88,6 +88,11 @@ $disabled-border: var(--amino-checkbox-disabled-border);
   margin-bottom: 0;
 }
 
+.styledSubtitle{
+  margin-left: 24px;
+  margin-top: 4px;
+}
+
 .labelWrapper {
   display: flex;
   align-items: center;

--- a/src/components/checkbox/Checkbox.tsx
+++ b/src/components/checkbox/Checkbox.tsx
@@ -53,26 +53,19 @@ export type CheckboxProps = Omit<
 > &
   BaseProps &
   HelpTextProps & {
-    /**
-     * Don't stop propagation of the click event
-     * @default false
-     */
-    allowPropagation?: boolean;
     checked: boolean;
     disabled?: boolean;
     icon?: ReactNode;
     label?: string;
-    labelComponent?: ReactNode;
     labelDescription?: string;
     onChange: (
       checked: boolean,
       event: ChangeEvent<HTMLInputElement> | KeyboardEvent<HTMLInputElement>,
     ) => void;
-    subtitle?: string;
+    subtitle?: ReactNode;
   };
 
 export const Checkbox = ({
-  allowPropagation = false,
   checked = false,
   className,
   disabled,
@@ -80,7 +73,6 @@ export const Checkbox = ({
   helpText,
   icon,
   label,
-  labelComponent,
   labelDescription,
   onChange,
   style,
@@ -97,9 +89,6 @@ export const Checkbox = ({
   const handleChange = (
     e: ChangeEvent<HTMLInputElement> | KeyboardEvent<HTMLInputElement>,
   ) => {
-    if (!allowPropagation) {
-      e.stopPropagation();
-    }
     if (!disabled) {
       onChange(!checked, e);
     }
@@ -109,7 +98,6 @@ export const Checkbox = ({
     <label
       className={clsx(globalStyles.focusableLabel, styles.wrapper, className)}
       htmlFor={id}
-      onClick={e => !allowPropagation && e.stopPropagation()}
       style={{
         ...style,
         '--amino-checkbox-background': getBackgroundColor(checked, error),
@@ -160,28 +148,28 @@ export const Checkbox = ({
           </AnimatePresence>
         </div>
 
-        {labelComponent ||
-          (label && (
-            <div className={styles.infoWrapper}>
-              <div className={styles.labelWrapper}>
-                {icon}
-                <Text className={styles.styledLabel} type="input-label">
-                  {label}
-                  {labelDescription && (
-                    <span className={styles.styledLabelDescription}>
-                      {labelDescription}
-                    </span>
-                  )}
-                </Text>
-              </div>
-              {subtitle && (
-                <Text className={styles.styledSubtitle} type="subtitle">
-                  {subtitle}
-                </Text>
-              )}
+        {label && (
+          <div className={styles.infoWrapper}>
+            <div className={styles.labelWrapper}>
+              {icon}
+              <Text className={styles.styledLabel} type="input-label">
+                {label}
+                {labelDescription && (
+                  <span className={styles.styledLabelDescription}>
+                    {labelDescription}
+                  </span>
+                )}
+              </Text>
             </div>
-          ))}
+          </div>
+        )}
       </div>
+
+      {subtitle && (
+        <div className={styles.styledSubtitle}>
+          <Text type="subtitle">{subtitle}</Text>
+        </div>
+      )}
 
       <HelpText error={error} helpText={helpText} />
     </label>

--- a/src/components/checkbox/Checkbox.tsx
+++ b/src/components/checkbox/Checkbox.tsx
@@ -57,6 +57,7 @@ export type CheckboxProps = Omit<
     disabled?: boolean;
     icon?: ReactNode;
     label?: string;
+    labelComponent?: ReactNode;
     labelDescription?: string;
     onChange: (
       checked: boolean,
@@ -73,6 +74,7 @@ export const Checkbox = ({
   helpText,
   icon,
   label,
+  labelComponent,
   labelDescription,
   onChange,
   style,
@@ -148,21 +150,22 @@ export const Checkbox = ({
           </AnimatePresence>
         </div>
 
-        {label && (
-          <div className={styles.infoWrapper}>
-            <div className={styles.labelWrapper}>
-              {icon}
-              <Text className={styles.styledLabel} type="input-label">
-                {label}
-                {labelDescription && (
-                  <span className={styles.styledLabelDescription}>
-                    {labelDescription}
-                  </span>
-                )}
-              </Text>
+        {labelComponent ||
+          (label && (
+            <div className={styles.infoWrapper}>
+              <div className={styles.labelWrapper}>
+                {icon}
+                <Text className={styles.styledLabel} type="input-label">
+                  {label}
+                  {labelDescription && (
+                    <span className={styles.styledLabelDescription}>
+                      {labelDescription}
+                    </span>
+                  )}
+                </Text>
+              </div>
             </div>
-          </div>
-        )}
+          ))}
       </div>
 
       {subtitle && (

--- a/src/components/checkbox/__stories__/Checkbox.stories.tsx
+++ b/src/components/checkbox/__stories__/Checkbox.stories.tsx
@@ -74,7 +74,7 @@ export const BasicCheckboxWithoutSubtitle: StoryObj<CheckboxProps> = {
   },
 };
 
-export const CheckboxWithSubstituteLabel: StoryObj<CheckboxProps> = {
+export const CheckboxWithComplexSubtitle: StoryObj<CheckboxProps> = {
   args: {
     helpText: 'This is help text',
     icon: <Default height={16} width={16} />,

--- a/src/components/checkbox/__stories__/Checkbox.stories.tsx
+++ b/src/components/checkbox/__stories__/Checkbox.stories.tsx
@@ -76,11 +76,13 @@ export const BasicCheckboxWithoutSubtitle: StoryObj<CheckboxProps> = {
 
 export const CheckboxWithSubstituteLabel: StoryObj<CheckboxProps> = {
   args: {
+    helpText: 'This is help text',
     icon: <Default height={16} width={16} />,
-    label: 'Input label',
-    labelComponent: (
+    label:
+      'I have read and agree to the Zonos terms of service and UPS agreement',
+    subtitle: (
       <div className={styles.labelComponent}>
-        I have read and agree to the{' '}
+        See{' '}
         <a
           href="https://docs.zonos.com/legal"
           rel="noopener noreferrer"
@@ -103,14 +105,6 @@ export const CheckboxWithSubstituteLabel: StoryObj<CheckboxProps> = {
           target="_blank"
         >
           UPS Rate and Service Guideline
-        </a>
-        , and{' '}
-        <a
-          href="https://www.ups.com/assets/resources/media/terms_service_us.pdf"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          Tariff
         </a>
         .
       </div>

--- a/src/components/select/_StyledReactSelect.tsx
+++ b/src/components/select/_StyledReactSelect.tsx
@@ -244,7 +244,6 @@ export const CheckboxOptionComponent = <
       >
         {selectProps.isMulti ? (
           <Checkbox
-            allowPropagation
             checked={isSelected}
             disabled={isDisabled}
             icon={data.icon}


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->
[CXT-1344: Frontend - Fix checkbox in Amino](https://linear.app/zonos/issue/CXT-1344/frontend-fix-checkbox-in-amino)

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR moves the subtitle out of the checkbox label element. It was causing nested links to be un-clickable and is actually recommended as a poor user experience by [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label#interactive_content). Removed unnecessary props because of this change.

Preview: https://cade.amino.zonos.com/?path=/story/amino-checkbox--checkbox-with-complex-subtitle

Country multiselect still works: https://cade.amino.zonos.com/?path=/story/amino-country-multi-select-countrymultiselectexpanded--basic

## Todo

- [x] Bump version and add tag
