### PR TITLE
Feat/add custom file upload text action

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.5.40",
+  "version": "5.5.41",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/components/file-upload/FileUpload.tsx
+++ b/src/components/file-upload/FileUpload.tsx
@@ -17,6 +17,7 @@ type UploadFileNoImage = {
 };
 
 export type FileUploadProps = BaseProps & {
+  buttonActionText?: string;
   /**
    * This `disabled` state only applies when no file is selected
    * @default false
@@ -123,6 +124,7 @@ export type FileUploadProps = BaseProps & {
  * ```
  */
 export const FileUpload = ({
+  buttonActionText = 'Browse',
   className,
   disabled = false,
   dropzoneOptions,
@@ -180,7 +182,7 @@ export const FileUpload = ({
       <input {...getInputProps()} />
       <div className={styles.contentWrapper}>
         <Button loading={loading} onClick={open} spinnerColor="black">
-          Browse
+          {buttonActionText}
         </Button>
         {renderText()}
       </div>


### PR DESCRIPTION
## Preview
- Worked in prepay web version
<img width="671" height="490" alt="image" src="https://github.com/user-attachments/assets/933192b1-32a0-4fd7-b485-28982e3465e6" />


## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR adds ability to customize the button action text in file upload so that we can localize the input

## Todo

- [ ] Bump version and add tag
