### PR TITLE
Fix: Simple table row click with selectable table bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.5.3",
+  "version": "5.5.4",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/simple-table/SimpleTable.tsx
+++ b/src/components/simple-table/SimpleTable.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, type ReactNode } from 'react';
+import React, { Fragment, type ReactNode, useRef } from 'react';
 
 import clsx from 'clsx';
 
@@ -400,6 +400,7 @@ export const SimpleTable = <T extends object>({
     }
 
     return items.map((item, index) => {
+      const checkboxRef = useRef<HTMLTableCellElement>(null);
       const clickable =
         !!onRowClick ||
         (!!selectable.anySelected && !!selectable.onRowCheckboxChange);
@@ -412,7 +413,10 @@ export const SimpleTable = <T extends object>({
             !noHoverBackground && styles.withHover,
           )}
           onClick={e => {
-            if (selectable.anySelected) {
+            if (
+              selectable.anySelected ||
+              checkboxRef.current?.contains(e.target as Node)
+            ) {
               if (!selectable.isRowCheckboxDisabled?.(item, index)) {
                 e.preventDefault();
                 selectable.onRowCheckboxChange?.(
@@ -428,7 +432,7 @@ export const SimpleTable = <T extends object>({
           onMouseEnter={() => onRowHover?.(item)}
         >
           {selectable.enabled && (
-            <td>
+            <td ref={checkboxRef}>
               {selectable.renderCustomRowCheckbox?.(item, index) || (
                 <Checkbox
                   checked={selectable.isRowChecked?.(item, index) || false}

--- a/src/components/simple-table/__stories__/SimpleTable.stories.tsx
+++ b/src/components/simple-table/__stories__/SimpleTable.stories.tsx
@@ -243,6 +243,9 @@ export const Selectable: StoryObj<SimpleTableProps<object>> = {
         items={items}
         keyExtractor={item => String(item.id)}
         loading={loading}
+        onRowClick={() => {
+          alert(`Should not see this on checkbox click`);
+        }}
         selectable={{
           anySelected: selectedRowIndexes.length > 0,
           enabled: true,


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR makes checkboxes work without triggering a row click

Preview: https://amino-git-fix-components-zonos.vercel.app/?path=/story/amino-simpletable--selectable

Try first click on row and try first click on checkbox

## Todo

- [ ] Bump version and add tag
