### PR TITLE
FEAT: Allow icon on toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.5.32",
+  "version": "5.5.33",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/toggle/Toggle.module.scss
+++ b/src/components/toggle/Toggle.module.scss
@@ -29,13 +29,21 @@
 
   .optionWrapper {
     z-index: 2;
+    gap: 6px;
+    display: flex;
     text-align: center;
+    justify-content: center;
     cursor: pointer;
     padding: 4px 12px;
     border-radius: 6px;
     font-size: theme.$amino-font-size-base;
     font-weight: 500;
     color: theme.$amino-text-color-secondary;
+
+    .icon, .icon svg {
+      max-height: 100%;
+      width: auto;
+    }
 
     &:focus {
       outline: none;

--- a/src/components/toggle/Toggle.module.scss.d.ts
+++ b/src/components/toggle/Toggle.module.scss.d.ts
@@ -1,4 +1,5 @@
 export declare const fullWidth: string;
+export declare const icon: string;
 export declare const optionWrapper: string;
 export declare const selected: string;
 export declare const selectedSlider: string;

--- a/src/components/toggle/Toggle.tsx
+++ b/src/components/toggle/Toggle.tsx
@@ -217,7 +217,8 @@ export const Toggle = <TValue extends SelectValue>({
               onClick={() => onChange(option.value)}
               type="button"
             >
-              {option.label}
+              {option.icon && <div className={styles.icon}>{option.icon}</div>}
+              <div>{option.label}</div>
             </button>
           );
         })}

--- a/src/components/toggle/__stories__/Toggle.stories.tsx
+++ b/src/components/toggle/__stories__/Toggle.stories.tsx
@@ -5,6 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Button } from 'src/components/button/Button';
 import { Flex } from 'src/components/flex/Flex';
 import { Toggle, type ToggleProps } from 'src/components/toggle/Toggle';
+import { UFODuotoneIcon } from 'src/icons/UFODuotoneIcon';
 import type { SelectOption, SelectValue } from 'src/types/SelectOption';
 
 const Template = ({ value: initialValue, ...props }: ToggleProps) => {
@@ -83,5 +84,14 @@ export const WithButtonSize: StoryObj<ToggleProps> = {
         </div>
       </Flex>
     );
+  },
+};
+
+export const WithIcon: StoryObj<ToggleProps> = {
+  args: {
+    options: options.map(option => ({
+      ...option,
+      icon: <UFODuotoneIcon />,
+    })),
   },
 };


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR allows the icon prop to work from the options on a toggle

https://amino-git-fix-toggle-zonos.vercel.app/?path=/story/amino-toggle--with-icon

## Todo

- [x] Bump version and add tag
