### PR TITLE
feat(CountryMultiSelectExpanded): add options to hide "Select all" checkbox and expand all groups by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.5.33",
+  "version": "5.5.34",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/country-multi-select/CountryMultiSelectExpanded.tsx
+++ b/src/components/country-multi-select/CountryMultiSelectExpanded.tsx
@@ -86,6 +86,16 @@ export type CountryMultiSelectExpandedProps<
      * @default false
      */
     withoutSearch?: boolean;
+    /**
+     * Whether to hide the "Select all" checkbox
+     * @default false
+     */
+    hideSelectAll?: boolean;
+    /**
+     * Expand all groups by default
+     * @default false
+     */
+    expandAllGroups?: boolean;
   };
 
 /**
@@ -182,6 +192,8 @@ export const CountryMultiSelectExpanded = <
   selectedCountries,
   style,
   withoutSearch = false,
+  hideSelectAll = false,
+  expandAllGroups = false,
 }: CountryMultiSelectExpandedProps<CountryCode>) => {
   const id = useId();
 
@@ -244,6 +256,12 @@ export const CountryMultiSelectExpanded = <
     }
   }, [groups, searchText]);
 
+  useEffect(() => {
+    if (expandAllGroups) {
+      setExpandedGroups(groups.map(group => group.label));
+    }
+  }, [groups, expandAllGroups]);
+
   if (!sortedCountries.length) {
     return (
       <div className={clsx(className)}>
@@ -272,7 +290,7 @@ export const CountryMultiSelectExpanded = <
           maxHeight: `${maxHeight}px`,
         }}
       >
-        {!searchText && (
+        {!searchText && !hideSelectAll && (
           <div className={styles.checkboxWrapper}>
             <Checkbox
               checked={allSelected}

--- a/src/components/country-multi-select/CountryMultiSelectExpanded.tsx
+++ b/src/components/country-multi-select/CountryMultiSelectExpanded.tsx
@@ -64,7 +64,7 @@ export type CountryMultiSelectExpandedProps<
      * Expand all groups by default
      * @default false
      */
-    expandAllGroups?: boolean;
+    expandAllGroupsOnInitialRender?: boolean;
     /**
      * Whether to hide the "Select all" checkbox
      * @default false
@@ -185,7 +185,7 @@ export const CountryMultiSelectExpanded = <
   countries,
   disabled = false,
   error = false,
-  expandAllGroups = false,
+  expandAllGroupsOnInitialRender = false,
   helpText,
   hideSelectAll = false,
   maxHeight = 380,
@@ -257,10 +257,10 @@ export const CountryMultiSelectExpanded = <
   }, [groups, searchText]);
 
   useEffect(() => {
-    if (expandAllGroups) {
+    if (expandAllGroupsOnInitialRender) {
       setExpandedGroups(groups.map(group => group.label));
     }
-  }, [groups, expandAllGroups]);
+  }, [groups, expandAllGroupsOnInitialRender]);
 
   if (!sortedCountries.length) {
     return (

--- a/src/components/country-multi-select/CountryMultiSelectExpanded.tsx
+++ b/src/components/country-multi-select/CountryMultiSelectExpanded.tsx
@@ -199,6 +199,8 @@ export const CountryMultiSelectExpanded = <
 
   const [searchText, setSearchText] = useState('');
   const [expandedGroups, setExpandedGroups] = useState<string[]>([]);
+  const [isExpandedOnInitialRender, setIsExpandedOnInitialRender] =
+    useState(false);
 
   const sortedCountries = useMemo(
     () => countries.sort((a, b) => a.label.localeCompare(b.label)),
@@ -257,10 +259,11 @@ export const CountryMultiSelectExpanded = <
   }, [groups, searchText]);
 
   useEffect(() => {
-    if (expandAllGroupsOnInitialRender) {
+    if (expandAllGroupsOnInitialRender && !isExpandedOnInitialRender) {
       setExpandedGroups(groups.map(group => group.label));
+      setIsExpandedOnInitialRender(true);
     }
-  }, [groups, expandAllGroupsOnInitialRender]);
+  }, [groups, expandAllGroupsOnInitialRender, isExpandedOnInitialRender]);
 
   if (!sortedCountries.length) {
     return (

--- a/src/components/country-multi-select/CountryMultiSelectExpanded.tsx
+++ b/src/components/country-multi-select/CountryMultiSelectExpanded.tsx
@@ -61,6 +61,16 @@ export type CountryMultiSelectExpandedProps<
      */
     disabled?: boolean;
     /**
+     * Expand all groups by default
+     * @default false
+     */
+    expandAllGroups?: boolean;
+    /**
+     * Whether to hide the "Select all" checkbox
+     * @default false
+     */
+    hideSelectAll?: boolean;
+    /**
      * Maximum height of the country selection area in pixels
      * @default 380
      */
