### PR TITLE
fix: if date is null, don't run dayjs on it.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.5.14",
+  "version": "5.5.15",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/filter/filter-date/FilterDate.tsx
+++ b/src/components/filter/filter-date/FilterDate.tsx
@@ -49,6 +49,9 @@ export const FilterDate = ({
     date: string | null;
     type: 'begin' | 'end';
   }) => {
+    if (!date) {
+      return null;
+    }
     switch (rangeType) {
       case 'is between':
       case 'is equal to':


### PR DESCRIPTION
## Linear issue
[CXT-1523: Fix Date Filter in Amino](https://linear.app/zonos/issue/CXT-1523/fix-date-filter-in-amino)

## Description
This PR fixes a bug where the date being `null` causes the dayjs call to return 'Invalid date'. This fix makes the `getAdjustedDate` function return `null` if the date is `null`.

## Todo

- [x] Bump version and add tag
