### PR TITLE
DEV-1021: Add Datadog service catalog definition

### DIFF
--- a/.github/service.datadog.yaml
+++ b/.github/service.datadog.yaml
@@ -1,0 +1,33 @@
+apiVersion: v3
+kind: service
+metadata:
+  name: amino
+  owner: team-16
+  additionalOwners:
+    - name: devops
+      type: infra
+  tags:
+    - language:typescript
+    - cloud_provider:aws
+  contacts:
+    - name: team-16-hello
+      type: slack
+      contact: https://zonos.slack.com/archives/C0APYQ68LH4
+  links:
+    - name: Source Code
+      type: repo
+      url: https://github.com/Zonos/amino
+      provider: github
+spec:
+  lifecycle: production
+  tier: "bronze"
+  type: web
+  languages:
+    - typescript
+datadog:
+  codeLocations:
+    - repositoryURL: https://github.com/Zonos/amino
+extensions:
+  datadoghq.com/ci-pipelines:
+    - name: amino
+      provider: github


### PR DESCRIPTION
## Summary

- Adds `.github/service.datadog.yaml` (v3 schema) for the Datadog Software Catalog
- Sets service owner to `team-16` with `devops` as infra co-owner
- Includes Slack contact, repo link, language tags, tier, and lifecycle metadata

## Test plan

- [ ] Verify yaml renders correctly in Datadog Software Catalog after merge
- [ ] Confirm team ownership shows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new metadata-only YAML file and does not change runtime behavior.
> 
> **Overview**
> Adds `.github/service.datadog.yaml` to register `amino` in the Datadog Software Catalog (v3), including **ownership**, **contacts/links**, **tags**, service *lifecycle/tier/type/languages*, and a CI pipeline extension.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6d8262c35c967c1dd3989580029979fc7e15198. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->