@@ -86,16 +96,6 @@ export type CountryMultiSelectExpandedProps<
      * @default false
      */
     withoutSearch?: boolean;
-    /**
-     * Whether to hide the "Select all" checkbox
-     * @default false
-     */
-    hideSelectAll?: boolean;
-    /**
-     * Expand all groups by default
-     * @default false
-     */
-    expandAllGroups?: boolean;
   };
 
 /**
@@ -185,15 +185,15 @@ export const CountryMultiSelectExpanded = <
   countries,
   disabled = false,
   error = false,
+  expandAllGroups = false,
   helpText,
+  hideSelectAll = false,
   maxHeight = 380,
   noHeader = false,
   onChange,
   selectedCountries,
   style,
   withoutSearch = false,
-  hideSelectAll = false,
-  expandAllGroups = false,
 }: CountryMultiSelectExpandedProps<CountryCode>) => {
   const id = useId();
 

--- a/src/components/country-multi-select/__stories__/CountryMultiSelectExpanded.stories.tsx
+++ b/src/components/country-multi-select/__stories__/CountryMultiSelectExpanded.stories.tsx
@@ -121,3 +121,35 @@ export const WithToggle = (props: CountryMultiSelectExpandedProps) => {
     />
   );
 };
+
+export const NoGroups = (props: CountryMultiSelectExpandedProps) => {
+  const dashboardUrl = getCountryUrls();
+  const countryOptions = useCountryOptions(dashboardUrl);
+
+  const [value, setValue] = useState<CountryMultiSelectExpandedOption[]>([]);
+
+  const countries = useMemo(() => {
+    return countryOptions.map<CountryMultiSelectExpandedOption>(x => ({
+      code: x.code,
+      group: 'Select all',
+      icon: x.icon,
+      label: x.displayName,
+    }));
+  }, [countryOptions]);
+
+  return (
+    <CountryMultiSelectExpanded
+      style={{
+        overflow: 'auto',
+        resize: 'both',
+        width: '632px',
+      }}
+      {...props}
+      expandAllGroups
+      hideSelectAll
+      countries={countries}
+      onChange={setValue}
+      selectedCountries={value}
+    />
+  );
+};

--- a/src/components/country-multi-select/__stories__/CountryMultiSelectExpanded.stories.tsx
+++ b/src/components/country-multi-select/__stories__/CountryMultiSelectExpanded.stories.tsx
@@ -148,7 +148,7 @@ export const NoGroups = (props: CountryMultiSelectExpandedProps) => {
       }}
       {...props}
       countries={countries}
-      expandAllGroups
+      expandAllGroupsOnInitialRender
       hideSelectAll
       onChange={setValue}
       selectedCountries={value}

--- a/src/components/country-multi-select/__stories__/CountryMultiSelectExpanded.stories.tsx
+++ b/src/components/country-multi-select/__stories__/CountryMultiSelectExpanded.stories.tsx
@@ -128,14 +128,16 @@ export const NoGroups = (props: CountryMultiSelectExpandedProps) => {
 
   const [value, setValue] = useState<CountryMultiSelectExpandedOption[]>([]);
 
-  const countries = useMemo(() => {
-    return countryOptions.map<CountryMultiSelectExpandedOption>(x => ({
-      code: x.code,
-      group: 'Select all',
-      icon: x.icon,
-      label: x.displayName,
-    }));
-  }, [countryOptions]);
+  const countries = useMemo(
+    () =>
+      countryOptions.map<CountryMultiSelectExpandedOption>(x => ({
+        code: x.code,
+        group: 'Select all',
+        icon: x.icon,
+        label: x.displayName,
+      })),
+    [countryOptions],
+  );
 
   return (
     <CountryMultiSelectExpanded
@@ -145,9 +147,9 @@ export const NoGroups = (props: CountryMultiSelectExpandedProps) => {
         width: '632px',
       }}
       {...props}
+      countries={countries}
       expandAllGroups
       hideSelectAll
-      countries={countries}
       onChange={setValue}
       selectedCountries={value}
     />


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->
- [CO-730: New option for Country Multi Select Expanded](https://linear.app/zonos/issue/CO-730/new-option-for-country-multi-select-expanded)
<img width="527" height="796" alt="image" src="https://github.com/user-attachments/assets/199cdd19-2f18-40bc-8c0f-19b778b20692" />

## Preview
### After
- https://amino-git-feat-new-option-for-country-multi-select-e2848e-zonos.vercel.app/?path=/story/amino-country-multi-select-countrymultiselectexpanded--no-groups
<img width="679" height="498" alt="image" src="https://github.com/user-attachments/assets/7ca50161-4198-45dc-b7b8-ee7d4b99c8a6" />


## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->
Resolved CO-730
This PR update new option for country mutli select expanded to be able to expand by default and no group by

## Todo

- [ ] Bump version and add tag
