### PR TITLE
FIX: Simple table useRef bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.5.4",
+  "version": "5.5.5",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/all.ts
+++ b/src/all.ts
@@ -75,6 +75,7 @@ import './components/select/CountrySelect';
 import './components/select/MultiSelect';
 import './components/select/Select';
 import './components/simple-table/SimpleTable';
+import './components/simple-table/SimpleTableRow';
 import './components/skeleton/Skeleton';
 import './components/slide-over/SlideOver';
 import './components/spinner/Spinner';

--- a/src/components/filter/FilterWrapper.module.scss
+++ b/src/components/filter/FilterWrapper.module.scss
@@ -70,7 +70,7 @@ $border-right-color: var(--amino-filter-wrapper-border-right-color);
 }
 
 .dropdownWrapper {
-  z-index: 1;
+  z-index: 5;
   display: flex;
   min-width: 400px;
   position: absolute;

--- a/src/components/simple-table/SimpleTable.module.scss
+++ b/src/components/simple-table/SimpleTable.module.scss
@@ -1,7 +1,5 @@
 @use 'theme';
 
-$cellMinWidth: var(--amino-cell-min-width);
-
 .tableContainer {
   width: 100%;
 }
@@ -11,6 +9,12 @@ $cellMinWidth: var(--amino-cell-min-width);
   border-collapse: separate;
   border-spacing: 0;
   font-size: theme.$amino-font-size-base;
+
+  tr > td {
+    &.skeletonCellWrapper {
+      display: flex;
+    }
+  }
 
   &.noHeaders {
     thead {
@@ -71,96 +75,11 @@ $cellMinWidth: var(--amino-cell-min-width);
     }
   }
 
-  > tbody {
-    > tr {
-      height: 48px;
-
-      &.withHover:hover {
-        background-color: theme.$amino-hover-color;
-      }
-
-      &.clickable {
-        cursor: pointer;
-      }
-
-      &:not(:hover) {
-        :global(.row-hover-show) {
-          visibility: collapse;
-        }
-      }
-
-      > td {
-        border-bottom: theme.$amino-border-subtle;
-        padding: 0;
-
-        > :first-child {
-          display: block;
-          height: 100%;
-          width: 100%;
-          padding: 12px;
-          white-space: nowrap;
-
-          &:global(.tooltip-wrapper) {
-            padding: 0;
-
-            > a {
-              display: inline-flex;
-              padding: 12px;
-              width: 100%;
-              height: 100%;
-            }
-          }
-
-          &.noPadding {
-            padding: 0;
-          }
-
-          &.allowTextWrap {
-            white-space: normal;
-          }
-
-          &.loading {
-            text-align: center;
-          }
-
-          &.skeletonCellWrapper {
-            display: flex;
-          }
-
-          &:not(:hover) {
-            :global(.cell-hover-show) {
-              visibility: collapse;
-            }
-          }
-        }
-
-        &.shouldTruncate {
-          max-width: $cellMinWidth;
-          min-width: $cellMinWidth;
-          > :first-child {
-            // Truncating the first child will cover most cases.
-            // For custom rendered cells, these 3 properties may need to be apply to deeply nested children on a per need basis.
-            overflow: hidden;
-            text-overflow: ellipsis;
-          }
-        }
-      }
-    }
-  }
-
   &.collapsible {
     tr > td:last-child {
       width: 40px;
       > div {
         padding: 0;
-      }
-    }
-    &.bordered {
-      tr:nth-last-child(2).collapsed td:first-child {
-        border-bottom-left-radius: 12px;
-      }
-      tr:nth-last-child(2).collapsed td:last-child {
-        border-bottom-right-radius: 12px;
       }
     }
     > tbody {
@@ -170,20 +89,6 @@ $cellMinWidth: var(--amino-cell-min-width);
 
       > tr:not(:has(.loading)) {
         height: unset;
-
-        &:not(.collapsed) {
-          td {
-            border-bottom: theme.$amino-border-subtle;
-          }
-        }
-        &.collapsed.hasContent {
-          & + tr > td {
-            border: 0;
-          }
-          + tr > td > :first-child {
-            padding: 0;
-          }
-        }
       }
     }
   }

--- a/src/components/simple-table/SimpleTable.module.scss.d.ts
+++ b/src/components/simple-table/SimpleTable.module.scss.d.ts
@@ -1,15 +1,9 @@
-export declare const allowTextWrap: string;
 export declare const bordered: string;
-export declare const clickable: string;
-export declare const collapsed: string;
 export declare const collapsible: string;
-export declare const hasContent: string;
 export declare const loading: string;
 export declare const noHeaders: string;
 export declare const noPadding: string;
-export declare const shouldTruncate: string;
 export declare const skeletonCellWrapper: string;
 export declare const styledCheckbox: string;
 export declare const tableContainer: string;
 export declare const tableStyled: string;
-export declare const withHover: string;

--- a/src/components/simple-table/SimpleTable.tsx
+++ b/src/components/simple-table/SimpleTable.tsx
@@ -243,21 +243,26 @@ export const SimpleTable = <T extends object>({
       ));
     }
 
