### PR TITLE
FIX: Simple table styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.5.6",
+  "version": "5.5.7",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/simple-table/SimpleTable.module.scss
+++ b/src/components/simple-table/SimpleTable.module.scss
@@ -10,9 +10,17 @@
   border-spacing: 0;
   font-size: theme.$amino-font-size-base;
 
-  tr > td {
-    &.skeletonCellWrapper {
-      display: flex;
+  > tbody {
+    > tr {
+      height: 48px;
+      > td {
+        &.skeletonCellWrapper {
+          display: flex;
+        }
+        &.loading {
+          padding: 12px;
+        }
+      }
     }
   }
 

--- a/src/components/simple-table/SimpleTable.tsx
+++ b/src/components/simple-table/SimpleTable.tsx
@@ -250,6 +250,7 @@ export const SimpleTable = <T extends object>({
         <SimpleTableRow
           key={key}
           CustomLinkComponent={CustomLinkComponent}
+          bordered={bordered}
           collapsible={collapsible}
           getRowLink={getRowLink}
           headers={headers}

--- a/src/components/simple-table/SimpleTableRow.module.scss
+++ b/src/components/simple-table/SimpleTableRow.module.scss
@@ -2,104 +2,102 @@
 
 $cellMinWidth: var(--amino-cell-min-width);
 
-table {
+.styledTr {
+  height: 48px;
+
   &.bordered {
-    tr:nth-last-child(2).collapsed td:first-child {
+    &:nth-last-child(2).collapsed td:first-child {
       border-bottom-left-radius: 12px;
     }
-    tr:nth-last-child(2).collapsed td:last-child {
+    &:nth-last-child(2).collapsed td:last-child {
       border-bottom-right-radius: 12px;
     }
   }
 
-  tr {
-    height: 48px;
+  &.withHover:hover {
+    background-color: theme.$amino-hover-color;
+  }
 
-    &.withHover:hover {
-      background-color: theme.$amino-hover-color;
+  &.clickable {
+    cursor: pointer;
+  }
+
+  &:not(:hover) {
+    :global(.row-hover-show) {
+      visibility: collapse;
     }
+  }
 
-    &.clickable {
-      cursor: pointer;
-    }
+  > td {
+    border-bottom: theme.$amino-border-subtle;
+    padding: 0;
 
-    &:not(:hover) {
-      :global(.row-hover-show) {
-        visibility: collapse;
-      }
-    }
+    > :first-child {
+      display: block;
+      height: 100%;
+      width: 100%;
+      padding: 12px;
+      white-space: nowrap;
 
-    > td {
-      border-bottom: theme.$amino-border-subtle;
-      padding: 0;
+      &:global(.tooltip-wrapper) {
+        padding: 0;
 
-      > :first-child {
-        display: block;
-        height: 100%;
-        width: 100%;
-        padding: 12px;
-        white-space: nowrap;
-
-        &:global(.tooltip-wrapper) {
-          padding: 0;
-
-          > a {
-            padding: 12px;
-            width: 100%;
-            height: 100%;
-          }
-
-          span {
-            padding: 12px;
-            width: 100%;
-            height: 100%;
-          }
+        > a {
+          padding: 12px;
+          width: 100%;
+          height: 100%;
         }
 
-        &.noPadding {
-          padding: 0;
-        }
-
-        &.allowTextWrap {
-          white-space: normal;
-        }
-
-        &.loading {
-          text-align: center;
-        }
-
-        &:not(:hover) {
-          :global(.cell-hover-show) {
-            visibility: collapse;
-          }
+        span {
+          padding: 12px;
+          width: 100%;
+          height: 100%;
         }
       }
 
-      &.shouldTruncate {
-        max-width: $cellMinWidth;
-        min-width: $cellMinWidth;
-        > :first-child {
-          // Truncating the first child will cover most cases.
-          // For custom rendered cells, these 3 properties may need to be apply to deeply nested children on a per need basis.
-          overflow: hidden;
-          text-overflow: ellipsis;
-        }
-      }
-    }
-
-    &:not(.collapsed) {
-      td {
-        border-bottom: theme.$amino-border-subtle;
-      }
-    }
-
-    &.collapsed.hasContent {
-      & + tr > td {
-        border: 0;
-      }
-      + tr > td > :first-child {
+      &.noPadding {
         padding: 0;
       }
+
+      &.allowTextWrap {
+        white-space: normal;
+      }
+
+      &.loading {
+        text-align: center;
+      }
+
+      &:not(:hover) {
+        :global(.cell-hover-show) {
+          visibility: collapse;
+        }
+      }
+    }
+
+    &.shouldTruncate {
+      max-width: $cellMinWidth;
+      min-width: $cellMinWidth;
+      > :first-child {
+        // Truncating the first child will cover most cases.
+        // For custom rendered cells, these 3 properties may need to be apply to deeply nested children on a per need basis.
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+    }
+  }
+
+  &:not(.collapsed) {
+    td {
+      border-bottom: theme.$amino-border-subtle;
+    }
+  }
+
+  &.collapsed.hasContent {
+    & + tr > td {
+      border: 0;
+    }
+    + tr > td > :first-child {
+      padding: 0;
     }
   }
 }

--- a/src/components/simple-table/SimpleTableRow.module.scss
+++ b/src/components/simple-table/SimpleTableRow.module.scss
@@ -63,10 +63,6 @@ $cellMinWidth: var(--amino-cell-min-width);
         white-space: normal;
       }
 
-      &.loading {
-        text-align: center;
-      }
-
       &:not(:hover) {
         :global(.cell-hover-show) {
           visibility: collapse;

--- a/src/components/simple-table/SimpleTableRow.module.scss.d.ts
+++ b/src/components/simple-table/SimpleTableRow.module.scss.d.ts
@@ -6,4 +6,5 @@ export declare const hasContent: string;
 export declare const loading: string;
 export declare const noPadding: string;
 export declare const shouldTruncate: string;
+export declare const styledTr: string;
 export declare const withHover: string;

--- a/src/components/simple-table/SimpleTableRow.module.scss.d.ts
+++ b/src/components/simple-table/SimpleTableRow.module.scss.d.ts
@@ -3,7 +3,6 @@ export declare const bordered: string;
 export declare const clickable: string;
 export declare const collapsed: string;
 export declare const hasContent: string;
-export declare const loading: string;
 export declare const noPadding: string;
 export declare const shouldTruncate: string;
 export declare const styledTr: string;

--- a/src/components/simple-table/SimpleTableRow.tsx
+++ b/src/components/simple-table/SimpleTableRow.tsx
@@ -31,6 +31,7 @@ const tooltipDelay = 800;
 
 type SimpleTableRowProps<T extends object> = {
   CustomLinkComponent?: SimpleTableProps<T>['CustomLinkComponent'];
+  bordered: SimpleTableProps<T>['bordered'];
   collapsible: SimpleTableProps<T>['collapsible'];
   getRowLink?: (item: T) => string;
   headers: SimpleTableHeader<T>[];
@@ -44,6 +45,7 @@ type SimpleTableRowProps<T extends object> = {
 };
 
 export const SimpleTableRow = <T extends object>({
+  bordered,
   collapsible,
   CustomLinkComponent,
   getRowLink,
@@ -176,9 +178,11 @@ export const SimpleTableRow = <T extends object>({
       <TableRowCollapse
         key={rowKey}
         className={clsx(
+          styles.styledTr,
           !noHoverBackground && styles.withHover,
           collapsed && styles.collapsed,
           rowCollapseContent && styles.hasContent,
+          bordered && styles.bordered,
         )}
         collapsed={collapsed}
         onToggleCollapse={() => {
@@ -200,8 +204,10 @@ export const SimpleTableRow = <T extends object>({
     <tr
       key={rowKey}
       className={clsx(
+        styles.styledTr,
         clickable && styles.clickable,
         !noHoverBackground && styles.withHover,
+        bordered && styles.bordered,
       )}
       onClick={e => {
         if (


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR fixes the styling for simple table. A global table style accidentally slipped through giving the potential to break other tables. Corrected some other styling as well.

https://cade.amino.zonos.com/?path=/story/amino-simpletable--selectable

## Todo

- [ ] Bump version and add tag
