### PR TITLE
FIX: Simple table loading state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.5.7",
+  "version": "5.5.8",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/simple-table/SimpleTable.module.scss
+++ b/src/components/simple-table/SimpleTable.module.scss
@@ -11,14 +11,13 @@
   font-size: theme.$amino-font-size-base;
 
   > tbody {
+    // Loading row
     > tr {
       height: 48px;
-      > td {
-        &.skeletonCellWrapper {
+      > td.loading {
+        padding: 12px;
+        .skeletonCellWrapper {
           display: flex;
-        }
-        &.loading {
-          padding: 12px;
         }
       }
     }

--- a/src/components/simple-table/SimpleTable.tsx
+++ b/src/components/simple-table/SimpleTable.tsx
@@ -208,7 +208,7 @@ export const SimpleTable = <T extends object>({
       return [...Array(loadingItems).keys()].map(n => (
         <tr key={n}>
           {selectable.enabled && (
-            <td>
+            <td className={styles.loading}>
               <div>
                 <Skeleton key={n} height={loadingSkeletonHeight} />
               </div>
@@ -232,7 +232,7 @@ export const SimpleTable = <T extends object>({
                   key={n}
                   height={loadingSkeletonHeight}
                   style={{
-                    width: '50%',
+                    width: '70%',
                   }}
                 />
               </div>

--- a/src/components/simple-table/__stories__/SimpleTable.spec.ts
+++ b/src/components/simple-table/__stories__/SimpleTable.spec.ts
@@ -296,4 +296,37 @@ test.describe('SimpleTable', () => {
       await expect(framePage.url()).toBe('https://letmegooglethat.com/?q=John');
     });
   });
+
+  test.describe('Row click behavior with multiple selections', () => {
+    test('disables onRowClick when multiple checkboxes are selected', async () => {
+      // First select multiple checkboxes
+      const checkbox1 = framePage
+        .getByRole('row', { name: 'John 24 Not long enough' })
+        .locator('label');
+      const checkbox2 = framePage
+        .getByRole('row', { name: 'Joan 27 This is a long string' })
+        .locator('label');
+
+      await checkbox1.click();
+      await checkbox2.click();
+
+      // Verify both are checked
+      await expect(checkbox1).toBeChecked();
+      await expect(checkbox2).toBeChecked();
+
+      // Try to click a row that has onRowClick handler
+      await framePage.locator('.tooltip-wrapper').first().click();
+
+      // Dialog should NOT appear (since onRowClick should be disabled)
+      // We can verify this by adding a small delay and checking that no dialog appeared
+      await framePage.waitForTimeout(100);
+
+      // Get all dialogs that appeared (should be empty)
+      const dialogs = await framePage.evaluate(
+        () => document.querySelectorAll('dialog').length,
+      );
+
+      expect(dialogs).toBe(0);
+    });
+  });
 });

--- a/src/components/simple-table/__stories__/SimpleTable.spec.ts
+++ b/src/components/simple-table/__stories__/SimpleTable.spec.ts
@@ -26,15 +26,17 @@ test.describe('SimpleTable', () => {
 
   test.describe('Ensure Selectable works', () => {
     test('Selectable', async () => {
-      const checkbox1 = framePage
-        .getByRole('row', { name: 'John 24 Not long enough' })
-        .locator('label');
+      const row1 = framePage.getByRole('row', {
+        name: 'John 24 Not long enough',
+      });
+      const checkbox1 = row1.locator('label');
       await checkbox1.click();
       await expect(checkbox1).toBeChecked();
 
-      const checkbox2 = framePage
-        .getByRole('row', { name: 'Joan 27 This is a long string' })
-        .locator('label');
+      const row2 = framePage.getByRole('row', {
+        name: 'Joan 27 This is a long string',
+      });
+      const checkbox2 = row2.locator('label');
       await checkbox2.click();
       await expect(checkbox2).toBeChecked();
 
@@ -53,6 +55,25 @@ test.describe('SimpleTable', () => {
           .getByRole('row', { name: 'Cade 26 This is a long string' })
           .locator('label'),
       ).toBeChecked();
+
+      await row1.click();
+
+      // Try to trigger row click and verify no action occurs
+      framePage.once('dialog', () => {
+        throw new Error('Dialog should not appear when row is selected');
+      });
+
+      // select all then unselect all and verify onClick works again
+      await checkboxAll.click();
+      await checkboxAll.click();
+
+      await expect(checkbox1).not.toBeChecked();
+      await expect(checkbox2).not.toBeChecked();
+
+      framePage.once('dialog', async dialog => {
+        expect(dialog.message()).toBe('Clicked John');
+        await dialog.dismiss();
+      });
     });
   });
 
@@ -294,39 +315,6 @@ test.describe('SimpleTable', () => {
       // Expect link to be clicked (https://letmegooglethat.com/?q=John)
       await framePage.waitForLoadState('domcontentloaded');
       await expect(framePage.url()).toBe('https://letmegooglethat.com/?q=John');
-    });
-  });
-
-  test.describe('Row click behavior with multiple selections', () => {
-    test('disables onRowClick when multiple checkboxes are selected', async () => {
-      // First select multiple checkboxes
-      const checkbox1 = framePage
-        .getByRole('row', { name: 'John 24 Not long enough' })
-        .locator('label');
-      const checkbox2 = framePage
-        .getByRole('row', { name: 'Joan 27 This is a long string' })
-        .locator('label');
-
-      await checkbox1.click();
-      await checkbox2.click();
-
-      // Verify both are checked
-      await expect(checkbox1).toBeChecked();
-      await expect(checkbox2).toBeChecked();
-
-      // Try to click a row that has onRowClick handler
-      await framePage.locator('.tooltip-wrapper').first().click();
-
-      // Dialog should NOT appear (since onRowClick should be disabled)
-      // We can verify this by adding a small delay and checking that no dialog appeared
-      await framePage.waitForTimeout(100);
-
-      // Get all dialogs that appeared (should be empty)
-      const dialogs = await framePage.evaluate(
-        () => document.querySelectorAll('dialog').length,
-      );
-
-      expect(dialogs).toBe(0);
     });
   });
 });


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR fixes the loading styles for the simple table after refactoring in a previous PR. It also writes a test for my previous PR against selecting rows and disabling the onClick event.

https://cade.amino.zonos.com/?path=/story/amino-simpletable--loading

## Todo

- [ ] Bump version and add tag
