### PR TITLE
fix: date filter input bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.5.5",
+  "version": "5.5.6",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/filter/filter-date/FilterDate.tsx
+++ b/src/components/filter/filter-date/FilterDate.tsx
@@ -60,8 +60,14 @@ export const FilterDate = ({
         }
         return date;
       case 'is on or after':
+        if (type === 'end') {
+          return date;
+        }
         return dayjs(date).subtract(1, 'days').format(defaultDateFormat);
       case 'is before or on':
+        if (type === 'begin') {
+          return date;
+        }
         return dayjs(date).add(1, 'days').format(defaultDateFormat);
       default:
         return date;
@@ -78,12 +84,13 @@ export const FilterDate = ({
       dispatch({
         name: 'dateData.dateBegin',
         type: 'change',
-        value: getAdjustedDate({ date: value.dateBegin, type: 'begin' }),
+        value:
+          getAdjustedDate({ date: value.dateBegin, type: 'begin' }) || null,
       });
       dispatch({
         name: 'dateData.dateEnd',
         type: 'change',
-        value: getAdjustedDate({ date: value.dateEnd, type: 'end' }),
+        value: getAdjustedDate({ date: value.dateEnd, type: 'end' }) || null,
       });
       dispatch({
         name: 'dateData.lastCount',
@@ -100,6 +107,8 @@ export const FilterDate = ({
   );
 
   const handleApplyEditingState = useCallback(() => {
+    console.log(editingValue.dateBegin, editingValue.dateEnd);
+
     dispatch({
       name: 'dateRangeType',
       type: 'change',

--- a/src/components/filter/filter-date/FilterDate.tsx
+++ b/src/components/filter/filter-date/FilterDate.tsx
@@ -1,5 +1,7 @@
 import { type Dispatch, useCallback, useState } from 'react';
 
+import dayjs from 'dayjs';
+
 import { DateControls } from 'src/components/filter/filter-date/DateControls';
 import {
   type FilterDateAction,
@@ -13,6 +15,8 @@ import {
   type FilterApplyCallback,
   useFilterWrapper,
 } from 'src/components/filter/useFilterWrapper';
+
+import { defaultDateFormat } from './DateControlsWrapper';
 
 export type FilterDateProps = BaseFilterProps & {
   dispatch: Dispatch<FilterDateAction>;
@@ -37,6 +41,27 @@ export const FilterDate = ({
 
   const [editingFilterText, setEditingFilterText] = useState<string>('');
 
+  // adjusts the date to set the filter to be inclusive of the entered value
+  const getAdjustedDate = (date: string, type: 'begin' | 'end') => {
+    switch (rangeType) {
+      case 'is between':
+      case 'is equal to':
+        if (type === 'begin') {
+          return dayjs(date).subtract(1, 'days').format(defaultDateFormat);
+        }
+        if (type === 'end') {
+          return dayjs(date).add(1, 'days').format(defaultDateFormat);
+        }
+        return date;
+      case 'is on or after':
+        return dayjs(date).subtract(1, 'days').format(defaultDateFormat);
+      case 'is before or on':
+        return dayjs(date).add(1, 'days').format(defaultDateFormat);
+      default:
+        return date;
+    }
+  };
+
   const dispatchDateValues = useCallback(
     (value: FilterDateData) => {
       dispatch({
@@ -47,12 +72,15 @@ export const FilterDate = ({
       dispatch({
         name: 'dateData.dateBegin',
         type: 'change',
-        value: value.dateBegin || null,
+        value:
+          dayjs(value.dateBegin)
+            .subtract(1, 'days')
+            .format(defaultDateFormat) || null,
       });
       dispatch({
         name: 'dateData.dateEnd',
         type: 'change',
-        value: value.dateEnd || null,
+        value: getAdjustedDate(value.dateEnd || '', 'end'),
       });
       dispatch({
         name: 'dateData.lastCount',
@@ -77,12 +105,17 @@ export const FilterDate = ({
     dispatch({
       name: 'dateData.dateBegin',
       type: 'change',
-      value: editingValue.dateBegin || null,
+      value:
+        dayjs(editingValue.dateBegin)
+          .subtract(1, 'days')
+          .format(defaultDateFormat) || null,
     });
     dispatch({
       name: 'dateData.dateEnd',
       type: 'change',
-      value: editingValue.dateEnd || null,
+      value:
+        dayjs(editingValue.dateEnd).add(1, 'days').format(defaultDateFormat) ||
+        null,
     });
     dispatch({
       name: 'dateData.lastCount',

--- a/src/components/filter/filter-date/FilterDate.tsx
+++ b/src/components/filter/filter-date/FilterDate.tsx
@@ -107,8 +107,6 @@ export const FilterDate = ({
   );
 
   const handleApplyEditingState = useCallback(() => {
-    console.log(editingValue.dateBegin, editingValue.dateEnd);
-
     dispatch({
       name: 'dateRangeType',
       type: 'change',

--- a/src/components/filter/filter-date/FilterDate.tsx
+++ b/src/components/filter/filter-date/FilterDate.tsx
@@ -42,7 +42,13 @@ export const FilterDate = ({
   const [editingFilterText, setEditingFilterText] = useState<string>('');
 
   // adjusts the date to set the filter to be inclusive of the entered value
-  const getAdjustedDate = (date: string, type: 'begin' | 'end') => {
+  const getAdjustedDate = ({
+    date,
+    type,
+  }: {
+    date: string | null;
+    type: 'begin' | 'end';
+  }) => {
     switch (rangeType) {
       case 'is between':
       case 'is equal to':
@@ -72,15 +78,12 @@ export const FilterDate = ({
       dispatch({
         name: 'dateData.dateBegin',
         type: 'change',
-        value:
-          dayjs(value.dateBegin)
-            .subtract(1, 'days')
-            .format(defaultDateFormat) || null,
+        value: getAdjustedDate({ date: value.dateBegin, type: 'begin' }),
       });
       dispatch({
         name: 'dateData.dateEnd',
         type: 'change',
-        value: getAdjustedDate(value.dateEnd || '', 'end'),
+        value: getAdjustedDate({ date: value.dateEnd, type: 'end' }),
       });
       dispatch({
         name: 'dateData.lastCount',
@@ -105,17 +108,12 @@ export const FilterDate = ({
     dispatch({
       name: 'dateData.dateBegin',
       type: 'change',
-      value:
-        dayjs(editingValue.dateBegin)
-          .subtract(1, 'days')
-          .format(defaultDateFormat) || null,
+      value: getAdjustedDate({ date: editingValue.dateBegin, type: 'begin' }),
     });
     dispatch({
       name: 'dateData.dateEnd',
       type: 'change',
-      value:
-        dayjs(editingValue.dateEnd).add(1, 'days').format(defaultDateFormat) ||
-        null,
+      value: getAdjustedDate({ date: editingValue.dateEnd, type: 'end' }),
     });
     dispatch({
       name: 'dateData.lastCount',

--- a/src/components/filter/filter-date/_DateControls/_IsBeforeOrOn.tsx
+++ b/src/components/filter/filter-date/_DateControls/_IsBeforeOrOn.tsx
@@ -20,13 +20,11 @@ export const IsBeforeOrOn = ({
     [value],
   );
 
-  const displayDate = dayjs(date).subtract(1, 'days').format(defaultDateFormat);
-
   const handleChange = useCallback(
     (val: string) => {
       onChange({
         dateBegin: null,
-        dateEnd: dayjs(val).add(1, 'days').format(defaultDateFormat),
+        dateEnd: val,
         lastCount: 5,
         lastUnit: 'days',
       });
@@ -35,13 +33,13 @@ export const IsBeforeOrOn = ({
   );
 
   useEffect(() => {
-    const filterText = `Ending on ${formatDate(displayDate)}`;
+    const filterText = `Ending on ${formatDate(date)}`;
     onChangeFilterText(filterText);
-  }, [displayDate, onChangeFilterText]);
+  }, [date, onChangeFilterText]);
 
   useEffect(() => {
-    handleChange(displayDate);
-  }, [displayDate, handleChange]);
+    handleChange(date);
+  }, [date, handleChange]);
 
   return (
     <DateControlsWrapper>
@@ -49,7 +47,7 @@ export const IsBeforeOrOn = ({
         onChange={ev => handleChange(ev.target.value)}
         size="sm"
         type="date"
-        value={displayDate}
+        value={date}
       />
     </DateControlsWrapper>
   );

--- a/src/components/filter/filter-date/_DateControls/_IsBetween.tsx
+++ b/src/components/filter/filter-date/_DateControls/_IsBetween.tsx
@@ -19,25 +19,17 @@ export const IsBetween = ({
 }: _DateControlProps) => {
   const { dateBegin, dateEnd } = useMemo(
     () => ({
-      dateBegin:
-        value.dateBegin ||
-        dayjs().subtract(1, 'days').format(defaultDateFormat),
-      dateEnd:
-        value.dateEnd || dayjs().add(1, 'days').format(defaultDateFormat),
+      dateBegin: value.dateBegin || dayjs().format(defaultDateFormat),
+      dateEnd: value.dateEnd || dayjs().format(defaultDateFormat),
     }),
     [value],
   );
 
-  const displayDateEnd = dayjs(dateEnd)
-    .subtract(1, 'days')
-    .format(defaultDateFormat);
-  const displayDateBegin = dayjs(dateBegin)
-    .add(1, 'days')
-    .format(defaultDateFormat);
-
+  const displayDateEnd = dateEnd;
+  const displayDateBegin = dateBegin;
   const handleChangeDateBegin = (val: string) => {
     onChange({
-      dateBegin: dayjs(val).subtract(1, 'days').format(defaultDateFormat),
+      dateBegin: val,
       dateEnd,
       lastCount: 5,
       lastUnit: 'days',
@@ -47,7 +39,7 @@ export const IsBetween = ({
   const handleChangeDateEnd = (val: string) => {
     onChange({
       dateBegin,
-      dateEnd: dayjs(val).add(1, 'days').format(defaultDateFormat),
+      dateEnd: val,
       lastCount: 5,
       lastUnit: 'days',
     });

--- a/src/components/filter/filter-date/_DateControls/_IsEqualTo.tsx
+++ b/src/components/filter/filter-date/_DateControls/_IsEqualTo.tsx
@@ -20,13 +20,11 @@ export const IsEqualTo = ({
     [value],
   );
 
-  const displayDate = dayjs(date).add(1, 'days').format(defaultDateFormat);
-
   const handleChange = useCallback(
     (val: string) => {
       onChange({
-        dateBegin: dayjs(val).subtract(1, 'days').format(defaultDateFormat),
-        dateEnd: dayjs(val).add(1, 'days').format(defaultDateFormat),
+        dateBegin: val,
+        dateEnd: val,
         lastCount: 5,
         lastUnit: 'days',
       });
@@ -35,12 +33,12 @@ export const IsEqualTo = ({
   );
 
   useEffect(() => {
-    onChangeFilterText(`On ${formatDate(displayDate)}`);
-  }, [displayDate, onChangeFilterText]);
+    onChangeFilterText(`On ${formatDate(date)}`);
+  }, [date, onChangeFilterText]);
 
   useEffect(() => {
-    handleChange(displayDate);
-  }, [displayDate, handleChange]);
+    handleChange(date);
+  }, [date, handleChange]);
 
   return (
     <DateControlsWrapper>
@@ -48,7 +46,7 @@ export const IsEqualTo = ({
         onChange={ev => handleChange(ev.target.value)}
         size="sm"
         type="date"
-        value={displayDate}
+        value={date}
       />
     </DateControlsWrapper>
   );

--- a/src/components/filter/filter-date/_DateControls/_IsOnOrAfter.tsx
+++ b/src/components/filter/filter-date/_DateControls/_IsOnOrAfter.tsx
@@ -20,12 +20,10 @@ export const IsOnOrAfter = ({
     [value],
   );
 
-  const displayDate = dayjs(date).add(1, 'days').format(defaultDateFormat);
-
   const handleChange = useCallback(
     (val: string) => {
       onChange({
-        dateBegin: dayjs(val).subtract(1, 'days').format(defaultDateFormat),
+        dateBegin: val,
         dateEnd: null,
         lastCount: 5,
         lastUnit: 'days',
@@ -35,13 +33,13 @@ export const IsOnOrAfter = ({
   );
 
   useEffect(() => {
-    const filterText = `Starting from ${formatDate(displayDate)}`;
+    const filterText = `Starting from ${formatDate(date)}`;
     onChangeFilterText(filterText);
-  }, [displayDate, onChangeFilterText]);
+  }, [date, onChangeFilterText]);
 
   useEffect(() => {
-    handleChange(displayDate);
-  }, [displayDate, handleChange]);
+    handleChange(date);
+  }, [date, handleChange]);
 
   return (
     <DateControlsWrapper>
@@ -49,7 +47,7 @@ export const IsOnOrAfter = ({
         onChange={ev => handleChange(ev.target.value)}
         size="sm"
         type="date"
-        value={displayDate}
+        value={date}
       />
     </DateControlsWrapper>
   );


### PR DESCRIPTION
## Description
This PR fixes a bug in the Date Filter where typing the date into the date inputs was incredibly buggy and difficult to use.

## Preview
**Before**
<https://amino.zonos.com/?path=/story/amino-filters--date>

**After**
<https://nick.amino.zonos.com/?path=/story/amino-filters--date>

Functionality should be the same between the two versions, but typing the dates will be more intuitive in the **After**

## Todo

- [x] Bump version and add tag
