### PR TITLE
FIX: Select styles and simple table links

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.5.8",
+  "version": "5.5.9",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig, devices } from '@playwright/test';
+import dotenv from 'dotenv';
 
 /**
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
  */
-// require('dotenv').config();
+dotenv.config();
 
 // eslint-disable-next-line no-console
 console.info('PLAYWRIGHT_TEST_BASE_URL', process.env.PLAYWRIGHT_TEST_BASE_URL);

--- a/src/components/select/_StyledReactSelect.tsx
+++ b/src/components/select/_StyledReactSelect.tsx
@@ -259,16 +259,20 @@ export const CheckboxOptionComponent = <
   );
 };
 
-const localStyles: StylesConfig<
-  SelectOption,
-  boolean,
-  GroupBase<SelectOption>
-> = {
-  clearIndicator: provided => ({
+const getMergedStyles = <
+  V extends SelectValue,
+  Option extends SelectOption<V>,
+  IsMulti extends boolean,
+  Group extends GroupBase<Option>,
+>(
+  stylesProp?: StylesConfig<Option, IsMulti, Group>,
+): StylesConfig<Option, IsMulti, Group> => ({
+  clearIndicator: (provided, state) => ({
     ...provided,
     color: theme.gray700,
     paddingLeft: 14,
     paddingRight: 4,
+    ...stylesProp?.clearIndicator?.(provided, state),
   }),
   // container
   control: (provided, state) => {
@@ -288,44 +292,54 @@ const localStyles: StylesConfig<
       flexWrap: 'inherit',
       height: `var(--amino-size-${size})`,
       minHeight: `var(--amino-size-${size})`,
+      ...stylesProp?.control?.(provided, state),
     };
   },
-  dropdownIndicator: provided => ({
+  dropdownIndicator: (provided, state) => ({
     ...provided,
     color: theme.gray900,
     paddingLeft: 4,
     paddingRight: 10,
+    ...stylesProp?.dropdownIndicator?.(provided, state),
   }),
-  group: provided => ({
+  group: (provided, state) => ({
     ...provided,
     paddingBottom: 0,
     paddingTop: 0,
+    ...stylesProp?.group?.(provided, state),
   }),
   // groupHeading
   // indicatorsContainer
-  indicatorSeparator: provided => ({ ...provided, width: 0 }),
-  input: provided => ({
+  indicatorSeparator: (provided, state) => ({
+    ...provided,
+    width: 0,
+    ...stylesProp?.indicatorSeparator?.(provided, state),
+  }),
+  input: (provided, state) => ({
     ...provided,
     color: theme.textColor,
     opacity: 0.8,
+    ...stylesProp?.input?.(provided, state),
   }),
   // loadingIndicator
   // loadingMessage
-  menu: provided => ({
+  menu: (provided, state) => ({
     ...provided,
     background: theme.surfaceColor,
     borderRadius: 12,
     boxShadow: theme.v3ShadowLarge,
     marginTop: 4,
+    ...stylesProp?.menu?.(provided, state),
   }),
-  menuList: provided => ({
+  menuList: (provided, state) => ({
     ...provided,
     paddingLeft: 8,
     paddingRight: 8,
     paddingTop: 8,
+    ...stylesProp?.menuList?.(provided, state),
   }),
   // menuPortal
-  multiValue: provided => ({
+  multiValue: (provided, state) => ({
     ...provided,
     alignItems: 'center',
     background: theme.gray100,
@@ -334,10 +348,12 @@ const localStyles: StylesConfig<
     maxHeight: 20,
     minWidth: 'inherit',
     paddingRight: 2,
+    ...stylesProp?.multiValue?.(provided, state),
   }),
-  multiValueLabel: provided => ({
+  multiValueLabel: (provided, state) => ({
     ...provided,
     color: theme.textColor,
+    ...stylesProp?.multiValueLabel?.(provided, state),
   }),
   // multiValueRemove
   // noOptionsMessage
@@ -352,27 +368,31 @@ const localStyles: StylesConfig<
     paddingLeft: 8,
     paddingRight: 12,
     paddingTop: 7,
+    ...stylesProp?.option?.(provided, state),
   }),
-  placeholder: provided => ({
+  placeholder: (provided, state) => ({
     ...provided,
     '.has-label.is-focused &': {
       opacity: 1,
     },
     opacity: 0,
+    ...stylesProp?.placeholder?.(provided, state),
   }),
-  singleValue: provided => ({
+  singleValue: (provided, state) => ({
     ...provided,
     color: theme.textColor,
     fontWeight: 500,
+    ...stylesProp?.singleValue?.(provided, state),
   }),
-  valueContainer: provided => ({
+  valueContainer: (provided, state) => ({
     ...provided,
     '.has-icon &': { paddingLeft: 0 },
     flexWrap: 'nowrap',
     padding: 'unset',
     paddingLeft: 12,
+    ...stylesProp?.valueContainer?.(provided, state),
   }),
-};
+});
 
 export type StyledReactSelectProps<
   V extends SelectValue,
@@ -436,6 +456,8 @@ export const StyledReactSelect = <
     return false;
   }, [closeOnOutsideScroll]);
 
+  const { styles: stylesProp, ...restProps } = props;
+  const mergedStyles = getMergedStyles(stylesProp);
   return (
     <div
       className={clsx(styles.styledSelectWrapper, error && styles.hasError)}
@@ -479,10 +501,10 @@ export const StyledReactSelect = <
         styles={
           {
             ...style,
-            ...localStyles,
+            ...mergedStyles,
           } as StylesConfig<Option, IsMulti, Group>
         }
-        {...props}
+        {...restProps}
         {...additionalProps}
       />
       <HelpText error={error} helpText={helpText} />

--- a/src/components/select/__stories__/Select.stories.tsx
+++ b/src/components/select/__stories__/Select.stories.tsx
@@ -10,6 +10,7 @@ import { VStack } from 'src/components/stack/VStack';
 import { Text } from 'src/components/text/Text';
 import { FileIcon } from 'src/icons/FileIcon';
 import { FlagIcon } from 'src/icons/flag-icon/FlagIcon';
+import { theme } from 'src/styles/constants/theme';
 import type { SelectOption } from 'src/types/SelectOption';
 
 import styles from './Select.stories.module.scss';
@@ -151,6 +152,11 @@ export const Customized: StoryObj<SelectProps> = {
         value: 'EUR',
       },
     ],
+    styles: {
+      menu: () => ({
+        background: theme.blue100,
+      }),
+    },
     value: [
       {
         icon: <FileIcon size={24} />,

--- a/src/components/simple-table/SimpleTableRow.module.scss
+++ b/src/components/simple-table/SimpleTableRow.module.scss
@@ -42,16 +42,8 @@ $cellMinWidth: var(--amino-cell-min-width);
       &:global(.tooltip-wrapper) {
         padding: 0;
 
-        > a {
-          padding: 12px;
-          width: 100%;
-          height: 100%;
-          display: block;
-          overflow: hidden;
-          text-overflow: ellipsis;
-        }
-
-        span {
+        > a,
+        > span {
           padding: 12px;
           width: 100%;
           height: 100%;

--- a/src/components/simple-table/SimpleTableRow.module.scss
+++ b/src/components/simple-table/SimpleTableRow.module.scss
@@ -47,9 +47,6 @@ $cellMinWidth: var(--amino-cell-min-width);
           padding: 12px;
           width: 100%;
           height: 100%;
-          display: block;
-          overflow: hidden;
-          text-overflow: ellipsis;
         }
       }
 

--- a/src/components/simple-table/SimpleTableRow.module.scss
+++ b/src/components/simple-table/SimpleTableRow.module.scss
@@ -46,12 +46,18 @@ $cellMinWidth: var(--amino-cell-min-width);
           padding: 12px;
           width: 100%;
           height: 100%;
+          display: block;
+          overflow: hidden;
+          text-overflow: ellipsis;
         }
 
         span {
           padding: 12px;
           width: 100%;
           height: 100%;
+          display: block;
+          overflow: hidden;
+          text-overflow: ellipsis;
         }
       }
 
@@ -73,6 +79,7 @@ $cellMinWidth: var(--amino-cell-min-width);
     &.shouldTruncate {
       max-width: $cellMinWidth;
       min-width: $cellMinWidth;
+
       > :first-child {
         // Truncating the first child will cover most cases.
         // For custom rendered cells, these 3 properties may need to be apply to deeply nested children on a per need basis.

--- a/src/components/simple-table/SimpleTableRow.module.scss
+++ b/src/components/simple-table/SimpleTableRow.module.scss
@@ -47,6 +47,9 @@ $cellMinWidth: var(--amino-cell-min-width);
           padding: 12px;
           width: 100%;
           height: 100%;
+          display: block;
+          overflow: hidden;
+          text-overflow: ellipsis;
         }
       }
 

--- a/src/components/simple-table/__stories__/SimpleTable.spec.ts
+++ b/src/components/simple-table/__stories__/SimpleTable.spec.ts
@@ -339,7 +339,6 @@ test.describe('SimpleTable', () => {
       await expect(normalCell).not.toHaveCSS('text-overflow', 'ellipsis');
       await expect(normalCell).not.toHaveCSS('overflow', 'hidden');
 
-      // Verify text wraps to multiple lines
       const normalCellBounds = await normalCell.boundingBox();
       expect(normalCellBounds?.height).toBeGreaterThan(50); // Height indicates multiple lines
 
@@ -349,14 +348,11 @@ test.describe('SimpleTable', () => {
         .first()
         .locator('td > :first-child')
         .first();
+
       await expect(truncateCell).toHaveCSS('white-space', 'nowrap');
       await expect(truncateCell).toHaveCSS('text-overflow', 'ellipsis');
       await expect(truncateCell).toHaveCSS('overflow', 'hidden');
-
-      const computedStyle = await truncateCell.evaluate(
-        element => window.getComputedStyle(element).textOverflow,
-      );
-      expect(computedStyle).toBe('ellipsis');
+      // There is no good way to verify truncation with ellipsis
 
       // Test nowrap
       const nowrapCell = nowrapTable
@@ -368,7 +364,6 @@ test.describe('SimpleTable', () => {
       await expect(nowrapCell).not.toHaveCSS('text-overflow', 'ellipsis');
       await expect(nowrapCell).not.toHaveCSS('overflow', 'hidden');
 
-      // Verify content extends beyond viewport
       const nowrapCellBounds = await nowrapCell.boundingBox();
       const viewportSize = await framePage.viewportSize();
       expect(nowrapCellBounds?.width).toBeGreaterThan(viewportSize?.width || 0);

--- a/src/components/simple-table/__stories__/SimpleTable.spec.ts
+++ b/src/components/simple-table/__stories__/SimpleTable.spec.ts
@@ -317,4 +317,65 @@ test.describe('SimpleTable', () => {
       await expect(framePage.url()).toBe('https://letmegooglethat.com/?q=John');
     });
   });
+
+  test.describe('text wrap methods', () => {
+    test('Text Wrap Methods', async () => {
+      // Wait for cell with long text to be visible
+      await framePage
+        .locator('tr td', { hasText: 'This is a very long text' })
+        .first()
+        .waitFor({
+          state: 'visible',
+        });
+
+      // Test normal wrapping
+      const normalCell = framePage
+        .locator('[data-testid="normal-wrap-table"]')
+        .locator('tbody tr')
+        .first()
+        .locator('td')
+        .first();
+      await expect(normalCell).toHaveCSS('white-space', 'normal');
+      await expect(normalCell).not.toHaveCSS('text-overflow', 'ellipsis');
+      await expect(normalCell).not.toHaveCSS('overflow', 'hidden');
+
+      // Test truncate wrapping
+      const truncateCell = framePage
+        .locator('[data-testid="truncate-wrap-table"]')
+        .locator('tbody tr')
+        .first()
+        .locator('td')
+        .first();
+      await expect(truncateCell).toHaveCSS('white-space', 'nowrap');
+      await expect(truncateCell).toHaveCSS('text-overflow', 'ellipsis');
+      await expect(truncateCell).toHaveCSS('overflow', 'hidden');
+
+      // Test nowrap
+      const nowrapCell = framePage
+        .locator('[data-testid="nowrap-wrap-table"]')
+        .locator('tbody tr')
+        .first()
+        .locator('td')
+        .first();
+      await expect(nowrapCell).toHaveCSS('white-space', 'nowrap');
+      await expect(nowrapCell).not.toHaveCSS('text-overflow', 'ellipsis');
+      await expect(nowrapCell).not.toHaveCSS('overflow', 'hidden');
+
+      // Verify content width differences
+      const normalCellWidth = await normalCell.evaluate(el => el.offsetWidth);
+      const truncateCellWidth = await truncateCell.evaluate(
+        el => el.offsetWidth,
+      );
+      const nowrapCellWidth = await nowrapCell.evaluate(el => el.offsetWidth);
+
+      // Normal should be smaller than nowrap (due to wrapping)
+      expect(normalCellWidth).toBeLessThan(nowrapCellWidth);
+
+      // Truncate should be equal to normal or smaller
+      expect(truncateCellWidth).toBeLessThanOrEqual(normalCellWidth);
+
+      // Nowrap should be the widest
+      expect(nowrapCellWidth).toBeGreaterThan(truncateCellWidth);
+    });
+  });
 });

--- a/src/components/simple-table/__stories__/SimpleTable.spec.ts
+++ b/src/components/simple-table/__stories__/SimpleTable.spec.ts
@@ -352,7 +352,7 @@ test.describe('SimpleTable', () => {
       await expect(truncateCell).toHaveCSS('white-space', 'nowrap');
       await expect(truncateCell).toHaveCSS('text-overflow', 'ellipsis');
       await expect(truncateCell).toHaveCSS('overflow', 'hidden');
-      // There is no good way to verify truncation with ellipsis
+      // There is no good way to verify truncation with ellipsis is actually displayed
 
       // Test nowrap
       const nowrapCell = nowrapTable

--- a/src/components/simple-table/__stories__/SimpleTable.spec.ts
+++ b/src/components/simple-table/__stories__/SimpleTable.spec.ts
@@ -321,16 +321,13 @@ test.describe('SimpleTable', () => {
   test.describe('text wrap methods', () => {
     test('Text Wrap Methods', async () => {
       // Wait for cell with long text to be visible
-      await framePage
-        .locator('tr td', { hasText: 'This is a very long text' })
-        .first()
-        .waitFor({
-          state: 'visible',
-        });
+      await framePage.locator('[data-test-id="normal-table"]').waitFor();
+      await framePage.locator('[data-test-id="truncate-table"]').waitFor();
+      await framePage.locator('[data-test-id="nowrap-table"]').waitFor();
 
       // Test normal wrapping
       const normalCell = framePage
-        .locator('[data-testid="normal-table"]')
+        .locator('[data-test-id="normal-table"]')
         .locator('tbody tr')
         .first()
         .locator('td')
@@ -345,7 +342,7 @@ test.describe('SimpleTable', () => {
 
       // Test truncating
       const truncateCell = framePage
-        .locator('[data-testid="truncate-table"]')
+        .locator('[data-test-id="truncate-table"]')
         .locator('tbody tr')
         .first()
         .locator('td')
@@ -361,7 +358,7 @@ test.describe('SimpleTable', () => {
 
       // Test nowrap
       const nowrapCell = framePage
-        .locator('[data-testid="nowrap-table"]')
+        .locator('[data-test-id="nowrap-table"]')
         .locator('tbody tr')
         .first()
         .locator('td')

--- a/src/components/simple-table/__stories__/SimpleTable.spec.ts
+++ b/src/components/simple-table/__stories__/SimpleTable.spec.ts
@@ -321,13 +321,16 @@ test.describe('SimpleTable', () => {
   test.describe('text wrap methods', () => {
     test('Text Wrap Methods', async () => {
       // Wait for cell with long text to be visible
-      await framePage.locator('[data-test-id="normal-table"]').waitFor();
-      await framePage.locator('[data-test-id="truncate-table"]').waitFor();
-      await framePage.locator('[data-test-id="nowrap-table"]').waitFor();
+      const normalTable = framePage.locator('[data-test-id="normal-table"]');
+      const truncateTable = framePage.locator(
+        '[data-test-id="truncate-table"]',
+      );
+      const nowrapTable = framePage.locator('[data-test-id="nowrap-table"]');
+
+      await normalTable.waitFor();
 
       // Test normal wrapping
-      const normalCell = framePage
-        .locator('[data-test-id="normal-table"]')
+      const normalCell = normalTable
         .locator('tbody tr')
         .first()
         .locator('td')
@@ -341,11 +344,10 @@ test.describe('SimpleTable', () => {
       expect(normalCellBounds?.height).toBeGreaterThan(50); // Height indicates multiple lines
 
       // Test truncating
-      const truncateCell = framePage
-        .locator('[data-test-id="truncate-table"]')
+      const truncateCell = truncateTable
         .locator('tbody tr')
         .first()
-        .locator('td')
+        .locator('td > :first-child')
         .first();
       await expect(truncateCell).toHaveCSS('white-space', 'nowrap');
       await expect(truncateCell).toHaveCSS('text-overflow', 'ellipsis');
@@ -357,11 +359,10 @@ test.describe('SimpleTable', () => {
       expect(computedStyle).toBe('ellipsis');
 
       // Test nowrap
-      const nowrapCell = framePage
-        .locator('[data-test-id="nowrap-table"]')
+      const nowrapCell = nowrapTable
         .locator('tbody tr')
         .first()
-        .locator('td')
+        .locator('td > :first-child')
         .first();
       await expect(nowrapCell).toHaveCSS('white-space', 'nowrap');
       await expect(nowrapCell).not.toHaveCSS('text-overflow', 'ellipsis');

--- a/src/components/simple-table/__stories__/SimpleTable.stories.tsx
+++ b/src/components/simple-table/__stories__/SimpleTable.stories.tsx
@@ -840,6 +840,7 @@ export const TextWrapMethods: StoryObj = {
         <div>
           <Text type="header">Normal</Text>
           <SimpleTable
+            data-testid="normal-table"
             headers={createHeaders('normal')}
             items={sampleData}
             keyExtractor={item => String(item.id)}
@@ -849,6 +850,7 @@ export const TextWrapMethods: StoryObj = {
         <div>
           <Text type="header">Truncate</Text>
           <SimpleTable
+            data-testid="truncate-table"
             headers={createHeaders('truncate')}
             items={sampleData}
             keyExtractor={item => String(item.id)}
@@ -858,6 +860,7 @@ export const TextWrapMethods: StoryObj = {
         <div>
           <Text type="header">Nowrap</Text>
           <SimpleTable
+            data-testid="nowrap-table"
             headers={createHeaders('nowrap')}
             items={sampleData}
             keyExtractor={item => String(item.id)}

--- a/src/components/simple-table/__stories__/SimpleTable.stories.tsx
+++ b/src/components/simple-table/__stories__/SimpleTable.stories.tsx
@@ -822,6 +822,7 @@ export const TextWrapMethods: StoryObj = {
         key: 'id',
         name: `Text Wrap: ${method}`,
         textWrapMethod: method,
+        width: 34,
       },
       {
         key: 'text',

--- a/src/components/simple-table/__stories__/SimpleTable.stories.tsx
+++ b/src/components/simple-table/__stories__/SimpleTable.stories.tsx
@@ -837,30 +837,27 @@ export const TextWrapMethods: StoryObj = {
 
     return (
       <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
-        <div>
+        <div data-testid="normal-table">
           <Text type="header">Normal</Text>
           <SimpleTable
-            data-testid="normal-table"
             headers={createHeaders('normal')}
             items={sampleData}
             keyExtractor={item => String(item.id)}
           />
         </div>
 
-        <div>
+        <div data-testid="truncate-table">
           <Text type="header">Truncate</Text>
           <SimpleTable
-            data-testid="truncate-table"
             headers={createHeaders('truncate')}
             items={sampleData}
             keyExtractor={item => String(item.id)}
           />
         </div>
 
-        <div>
+        <div data-testid="nowrap-table">
           <Text type="header">Nowrap</Text>
           <SimpleTable
-            data-testid="nowrap-table"
             headers={createHeaders('nowrap')}
             items={sampleData}
             keyExtractor={item => String(item.id)}

--- a/src/components/simple-table/__stories__/SimpleTable.stories.tsx
+++ b/src/components/simple-table/__stories__/SimpleTable.stories.tsx
@@ -837,7 +837,7 @@ export const TextWrapMethods: StoryObj = {
 
     return (
       <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
-        <div data-testid="normal-table">
+        <div data-test-id="normal-table">
           <Text type="header">Normal</Text>
           <SimpleTable
             headers={createHeaders('normal')}
@@ -846,7 +846,7 @@ export const TextWrapMethods: StoryObj = {
           />
         </div>
 
-        <div data-testid="truncate-table">
+        <div data-test-id="truncate-table">
           <Text type="header">Truncate</Text>
           <SimpleTable
             headers={createHeaders('truncate')}
@@ -855,7 +855,7 @@ export const TextWrapMethods: StoryObj = {
           />
         </div>
 
-        <div data-testid="nowrap-table">
+        <div data-test-id="nowrap-table">
           <Text type="header">Nowrap</Text>
           <SimpleTable
             headers={createHeaders('nowrap')}

--- a/src/components/simple-table/__stories__/SimpleTable.stories.tsx
+++ b/src/components/simple-table/__stories__/SimpleTable.stories.tsx
@@ -801,3 +801,70 @@ export const OnRowClick: StoryObj = {
   },
   tags: ['tested'],
 };
+
+export const TextWrapMethods: StoryObj = {
+  render: () => {
+    const longText =
+      'This is a very long text that should demonstrate different wrapping behaviors. '.repeat(
+        3,
+      );
+
+    const sampleData = [1, 2, 3].map(id => ({
+      extra: longText,
+      id: `${id} ${longText}`,
+      text: longText,
+    }));
+
+    const createHeaders = (
+      method: 'normal' | 'truncate' | 'nowrap',
+    ): SimpleTableHeader<{ extra: string; id: string; text: string }>[] => [
+      {
+        key: 'id',
+        name: `Text Wrap: ${method}`,
+        textWrapMethod: method,
+      },
+      {
+        key: 'text',
+        name: 'Text',
+        textWrapMethod: method,
+      },
+      {
+        key: 'extra',
+        name: 'Text',
+        textWrapMethod: method,
+      },
+    ];
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
+        <div>
+          <Text type="header">Normal</Text>
+          <SimpleTable
+            headers={createHeaders('normal')}
+            items={sampleData}
+            keyExtractor={item => String(item.id)}
+          />
+        </div>
+
+        <div>
+          <Text type="header">Truncate</Text>
+          <SimpleTable
+            headers={createHeaders('truncate')}
+            items={sampleData}
+            keyExtractor={item => String(item.id)}
+          />
+        </div>
+
+        <div>
+          <Text type="header">Nowrap</Text>
+          <SimpleTable
+            headers={createHeaders('nowrap')}
+            items={sampleData}
+            keyExtractor={item => String(item.id)}
+          />
+        </div>
+      </div>
+    );
+  },
+  tags: ['tested'],
+};


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR fixes the React Select to allow for passing a `styles` prop that actually merges with our base styles in amino. This PR also fixes the simple table for link rows so the whole thing is clickable and fixes links to truncate again. Created a story to see the text wrap methods working.

Link rows:
https://cade.amino.zonos.com/?path=/story/amino-simpletable--with-link

Text Wrap Method:
https://cade.amino.zonos.com/?path=/story/amino-simpletable--text-wrap-methods

Select with custom styles prop for background color:
https://cade.amino.zonos.com/?path=/story/amino-select--customized

Ran the built changes on dashboard and looks good ✅ 

## Todo

- [ ] Bump version and add tag