-    return items.map((item, index) => (
-      <SimpleTableRow
-        CustomLinkComponent={CustomLinkComponent}
-        collapsible={collapsible}
-        getRowLink={getRowLink}
-        headers={headers}
-        index={index}
-        item={item}
-        keyExtractor={keyExtractor}
-        noHoverBackground={noHoverBackground}
-        onRowClick={onRowClick}
-        onRowHover={onRowHover}
-        selectable={selectable}
-      />
-    ));
+    return items.map((item, index) => {
+      const key = keyExtractor(item);
+
+      return (
+        <SimpleTableRow
+          key={key}
+          CustomLinkComponent={CustomLinkComponent}
+          collapsible={collapsible}
+          getRowLink={getRowLink}
+          headers={headers}
+          index={index}
+          item={item}
+          noHoverBackground={noHoverBackground}
+          onRowClick={onRowClick}
+          onRowHover={onRowHover}
+          rowKey={key}
+          selectable={selectable}
+        />
+      );
+    });
   };
 
   return (

--- a/src/components/simple-table/SimpleTable.tsx
+++ b/src/components/simple-table/SimpleTable.tsx
@@ -1,16 +1,15 @@
-import React, { Fragment, type ReactNode, useRef } from 'react';
+import React, { type ReactNode } from 'react';
 
 import clsx from 'clsx';
 
 import { Checkbox } from 'src/components/checkbox/Checkbox';
 import { Skeleton } from 'src/components/skeleton/Skeleton';
-import { TableRowCollapse } from 'src/components/table/TableRowCollapse';
 import { Text } from 'src/components/text/Text';
-import { Tooltip } from 'src/components/tooltip/Tooltip';
 import type { BaseProps } from 'src/types/BaseProps';
 import type { ReactComponent } from 'src/types/ReactComponent';
 
 import styles from './SimpleTable.module.scss';
+import { SimpleTableRow } from './SimpleTableRow';
 
 const getFlexAlignment = (alignment: SimpleTableHeaderBaseProps['align']) => {
   switch (alignment) {
@@ -24,23 +23,7 @@ const getFlexAlignment = (alignment: SimpleTableHeaderBaseProps['align']) => {
   }
 };
 
-const getTooltipPlacement = (
-  alignment: SimpleTableHeaderBaseProps['align'],
-) => {
-  switch (alignment) {
-    case 'center':
-      return 'bottom';
-    case 'end':
-      return 'bottom-end';
-    case 'start':
-    default:
-      return 'bottom-start';
-  }
-};
-
-const tooltipDelay = 800;
-
-type SimpleTableHeaderBaseProps = {
+export type SimpleTableHeaderBaseProps = {
   /**
    * Text alignment for a column
    * @default 'start'
@@ -220,90 +203,6 @@ export const SimpleTable = <T extends object>({
   },
   style,
 }: SimpleTableProps<T>) => {
-  const renderHeader = (header: SimpleTableHeader<T>, item: T) => {
-    const value = item[header.key];
-
-    const renderContent = (content: ReactNode) => {
-      const hasRowHoverShowChild = React.Children.toArray(content).some(
-        child => {
-          if (React.isValidElement(child)) {
-            return /row-hover-show|cell-hover-show/.test(child.props.className);
-          }
-          return false;
-        },
-      );
-
-      // If the cell has a child that should only show on hover, don't allow truncating
-      const tdClassNames = clsx(
-        header.textWrapMethod === 'truncate' &&
-          !hasRowHoverShowChild &&
-          styles.shouldTruncate,
-      );
-
-      const containerStyle = {
-        '--amino-cell-min-width': `${header.minWidth || 0}px`,
-      };
-
-      const cellClassNames = clsx(
-        header.noPadding && styles.noPadding,
-        header.textWrapMethod === 'normal' && styles.allowTextWrap,
-      );
-
-      const cellStyle = {
-        textAlign: header.align || 'start',
-      };
-
-      const tooltipPlacement = getTooltipPlacement(header.align);
-
-      if (getRowLink && !selectable.anySelected && !header.disabledLink) {
-        const LinkComponent = CustomLinkComponent || 'a';
-
-        return (
-          <td className={tdClassNames} style={containerStyle}>
-            <Tooltip
-              disabled={header.textWrapMethod !== 'truncate'}
-              enterDelay={tooltipDelay}
-              enterNextDelay={tooltipDelay}
-              placement={tooltipPlacement}
-              subtitle={content}
-            >
-              <LinkComponent
-                className={cellClassNames}
-                href={getRowLink(item)}
-                style={cellStyle}
-              >
-                {content}
-              </LinkComponent>
-            </Tooltip>
-          </td>
-        );
-      }
-
-      return (
-        <td className={tdClassNames} style={containerStyle}>
-          <Tooltip
-            disabled={header.textWrapMethod !== 'truncate'}
-            enterDelay={tooltipDelay}
-            enterNextDelay={tooltipDelay}
-            placement={tooltipPlacement}
-            subtitle={content}
-          >
-            {/* Child div required for proper truncating */}
-            <span className={cellClassNames} style={cellStyle}>
-              {content}
-            </span>
-          </Tooltip>
-        </td>
-      );
-    };
-
-    return header.renderCustom ? (
-      <>{renderContent(header.renderCustom(value, item))}</>
-    ) : (
-      <>{renderContent(String(value))}</>
-    );
-  };
-
   const renderRows = () => {
     if (loading) {
       return [...Array(loadingItems).keys()].map(n => (
@@ -344,114 +243,21 @@ export const SimpleTable = <T extends object>({
       ));
     }
 
-    if (collapsible.enabled && collapsible.collapseContent?.length) {
-      const { collapseContent, expandedItemKeys, toggleItem } = collapsible;
-      return items.map((item, index) => {
-        const key = keyExtractor(item);
-        const collapsed = !expandedItemKeys.includes(key);
-        const rowCollapseContent = collapseContent?.find(
-          x => x.key === key,
-        )?.content;
-        return (
-          <TableRowCollapse
-            key={key}
-            className={clsx(
-              !noHoverBackground && styles.withHover,
-              collapsed && styles.collapsed,
-              rowCollapseContent && styles.hasContent,
-            )}
-            collapsed={collapsed}
-            onToggleCollapse={() => {
-              toggleItem(key);
-              onRowClick?.(item);
-            }}
-            rowContent={
-              <>
-                {selectable.enabled && (
-                  <td>
-                    {selectable.renderCustomRowCheckbox?.(item, index) || (
-                      <Checkbox
-                        checked={
-                          selectable.isRowChecked?.(item, index) || false
-                        }
-                        disabled={
-                          selectable.isRowCheckboxDisabled?.(item, index) ||
-                          false
-                        }
-                        onChange={checked =>
-                          selectable.onRowCheckboxChange?.(checked, item, index)
-                        }
-                      />
-                    )}
-                  </td>
-                )}
-                {headers.map(header => (
-                  <Fragment key={header.key}>
-                    {renderHeader(header, item)}
-                  </Fragment>
-                ))}
-              </>
-            }
-          >
-            {rowCollapseContent}
-          </TableRowCollapse>
-        );
-      });
-    }
-
-    return items.map((item, index) => {
-      const checkboxRef = useRef<HTMLTableCellElement>(null);
-      const clickable =
-        !!onRowClick ||
-        (!!selectable.anySelected && !!selectable.onRowCheckboxChange);
-
-      return (
-        <tr
-          key={keyExtractor(item)}
-          className={clsx(
-            clickable && styles.clickable,
-            !noHoverBackground && styles.withHover,
-          )}
-          onClick={e => {
-            if (
-              selectable.anySelected ||
-              checkboxRef.current?.contains(e.target as Node)
-            ) {
-              if (!selectable.isRowCheckboxDisabled?.(item, index)) {
-                e.preventDefault();
-                selectable.onRowCheckboxChange?.(
-                  !selectable.isRowChecked?.(item, index),
-                  item,
-                  index,
-                );
-              }
-            } else {
-              onRowClick?.(item);
-            }
-          }}
-          onMouseEnter={() => onRowHover?.(item)}
-        >
-          {selectable.enabled && (
-            <td ref={checkboxRef}>
-              {selectable.renderCustomRowCheckbox?.(item, index) || (
-                <Checkbox
-                  checked={selectable.isRowChecked?.(item, index) || false}
-                  disabled={
-                    selectable.isRowCheckboxDisabled?.(item, index) || false
-                  }
-                  onChange={checked =>
-                    selectable.onRowCheckboxChange?.(checked, item, index)
-                  }
-                />
-              )}
-            </td>
-          )}
-          {headers.map(header => (
-            <Fragment key={header.key}>{renderHeader(header, item)}</Fragment>
-          ))}
-        </tr>
-      );
-    });
+    return items.map((item, index) => (
+      <SimpleTableRow
+        CustomLinkComponent={CustomLinkComponent}
+        collapsible={collapsible}
+        getRowLink={getRowLink}
+        headers={headers}
+        index={index}
+        item={item}
+        keyExtractor={keyExtractor}
+        noHoverBackground={noHoverBackground}
+        onRowClick={onRowClick}
+        onRowHover={onRowHover}
+        selectable={selectable}
+      />
+    ));
   };
 
   return (

--- a/src/components/simple-table/SimpleTableRow.module.scss
+++ b/src/components/simple-table/SimpleTableRow.module.scss
@@ -1,0 +1,105 @@
+@use 'theme';
+
+$cellMinWidth: var(--amino-cell-min-width);
+
+table {
+  &.bordered {
+    tr:nth-last-child(2).collapsed td:first-child {
+      border-bottom-left-radius: 12px;
+    }
+    tr:nth-last-child(2).collapsed td:last-child {
+      border-bottom-right-radius: 12px;
+    }
+  }
+
+  tr {
+    height: 48px;
+
+    &.withHover:hover {
+      background-color: theme.$amino-hover-color;
+    }
+
+    &.clickable {
+      cursor: pointer;
+    }
+
+    &:not(:hover) {
+      :global(.row-hover-show) {
+        visibility: collapse;
+      }
+    }
+
+    > td {
+      border-bottom: theme.$amino-border-subtle;
+      padding: 0;
+
+      > :first-child {
+        display: block;
+        height: 100%;
+        width: 100%;
+        padding: 12px;
+        white-space: nowrap;
+
+        &:global(.tooltip-wrapper) {
+          padding: 0;
+
+          > a {
+            padding: 12px;
+            width: 100%;
+            height: 100%;
+          }
+
+          span {
+            padding: 12px;
+            width: 100%;
+            height: 100%;
+          }
+        }
+
+        &.noPadding {
+          padding: 0;
+        }
+
+        &.allowTextWrap {
+          white-space: normal;
+        }
+
+        &.loading {
+          text-align: center;
+        }
+
+        &:not(:hover) {
+          :global(.cell-hover-show) {
+            visibility: collapse;
+          }
+        }
+      }
+
+      &.shouldTruncate {
+        max-width: $cellMinWidth;
+        min-width: $cellMinWidth;
+        > :first-child {
+          // Truncating the first child will cover most cases.
+          // For custom rendered cells, these 3 properties may need to be apply to deeply nested children on a per need basis.
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+      }
+    }
+
+    &:not(.collapsed) {
+      td {
+        border-bottom: theme.$amino-border-subtle;
+      }
+    }
+
+    &.collapsed.hasContent {
+      & + tr > td {
+        border: 0;
+      }
+      + tr > td > :first-child {
+        padding: 0;
+      }
+    }
+  }
+}

--- a/src/components/simple-table/SimpleTableRow.module.scss.d.ts
+++ b/src/components/simple-table/SimpleTableRow.module.scss.d.ts
@@ -1,0 +1,9 @@
+export declare const allowTextWrap: string;
+export declare const bordered: string;
+export declare const clickable: string;
+export declare const collapsed: string;
+export declare const hasContent: string;
+export declare const loading: string;
+export declare const noPadding: string;
+export declare const shouldTruncate: string;
+export declare const withHover: string;

--- a/src/components/simple-table/SimpleTableRow.tsx
+++ b/src/components/simple-table/SimpleTableRow.tsx
@@ -36,10 +36,10 @@ type SimpleTableRowProps<T extends object> = {
   headers: SimpleTableHeader<T>[];
   index: number;
   item: T;
-  keyExtractor: SimpleTableProps<T>['keyExtractor'];
   noHoverBackground: boolean;
   onRowClick?: (item: T) => void;
   onRowHover?: (item: T) => void;
+  rowKey: string;
   selectable: SimpleTableProps<T>['selectable'];
 };
 
@@ -50,13 +50,12 @@ export const SimpleTableRow = <T extends object>({
   headers,
   index,
   item,
-  keyExtractor,
   noHoverBackground,
   onRowClick,
   onRowHover,
+  rowKey,
   selectable,
 }: SimpleTableRowProps<T>) => {
-  const key = keyExtractor(item);
   const checkboxRef = useRef<HTMLTableCellElement>(null);
 
   const renderHeader = (header: SimpleTableHeader<T>) => {
@@ -168,14 +167,14 @@ export const SimpleTableRow = <T extends object>({
 
   if (collapsible?.enabled && collapsible.collapseContent?.length) {
     const { collapseContent, expandedItemKeys, toggleItem } = collapsible;
-    const collapsed = !expandedItemKeys.includes(key);
+    const collapsed = !expandedItemKeys.includes(rowKey);
     const rowCollapseContent = collapseContent?.find(
-      x => x.key === key,
+      x => x.key === rowKey,
     )?.content;
 
     return (
       <TableRowCollapse
-        key={key}
+        key={rowKey}
         className={clsx(
           !noHoverBackground && styles.withHover,
           collapsed && styles.collapsed,
@@ -183,7 +182,7 @@ export const SimpleTableRow = <T extends object>({
         )}
         collapsed={collapsed}
         onToggleCollapse={() => {
-          toggleItem(key);
+          toggleItem(rowKey);
           onRowClick?.(item);
         }}
         rowContent={renderRowContent()}
@@ -199,6 +198,7 @@ export const SimpleTableRow = <T extends object>({
 
   return (
     <tr
+      key={rowKey}
       className={clsx(
         clickable && styles.clickable,
         !noHoverBackground && styles.withHover,

--- a/src/components/simple-table/SimpleTableRow.tsx
+++ b/src/components/simple-table/SimpleTableRow.tsx
@@ -1,0 +1,228 @@
+import React, { Fragment, type ReactNode, useRef } from 'react';
+
+import clsx from 'clsx';
+
+import { Checkbox } from 'src/components/checkbox/Checkbox';
+import { TableRowCollapse } from 'src/components/table/TableRowCollapse';
+import { Tooltip } from 'src/components/tooltip/Tooltip';
+
+import type {
+  SimpleTableHeader,
+  SimpleTableHeaderBaseProps,
+  SimpleTableProps,
+} from './SimpleTable';
+import styles from './SimpleTableRow.module.scss';
+
+const getTooltipPlacement = (
+  alignment: SimpleTableHeaderBaseProps['align'],
+) => {
+  switch (alignment) {
+    case 'center':
+      return 'bottom';
+    case 'end':
+      return 'bottom-end';
+    case 'start':
+    default:
+      return 'bottom-start';
+  }
+};
+
+const tooltipDelay = 800;
+
+type SimpleTableRowProps<T extends object> = {
+  CustomLinkComponent?: SimpleTableProps<T>['CustomLinkComponent'];
+  collapsible: SimpleTableProps<T>['collapsible'];
+  getRowLink?: (item: T) => string;
+  headers: SimpleTableHeader<T>[];
+  index: number;
+  item: T;
+  keyExtractor: SimpleTableProps<T>['keyExtractor'];
+  noHoverBackground: boolean;
+  onRowClick?: (item: T) => void;
+  onRowHover?: (item: T) => void;
+  selectable: SimpleTableProps<T>['selectable'];
+};
+
+export const SimpleTableRow = <T extends object>({
+  collapsible,
+  CustomLinkComponent,
+  getRowLink,
+  headers,
+  index,
+  item,
+  keyExtractor,
+  noHoverBackground,
+  onRowClick,
+  onRowHover,
+  selectable,
+}: SimpleTableRowProps<T>) => {
+  const key = keyExtractor(item);
+  const checkboxRef = useRef<HTMLTableCellElement>(null);
+
+  const renderHeader = (header: SimpleTableHeader<T>) => {
+    const value = item[header.key];
+
+    const renderContent = (content: ReactNode) => {
+      const hasRowHoverShowChild = React.Children.toArray(content).some(
+        child => {
+          if (React.isValidElement(child)) {
+            return /row-hover-show|cell-hover-show/.test(child.props.className);
+          }
+          return false;
+        },
+      );
+
+      // If the cell has a child that should only show on hover, don't allow truncating
+      const tdClassNames = clsx(
+        header.textWrapMethod === 'truncate' &&
+          !hasRowHoverShowChild &&
+          styles.shouldTruncate,
+      );
+
+      const containerStyle = {
+        '--amino-cell-min-width': `${header.minWidth || 0}px`,
+      };
+
+      const cellClassNames = clsx(
+        header.noPadding && styles.noPadding,
+        header.textWrapMethod === 'normal' && styles.allowTextWrap,
+      );
+
+      const cellStyle = {
+        textAlign: header.align || 'start',
+      };
+
+      const tooltipPlacement = getTooltipPlacement(header.align);
+
+      if (getRowLink && !selectable?.anySelected && !header.disabledLink) {
+        const LinkComponent = CustomLinkComponent || 'a';
+
+        return (
+          <td className={tdClassNames} style={containerStyle}>
+            <Tooltip
+              disabled={header.textWrapMethod !== 'truncate'}
+              enterDelay={tooltipDelay}
+              enterNextDelay={tooltipDelay}
+              placement={tooltipPlacement}
+              subtitle={content}
+            >
+              <LinkComponent
+                className={cellClassNames}
+                href={getRowLink(item)}
+                style={cellStyle}
+              >
+                {content}
+              </LinkComponent>
+            </Tooltip>
+          </td>
+        );
+      }
+
+      return (
+        <td className={tdClassNames} style={containerStyle}>
+          <Tooltip
+            disabled={header.textWrapMethod !== 'truncate'}
+            enterDelay={tooltipDelay}
+            enterNextDelay={tooltipDelay}
+            placement={tooltipPlacement}
+            subtitle={content}
+          >
+            {/* Child div required for proper truncating */}
+            <span className={cellClassNames} style={cellStyle}>
+              {content}
+            </span>
+          </Tooltip>
+        </td>
+      );
+    };
+
+    return header.renderCustom ? (
+      <>{renderContent(header.renderCustom(value, item))}</>
+    ) : (
+      <>{renderContent(String(value))}</>
+    );
+  };
+
+  const renderRowContent = () => (
+    <>
+      {selectable?.enabled && (
+        <td ref={checkboxRef}>
+          {selectable?.renderCustomRowCheckbox?.(item, index) || (
+            <Checkbox
+              checked={selectable?.isRowChecked?.(item, index) || false}
+              disabled={
+                selectable?.isRowCheckboxDisabled?.(item, index) || false
+              }
+              onChange={checked =>
+                selectable?.onRowCheckboxChange?.(checked, item, index)
+              }
+            />
+          )}
+        </td>
+      )}
+      {headers.map(header => (
+        <Fragment key={header.key}>{renderHeader(header)}</Fragment>
+      ))}
+    </>
+  );
+
+  if (collapsible?.enabled && collapsible.collapseContent?.length) {
+    const { collapseContent, expandedItemKeys, toggleItem } = collapsible;
+    const collapsed = !expandedItemKeys.includes(key);
+    const rowCollapseContent = collapseContent?.find(
+      x => x.key === key,
+    )?.content;
+
+    return (
+      <TableRowCollapse
+        key={key}
+        className={clsx(
+          !noHoverBackground && styles.withHover,
+          collapsed && styles.collapsed,
+          rowCollapseContent && styles.hasContent,
+        )}
+        collapsed={collapsed}
+        onToggleCollapse={() => {
+          toggleItem(key);
+          onRowClick?.(item);
+        }}
+        rowContent={renderRowContent()}
+      >
+        {rowCollapseContent}
+      </TableRowCollapse>
+    );
+  }
+
+  const clickable =
+    !!onRowClick ||
+    (!!selectable?.anySelected && !!selectable?.onRowCheckboxChange);
+
+  return (
+    <tr
+      className={clsx(
+        clickable && styles.clickable,
+        !noHoverBackground && styles.withHover,
+      )}
+      onClick={e => {
+        if (
+          selectable?.anySelected ||
+          checkboxRef.current?.contains(e.target as Node)
+        ) {
+          if (!selectable?.isRowCheckboxDisabled?.(item, index)) {
+            e.preventDefault();
+            selectable?.onRowCheckboxChange?.(
+              !selectable?.isRowChecked?.(item, index),
+              item,
+              index,
+            );
+          }
+        } else {
+          onRowClick?.(item);
+        }
+      }}
+      onMouseEnter={() => onRowHover?.(item)}
+    >
+      {renderRowContent()}
+    </tr>
+  );
+};


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->

## Preview

https://amino-git-fix-components-zonos.vercel.app/?path=/story/amino-simpletable--basic

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR moves table rows into a child component `SimpleTableRow`. This ref code previously violated React's Rules of Hooks by introducing a dynamic number of hook calls between renders because we were calling `useRef` directly in a mapped list. Creating the ref within a child component will fix this issue. This change makes the files a little easier to read as well. 

I ran these changes locally in dashboard and everything is looking good. All tests passing still.

This PR also:
- adds a higher z-index to filters so the dropdowns stop getting cut off by table headers.
- fixes some bugs noticed with truncating.


## Todo

- [x] Bump version and add tag
