### PR TITLE
fix: input xl float label

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.5.9",
+  "version": "5.5.10",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/input/input-type/_FloatLabelInput.module.scss
+++ b/src/components/input/input-type/_FloatLabelInput.module.scss
@@ -239,6 +239,14 @@ $height: var(--amino-float-label-input-height);
       .aminoInput {
         padding-bottom: 2px;
       }
+
+      &:global(.has-content),
+      &:focus-within {
+        .floatingLabel span {
+          top: 11px;
+          transform: scale(0.8);
+        }
+      }
     }
   }
 }

--- a/src/components/input/input-type/_FloatLabelInput.module.scss
+++ b/src/components/input/input-type/_FloatLabelInput.module.scss
@@ -135,7 +135,7 @@ $height: var(--amino-float-label-input-height);
       &::placeholder {
         opacity: theme.$amino-opacity-disabled;
       }
-      & + .floatingLabel span {
+      & ~ .floatingLabel span {
         top: 11px;
         transform: scale(0.8);
       }
@@ -168,7 +168,7 @@ $height: var(--amino-float-label-input-height);
     &:global(.has-input-prefix) {
       .aminoInput {
         padding-left: 0;
-        & + .floatingLabel span {
+        & ~ .floatingLabel span {
           margin-left: 0;
         }
       }
@@ -238,14 +238,6 @@ $height: var(--amino-float-label-input-height);
     &:global(.has-label) {
       .aminoInput {
         padding-bottom: 2px;
-      }
-
-      &:global(.has-content),
-      &:focus-within {
-        .floatingLabel span {
-          top: 11px;
-          transform: scale(0.8);
-        }
       }
     }
   }


### PR DESCRIPTION
## Linear issue
[SN-2198: Frontend - Floating Labels in Amino sometimes override the text that is entered](https://linear.app/zonos/issue/SN-2198/frontend-floating-labels-in-amino-sometimes-override-the-text-that-is)

## Description
This PR fixes the CSS for the XL FloatLabelInput. The floating styles weren't getting applied correctly upon `:focus-within` or `.has-content` until unfocused. Oddly, this only occurs outside of Amino's Storybook, in consuming projects.

Not sure how to add a preview. I tested by importing my local Amino into my local Zonos.com and this fix worked.

## Todo

- [x] Bump version and add tag
