### PR TITLE
FEAT: Reactnode labels on fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/all.ts
+++ b/src/all.ts
@@ -773,6 +773,7 @@ import './utils/getCountryUrls';
 import './utils/getFuzzySearch';
 import './utils/getHashId';
 import './utils/getIsInternalLink';
+import './utils/getNodeText';
 import './utils/getProductDetails';
 import './utils/getTestId';
 import './utils/handleFetch';

--- a/src/components/checkbox/Checkbox.tsx
+++ b/src/components/checkbox/Checkbox.tsx
@@ -18,6 +18,7 @@ import { CheckmarkIcon } from 'src/icons/CheckmarkIcon';
 import { theme } from 'src/styles/constants/theme';
 import type { BaseProps } from 'src/types/BaseProps';
 import { cn } from 'src/utils/cn';
+import { getNodeText } from 'src/utils/getNodeText';
 import { getTestId } from 'src/utils/getTestId';
 
 const AnimatedCheckIcon = motion(CheckmarkIcon);
@@ -53,7 +54,7 @@ export type CheckboxProps = Omit<
     checked: boolean;
     disabled?: boolean;
     icon?: ReactNode;
-    label?: string;
+    label?: ReactNode;
     labelComponent?: ReactNode;
     labelDescription?: string;
     onChange: (
@@ -153,7 +154,7 @@ export const Checkbox = ({
   const id = useId();
 
   const testId = useMemo(
-    () => getTestId({ componentName: 'checkbox', name: label }),
+    () => getTestId({ componentName: 'checkbox', name: getNodeText(label) }),
     [label],
   );
 

--- a/src/components/checkbox/Checkbox.tsx
+++ b/src/components/checkbox/Checkbox.tsx
@@ -54,6 +54,12 @@ export type CheckboxProps = Omit<
     checked: boolean;
     disabled?: boolean;
     icon?: ReactNode;
+    /**
+     * The whole visual row is a `<label>` for the checkbox, so clicking
+     * anywhere in it — including non-interactive markup in a ReactNode label,
+     * like a Tooltip trigger icon — toggles the box. Tooltips in labels open
+     * on hover only.
+     */
     label?: ReactNode;
     labelComponent?: ReactNode;
     labelDescription?: string;
@@ -218,6 +224,7 @@ export const Checkbox = ({
           // so the opt-in wins.
           `pointer-events-none flex flex-row select-none **:pointer-events-none
           **:select-none [&_.tooltip-wrapper]:pointer-events-auto
+          [&_.tooltip-wrapper]:cursor-help
           [&_.tooltip-wrapper_*]:pointer-events-auto`,
           'amino-input-wrapper',
           disabled && ['cursor-not-allowed', 'disabled'],

--- a/src/components/checkbox/Checkbox.tsx
+++ b/src/components/checkbox/Checkbox.tsx
@@ -208,12 +208,17 @@ export const Checkbox = ({
         className={cn(
           // pointer-events-none on the wrapper + all descendants lets clicks
           // pass through to the real <input type="checkbox"> underneath, so
-          // clicking anywhere in the visual row toggles the box. Our Tooltip
-          // trigger is excluded so a ReactNode label like
-          // `<>Terms <Tooltip>?</Tooltip></>` can still be hovered — Tooltip
-          // is the only interactive content we put in labels.
-          `pointer-events-none flex flex-row select-none **:select-none
-          [&_*:not(.tooltip-wrapper)]:pointer-events-none`,
+          // clicking anywhere in the visual row toggles the box (that's the
+          // intended label behavior — a click on a decorative icon in the
+          // label still selects the box). Explicitly re-enable pointer events
+          // on our Tooltip trigger *and its subtree* so a ReactNode label
+          // like `<>Terms <Tooltip>?</Tooltip></>` receives hover — otherwise
+          // the SVG inside `.tooltip-wrapper` swallows the pointer with
+          // `none` and nothing fires. Higher specificity than the wildcard,
+          // so the opt-in wins.
+          `pointer-events-none flex flex-row select-none **:pointer-events-none
+          **:select-none [&_.tooltip-wrapper]:pointer-events-auto
+          [&_.tooltip-wrapper_*]:pointer-events-auto`,
           'amino-input-wrapper',
           disabled && ['cursor-not-allowed', 'disabled'],
         )}

--- a/src/components/checkbox/Checkbox.tsx
+++ b/src/components/checkbox/Checkbox.tsx
@@ -206,8 +206,14 @@ export const Checkbox = ({
       />
       <div
         className={cn(
-          `pointer-events-none flex flex-row select-none
-          [&_*]:pointer-events-none [&_*]:select-none`,
+          // pointer-events-none on the wrapper + all descendants lets clicks
+          // pass through to the real <input type="checkbox"> underneath, so
+          // clicking anywhere in the visual row toggles the box. Our Tooltip
+          // trigger is excluded so a ReactNode label like
+          // `<>Terms <Tooltip>?</Tooltip></>` can still be hovered — Tooltip
+          // is the only interactive content we put in labels.
+          `pointer-events-none flex flex-row select-none **:select-none
+          [&_*:not(.tooltip-wrapper)]:pointer-events-none`,
           'amino-input-wrapper',
           disabled && ['cursor-not-allowed', 'disabled'],
         )}

--- a/src/components/checkbox/__stories__/Checkbox.stories.tsx
+++ b/src/components/checkbox/__stories__/Checkbox.stories.tsx
@@ -6,7 +6,9 @@ import { expect, userEvent, within } from '@storybook/test';
 import { Checkbox, type CheckboxProps } from 'src/components/checkbox/Checkbox';
 import { Flex } from 'src/components/flex/Flex';
 import { Text } from 'src/components/text/Text';
+import { Tooltip } from 'src/components/tooltip/Tooltip';
 import { Default } from 'src/icons/flags/Default';
+import { InfoIcon } from 'src/icons/InfoIcon';
 
 const Template: StoryFn<CheckboxProps> = ({
   checked,
@@ -108,6 +110,20 @@ export const CheckboxWithComplexSubtitle: StoryObj<CheckboxProps> = {
         .
       </div>
     ),
+  },
+};
+
+export const CheckboxWithTooltipLabel: StoryObj<CheckboxProps> = {
+  args: {
+    label: (
+      <span className="inline-flex items-center gap-1 align-middle">
+        I agree to the terms
+        <Tooltip title="You can review the full agreement in your account settings at any time.">
+          <InfoIcon color="gray600" inlineBlock size={14} />
+        </Tooltip>
+      </span>
+    ),
+    subtitle: 'Subtitle here',
   },
 };
 

--- a/src/components/input/__stories__/Input.stories.tsx
+++ b/src/components/input/__stories__/Input.stories.tsx
@@ -6,9 +6,11 @@ import { Input, type InputProps } from 'src/components/input/Input';
 import { HStack } from 'src/components/stack/HStack';
 import { VStack } from 'src/components/stack/VStack';
 import { Text } from 'src/components/text/Text';
+import { Tooltip } from 'src/components/tooltip/Tooltip';
 import { BagIcon } from 'src/icons/BagIcon';
 import { CubeIcon } from 'src/icons/CubeIcon';
 import { FlagIcon } from 'src/icons/flag-icon/FlagIcon';
+import { InfoIcon } from 'src/icons/InfoIcon';
 import { SearchIcon } from 'src/icons/SearchIcon';
 
 const InputMeta: Meta = {
@@ -223,6 +225,49 @@ export const DynamicErrorAndHelpText: StoryFn<InputProps> = ({
       </Text>
     </VStack>
   );
+};
+
+export const LabelWithTooltip: StoryFn<InputProps> = ({
+  value: _value,
+  ...props
+}) => {
+  const [value, setValue] = useState(_value);
+  const [emptyValue, setEmptyValue] = useState('');
+  const labelNode = (
+    <span className="inline-flex items-center gap-1 align-middle">
+      HS code
+      <Tooltip title="Harmonized System code used by customs to classify goods.">
+        <InfoIcon color="gray600" inlineBlock size={12} />
+      </Tooltip>
+    </span>
+  );
+  return (
+    <VStack>
+      <Input
+        {...props}
+        label={labelNode}
+        onChange={e => setValue(e.target.value)}
+        value={value}
+      />
+      <Input
+        {...props}
+        label={labelNode}
+        onChange={e => setEmptyValue(e.target.value)}
+        placeholder="Enter HS code"
+        value={emptyValue}
+      />
+      <Input
+        {...props}
+        disabled
+        label={labelNode}
+        onChange={() => {}}
+        value="9503.00"
+      />
+    </VStack>
+  );
+};
+LabelWithTooltip.args = {
+  value: '9503.00',
 };
 
 export const Search: StoryFn<InputProps> = ({ value: _value, ...props }) => {

--- a/src/components/input/__stories__/InputSimple.stories.tsx
+++ b/src/components/input/__stories__/InputSimple.stories.tsx
@@ -9,9 +9,11 @@ import {
 import { HStack } from 'src/components/stack/HStack';
 import { VStack } from 'src/components/stack/VStack';
 import { Text } from 'src/components/text/Text';
+import { Tooltip } from 'src/components/tooltip/Tooltip';
 import { BagIcon } from 'src/icons/BagIcon';
 import { CubeIcon } from 'src/icons/CubeIcon';
 import { FlagIcon } from 'src/icons/flag-icon/FlagIcon';
+import { InfoIcon } from 'src/icons/InfoIcon';
 import { SearchIcon } from 'src/icons/SearchIcon';
 
 const InputMeta: Meta = {
@@ -248,4 +250,40 @@ export const Search: StoryFn<InputProps> = ({ value: _value, ...props }) => {
       </Text>
     </VStack>
   );
+};
+
+export const LabelWithTooltip: StoryFn<InputProps> = ({
+  value: _value,
+  ...props
+}) => {
+  const [value, setValue] = useState(_value);
+  const labelNode = (
+    <span className="inline-flex items-center gap-1 align-middle">
+      HS code
+      <Tooltip title="Harmonized System code used by customs to classify goods.">
+        <InfoIcon color="gray600" inlineBlock size={14} />
+      </Tooltip>
+    </span>
+  );
+  return (
+    <VStack>
+      <InputSimple
+        {...props}
+        label={labelNode}
+        onChange={e => setValue(e.target.value)}
+        placeholder="Enter HS code"
+        value={value}
+      />
+      <InputSimple
+        {...props}
+        disabled
+        label={labelNode}
+        onChange={() => {}}
+        value="9503.00"
+      />
+    </VStack>
+  );
+};
+LabelWithTooltip.args = {
+  value: '9503.00',
 };

--- a/src/components/input/input-simple/input-type/_DateInput.tsx
+++ b/src/components/input/input-simple/input-type/_DateInput.tsx
@@ -8,6 +8,7 @@ import {
 } from 'src/components/input/input-simple/input-type/_InputBase';
 import { CalendarIcon } from 'src/icons/CalendarIcon';
 import { cn } from 'src/utils/cn';
+import { getNodeText } from 'src/utils/getNodeText';
 
 export const DateInput = forwardRef<HTMLInputElement, InputBaseProps>(
   (
@@ -50,7 +51,7 @@ export const DateInput = forwardRef<HTMLInputElement, InputBaseProps>(
       >
         <InputBase
           ref={mergedRef}
-          aria-label={label}
+          aria-label={getNodeText(label)}
           autoFocus={autoFocus}
           disabled={disabled}
           error={error}

--- a/src/components/input/input-simple/input-type/_DateInput.tsx
+++ b/src/components/input/input-simple/input-type/_DateInput.tsx
@@ -8,7 +8,6 @@ import {
 } from 'src/components/input/input-simple/input-type/_InputBase';
 import { CalendarIcon } from 'src/icons/CalendarIcon';
 import { cn } from 'src/utils/cn';
-import { getNodeText } from 'src/utils/getNodeText';
 
 export const DateInput = forwardRef<HTMLInputElement, InputBaseProps>(
   (
@@ -51,7 +50,6 @@ export const DateInput = forwardRef<HTMLInputElement, InputBaseProps>(
       >
         <InputBase
           ref={mergedRef}
-          aria-label={getNodeText(label)}
           autoFocus={autoFocus}
           disabled={disabled}
           error={error}

--- a/src/components/input/input-simple/input-type/_InputBase.tsx
+++ b/src/components/input/input-simple/input-type/_InputBase.tsx
@@ -28,7 +28,7 @@ type InputBaseType = BaseProps & {
   disabled?: boolean;
   inputMode?: InputMode;
   /** A label that will be displayed above the input */
-  label?: string;
+  label?: ReactNode;
   /**
    * @default false
    */

--- a/src/components/input/input-simple/input-type/_InputBase.tsx
+++ b/src/components/input/input-simple/input-type/_InputBase.tsx
@@ -5,6 +5,7 @@ import {
   type InputHTMLAttributes,
   type KeyboardEventHandler,
   type ReactNode,
+  useId,
 } from 'react';
 
 import type { HelpTextProps } from 'src/components/help-text/HelpText';
@@ -115,6 +116,7 @@ export const InputBase = forwardRef<HTMLInputElement, InputBaseProps>(
       className,
       disabled,
       error,
+      id: idProp,
       label,
       noBorder,
       placeholder,
@@ -127,6 +129,9 @@ export const InputBase = forwardRef<HTMLInputElement, InputBaseProps>(
     },
     ref,
   ) => {
+    const generatedId = useId();
+    const id = idProp || generatedId;
+
     const sizeClasses = {
       lg: 'h-12',
       md: 'h-10',
@@ -139,6 +144,10 @@ export const InputBase = forwardRef<HTMLInputElement, InputBaseProps>(
         {label && (
           <label
             className={cn('mb-2 block flex-none', error && 'text-red-600')}
+            // The label doesn't wrap the input, so htmlFor is the only thing
+            // giving the input an accessible name — including when the label
+            // is markup or a component whose text can't be extracted.
+            htmlFor={id}
             style={error ? undefined : { color: theme.textColorSecondary }}
           >
             {label}
@@ -179,6 +188,7 @@ export const InputBase = forwardRef<HTMLInputElement, InputBaseProps>(
               bg-transparent px-4 font-medium outline-none
               placeholder:font-normal placeholder:text-gray-500"
             disabled={disabled}
+            id={id}
             placeholder={placeholder}
             value={value || ''}
             {...props}

--- a/src/components/input/input-simple/input-type/_NumberInput.tsx
+++ b/src/components/input/input-simple/input-type/_NumberInput.tsx
@@ -11,6 +11,7 @@ import { CaretUpIcon } from 'src/icons/CaretUpIcon';
 import { theme } from 'src/styles/constants/theme';
 import type { Size } from 'src/types/Size';
 import { cn } from 'src/utils/cn';
+import { getNodeText } from 'src/utils/getNodeText';
 
 const sizeVar: Record<Size, string> = {
   lg: theme.sizeLg,
@@ -48,7 +49,7 @@ export const NumberInput = forwardRef<HTMLInputElement, InputBaseProps>(
         <InputBase
           {...props}
           ref={mergedRef}
-          aria-label={label}
+          aria-label={getNodeText(label)}
           className="[&_input]:appearance-none [&_input]:pr-10
             [&_input]:[-moz-appearance:textfield]
             [&_input::-webkit-calendar-picker-indicator]:hidden

--- a/src/components/input/input-simple/input-type/_NumberInput.tsx
+++ b/src/components/input/input-simple/input-type/_NumberInput.tsx
@@ -11,7 +11,6 @@ import { CaretUpIcon } from 'src/icons/CaretUpIcon';
 import { theme } from 'src/styles/constants/theme';
 import type { Size } from 'src/types/Size';
 import { cn } from 'src/utils/cn';
-import { getNodeText } from 'src/utils/getNodeText';
 
 const sizeVar: Record<Size, string> = {
   lg: theme.sizeLg,
@@ -49,7 +48,6 @@ export const NumberInput = forwardRef<HTMLInputElement, InputBaseProps>(
         <InputBase
           {...props}
           ref={mergedRef}
-          aria-label={getNodeText(label)}
           className="[&_input]:appearance-none [&_input]:pr-10
             [&_input]:[-moz-appearance:textfield]
             [&_input::-webkit-calendar-picker-indicator]:hidden

--- a/src/components/input/input-simple/input-type/_PasswordInput.tsx
+++ b/src/components/input/input-simple/input-type/_PasswordInput.tsx
@@ -8,6 +8,7 @@ import {
 import { EyeIcon } from 'src/icons/EyeIcon';
 import { EyeOffIcon } from 'src/icons/EyeOffIcon';
 import { cn } from 'src/utils/cn';
+import { getNodeText } from 'src/utils/getNodeText';
 
 export const PasswordInput = forwardRef<HTMLInputElement, InputBaseProps>(
   (
@@ -37,7 +38,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, InputBaseProps>(
       <div className={cn('relative w-full', className)}>
         <InputBase
           ref={ref}
-          aria-label={label}
+          aria-label={getNodeText(label)}
           autoFocus={autoFocus}
           className="[&_input]:pr-10"
           disabled={disabled}

--- a/src/components/input/input-simple/input-type/_PasswordInput.tsx
+++ b/src/components/input/input-simple/input-type/_PasswordInput.tsx
@@ -8,7 +8,6 @@ import {
 import { EyeIcon } from 'src/icons/EyeIcon';
 import { EyeOffIcon } from 'src/icons/EyeOffIcon';
 import { cn } from 'src/utils/cn';
-import { getNodeText } from 'src/utils/getNodeText';
 
 export const PasswordInput = forwardRef<HTMLInputElement, InputBaseProps>(
   (
@@ -38,7 +37,6 @@ export const PasswordInput = forwardRef<HTMLInputElement, InputBaseProps>(
       <div className={cn('relative w-full', className)}>
         <InputBase
           ref={ref}
-          aria-label={getNodeText(label)}
           autoFocus={autoFocus}
           className="[&_input]:pr-10"
           disabled={disabled}

--- a/src/components/input/input-simple/input-type/_TimeInput.tsx
+++ b/src/components/input/input-simple/input-type/_TimeInput.tsx
@@ -8,6 +8,7 @@ import {
 } from 'src/components/input/input-simple/input-type/_InputBase';
 import { ClockIcon } from 'src/icons/ClockIcon';
 import { cn } from 'src/utils/cn';
+import { getNodeText } from 'src/utils/getNodeText';
 
 export const TimeInput = forwardRef<HTMLInputElement, InputBaseProps>(
   (
@@ -47,7 +48,7 @@ export const TimeInput = forwardRef<HTMLInputElement, InputBaseProps>(
       >
         <InputBase
           ref={mergedRef}
-          aria-label={label}
+          aria-label={getNodeText(label)}
           autoFocus={autoFocus}
           disabled={disabled}
           error={error}

--- a/src/components/input/input-simple/input-type/_TimeInput.tsx
+++ b/src/components/input/input-simple/input-type/_TimeInput.tsx
@@ -8,7 +8,6 @@ import {
 } from 'src/components/input/input-simple/input-type/_InputBase';
 import { ClockIcon } from 'src/icons/ClockIcon';
 import { cn } from 'src/utils/cn';
-import { getNodeText } from 'src/utils/getNodeText';
 
 export const TimeInput = forwardRef<HTMLInputElement, InputBaseProps>(
   (
@@ -48,7 +47,6 @@ export const TimeInput = forwardRef<HTMLInputElement, InputBaseProps>(
       >
         <InputBase
           ref={mergedRef}
-          aria-label={getNodeText(label)}
           autoFocus={autoFocus}
           disabled={disabled}
           error={error}

--- a/src/components/input/input-type/_DateInput.tsx
+++ b/src/components/input/input-type/_DateInput.tsx
@@ -8,7 +8,6 @@ import {
 } from 'src/components/input/input-type/_FloatLabelInput';
 import { CalendarIcon } from 'src/icons/CalendarIcon';
 import { cn } from 'src/utils/cn';
-import { getNodeText } from 'src/utils/getNodeText';
 
 export const DateInput = forwardRef<HTMLInputElement, FloatLabelInputProps>(
   (
@@ -55,7 +54,6 @@ export const DateInput = forwardRef<HTMLInputElement, FloatLabelInputProps>(
       >
         <FloatLabelInput
           ref={mergedRef}
-          aria-label={getNodeText(label)}
           autoFocus={autoFocus}
           disabled={disabled}
           error={error}

--- a/src/components/input/input-type/_DateInput.tsx
+++ b/src/components/input/input-type/_DateInput.tsx
@@ -8,6 +8,7 @@ import {
 } from 'src/components/input/input-type/_FloatLabelInput';
 import { CalendarIcon } from 'src/icons/CalendarIcon';
 import { cn } from 'src/utils/cn';
+import { getNodeText } from 'src/utils/getNodeText';
 
 export const DateInput = forwardRef<HTMLInputElement, FloatLabelInputProps>(
   (
@@ -54,7 +55,7 @@ export const DateInput = forwardRef<HTMLInputElement, FloatLabelInputProps>(
       >
         <FloatLabelInput
           ref={mergedRef}
-          aria-label={label}
+          aria-label={getNodeText(label)}
           autoFocus={autoFocus}
           disabled={disabled}
           error={error}

--- a/src/components/input/input-type/_FloatLabelInput.tsx
+++ b/src/components/input/input-type/_FloatLabelInput.tsx
@@ -287,7 +287,15 @@ export const FloatLabelInput = forwardRef<
           {...props}
         />
         <div
+          // pointer-events-none lets clicks on the label text pass through
+          // to the input beneath (so the cursor lands where the user clicked
+          // instead of the label capturing the click). Interactive descendants
+          // — links, buttons, and our Tooltip trigger — opt back in so a
+          // ReactNode label like `<>Label <Tooltip>?</Tooltip></>` still works.
           className="pointer-events-none order-1 block max-h-0
+            [&_.tooltip-wrapper]:pointer-events-auto [&_a]:pointer-events-auto
+            [&_button]:pointer-events-auto
+            **:[[role=button]]:pointer-events-auto
             [.disabled_&]:pointer-events-auto"
         >
           <span

--- a/src/components/input/input-type/_FloatLabelInput.tsx
+++ b/src/components/input/input-type/_FloatLabelInput.tsx
@@ -250,7 +250,11 @@ export const FloatLabelInput = forwardRef<
         )}
         <input
           ref={ref}
-          aria-label={getNodeText(label)}
+          // Only string labels become an aria-label. For markup labels the
+          // wrapping <label> supplies the accessible name from rendered text —
+          // extracting here could truncate it (aria-label overrides the
+          // association) or drop it entirely for component labels.
+          aria-label={typeof label === 'string' ? label : undefined}
           autoFocus={autoFocus}
           className={cn(
             `bg-amino-input relative order-2 box-border w-full
@@ -292,10 +296,14 @@ export const FloatLabelInput = forwardRef<
           // instead of the label capturing the click). Our Tooltip trigger
           // opts back in so a ReactNode label like
           // `<>Label <Tooltip>?</Tooltip></>` can still be hovered — Tooltip
-          // is the only interactive content we put in labels.
+          // is the only interactive content we put in labels. When disabled,
+          // the label text hit-tests again and shows the not-allowed cursor
+          // (the ::after overlay below is always click-through, so the cursor
+          // has to live on an element that gets hit).
           className="pointer-events-none order-1 block max-h-0
             [&_.tooltip-wrapper]:pointer-events-auto
-            [.disabled_&]:pointer-events-auto"
+            [&_.tooltip-wrapper]:cursor-help [.disabled_&]:pointer-events-auto
+            [.disabled_&]:cursor-not-allowed"
         >
           <span
             className={cn(
@@ -317,17 +325,15 @@ export const FloatLabelInput = forwardRef<
           </span>
           <div
             className={cn(
-              // The ::after overlay only exists to draw the disabled cursor
-              // and z-index veil, so make it click-through by default —
-              // otherwise it sits above the label span (which lives inside
-              // the same block) and swallows hover on interactive descendants
-              // like a Tooltip trigger in the label. In the disabled state we
-              // re-enable pointer events so the not-allowed cursor shows.
+              // The ::after overlay is decorative; keep it click-through so
+              // it never sits above the label span (which lives inside the
+              // same block) and swallows hover on interactive descendants
+              // like a Tooltip trigger in the label. The disabled cursor is
+              // drawn by the label wrapper above — a click-through pseudo is
+              // never hit-tested, so a cursor here would never show.
               `after:pointer-events-none after:absolute after:inset-0
               after:rounded-[var(--amino-float-label-input-border-radius)]
               after:content-['']`,
-              `.disabled_&:after:pointer-events-auto
-              .disabled_&:after:cursor-not-allowed .disabled_&:after:z-[1]`,
             )}
           />
         </div>

--- a/src/components/input/input-type/_FloatLabelInput.tsx
+++ b/src/components/input/input-type/_FloatLabelInput.tsx
@@ -289,13 +289,12 @@ export const FloatLabelInput = forwardRef<
         <div
           // pointer-events-none lets clicks on the label text pass through
           // to the input beneath (so the cursor lands where the user clicked
-          // instead of the label capturing the click). Interactive descendants
-          // — links, buttons, and our Tooltip trigger — opt back in so a
-          // ReactNode label like `<>Label <Tooltip>?</Tooltip></>` still works.
+          // instead of the label capturing the click). Our Tooltip trigger
+          // opts back in so a ReactNode label like
+          // `<>Label <Tooltip>?</Tooltip></>` can still be hovered — Tooltip
+          // is the only interactive content we put in labels.
           className="pointer-events-none order-1 block max-h-0
-            [&_.tooltip-wrapper]:pointer-events-auto [&_a]:pointer-events-auto
-            [&_button]:pointer-events-auto
-            **:[[role=button]]:pointer-events-auto
+            [&_.tooltip-wrapper]:pointer-events-auto
             [.disabled_&]:pointer-events-auto"
         >
           <span
@@ -318,10 +317,17 @@ export const FloatLabelInput = forwardRef<
           </span>
           <div
             className={cn(
-              `after:absolute after:inset-0
+              // The ::after overlay only exists to draw the disabled cursor
+              // and z-index veil, so make it click-through by default —
+              // otherwise it sits above the label span (which lives inside
+              // the same block) and swallows hover on interactive descendants
+              // like a Tooltip trigger in the label. In the disabled state we
+              // re-enable pointer events so the not-allowed cursor shows.
+              `after:pointer-events-none after:absolute after:inset-0
               after:rounded-[var(--amino-float-label-input-border-radius)]
               after:content-['']`,
-              '.disabled_&:after:cursor-not-allowed .disabled_&:after:z-[1]',
+              `.disabled_&:after:pointer-events-auto
+              .disabled_&:after:cursor-not-allowed .disabled_&:after:z-[1]`,
             )}
           />
         </div>

--- a/src/components/input/input-type/_FloatLabelInput.tsx
+++ b/src/components/input/input-type/_FloatLabelInput.tsx
@@ -14,6 +14,7 @@ import { theme } from 'src/styles/constants/theme';
 import type { BaseProps } from 'src/types/BaseProps';
 import type { Size } from 'src/types/Size';
 import { cn } from 'src/utils/cn';
+import { getNodeText } from 'src/utils/getNodeText';
 import { getTestId } from 'src/utils/getTestId';
 
 export type InputMode =
@@ -48,7 +49,7 @@ type FloatLabelInputType = BaseProps & {
   inputMode?: InputMode;
 
   /** A label that will be displayed above the input */
-  label?: string;
+  label?: ReactNode;
 
   /**
    * @default false
@@ -169,7 +170,7 @@ export const FloatLabelInput = forwardRef<
   ) => {
     const inputId = useId();
     const testId = useMemo(
-      () => getTestId({ componentName: 'input', name: label }),
+      () => getTestId({ componentName: 'input', name: getNodeText(label) }),
       [label],
     );
     const hasValue = !!value || !!valuePrefix;
@@ -249,7 +250,7 @@ export const FloatLabelInput = forwardRef<
         )}
         <input
           ref={ref}
-          aria-label={label}
+          aria-label={getNodeText(label)}
           autoFocus={autoFocus}
           className={cn(
             `bg-amino-input relative order-2 box-border w-full

--- a/src/components/input/input-type/_NumberInput.tsx
+++ b/src/components/input/input-type/_NumberInput.tsx
@@ -11,6 +11,7 @@ import { CaretUpIcon } from 'src/icons/CaretUpIcon';
 import { theme } from 'src/styles/constants/theme';
 import type { Size } from 'src/types/Size';
 import { cn } from 'src/utils/cn';
+import { getNodeText } from 'src/utils/getNodeText';
 
 const sizeVar: Record<Size, string> = {
   lg: theme.sizeLg,
@@ -48,7 +49,7 @@ export const NumberInput = forwardRef<HTMLInputElement, FloatLabelInputProps>(
         <FloatLabelInput
           {...props}
           ref={mergedRef}
-          aria-label={label}
+          aria-label={getNodeText(label)}
           className="[&_input]:appearance-none [&_input]:pr-10
             [&_input::-webkit-calendar-picker-indicator]:hidden
             [&_input::-webkit-inner-spin-button]:hidden"

--- a/src/components/input/input-type/_NumberInput.tsx
+++ b/src/components/input/input-type/_NumberInput.tsx
@@ -11,7 +11,6 @@ import { CaretUpIcon } from 'src/icons/CaretUpIcon';
 import { theme } from 'src/styles/constants/theme';
 import type { Size } from 'src/types/Size';
 import { cn } from 'src/utils/cn';
-import { getNodeText } from 'src/utils/getNodeText';
 
 const sizeVar: Record<Size, string> = {
   lg: theme.sizeLg,
@@ -49,7 +48,6 @@ export const NumberInput = forwardRef<HTMLInputElement, FloatLabelInputProps>(
         <FloatLabelInput
           {...props}
           ref={mergedRef}
-          aria-label={getNodeText(label)}
           className="[&_input]:appearance-none [&_input]:pr-10
             [&_input::-webkit-calendar-picker-indicator]:hidden
             [&_input::-webkit-inner-spin-button]:hidden"

--- a/src/components/input/input-type/_PasswordInput.tsx
+++ b/src/components/input/input-type/_PasswordInput.tsx
@@ -8,7 +8,6 @@ import {
 import { EyeIcon } from 'src/icons/EyeIcon';
 import { EyeOffIcon } from 'src/icons/EyeOffIcon';
 import { cn } from 'src/utils/cn';
-import { getNodeText } from 'src/utils/getNodeText';
 
 export const PasswordInput = forwardRef<HTMLInputElement, FloatLabelInputProps>(
   (
@@ -38,7 +37,6 @@ export const PasswordInput = forwardRef<HTMLInputElement, FloatLabelInputProps>(
       <div className={cn('relative w-full', className)}>
         <FloatLabelInput
           ref={ref}
-          aria-label={getNodeText(label)}
           autoFocus={autoFocus}
           className="[&_input]:pr-10"
           disabled={disabled}

--- a/src/components/input/input-type/_PasswordInput.tsx
+++ b/src/components/input/input-type/_PasswordInput.tsx
@@ -8,6 +8,7 @@ import {
 import { EyeIcon } from 'src/icons/EyeIcon';
 import { EyeOffIcon } from 'src/icons/EyeOffIcon';
 import { cn } from 'src/utils/cn';
+import { getNodeText } from 'src/utils/getNodeText';
 
 export const PasswordInput = forwardRef<HTMLInputElement, FloatLabelInputProps>(
   (
@@ -37,7 +38,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, FloatLabelInputProps>(
       <div className={cn('relative w-full', className)}>
         <FloatLabelInput
           ref={ref}
-          aria-label={label}
+          aria-label={getNodeText(label)}
           autoFocus={autoFocus}
           className="[&_input]:pr-10"
           disabled={disabled}

--- a/src/components/input/input-type/_TimeInput.tsx
+++ b/src/components/input/input-type/_TimeInput.tsx
@@ -8,7 +8,6 @@ import {
 } from 'src/components/input/input-type/_FloatLabelInput';
 import { ClockIcon } from 'src/icons/ClockIcon';
 import { cn } from 'src/utils/cn';
-import { getNodeText } from 'src/utils/getNodeText';
 
 export const TimeInput = forwardRef<HTMLInputElement, FloatLabelInputProps>(
   (
@@ -48,7 +47,6 @@ export const TimeInput = forwardRef<HTMLInputElement, FloatLabelInputProps>(
       >
         <FloatLabelInput
           ref={mergedRef}
-          aria-label={getNodeText(label)}
           autoFocus={autoFocus}
           disabled={disabled}
           error={error}

--- a/src/components/input/input-type/_TimeInput.tsx
+++ b/src/components/input/input-type/_TimeInput.tsx
@@ -8,6 +8,7 @@ import {
 } from 'src/components/input/input-type/_FloatLabelInput';
 import { ClockIcon } from 'src/icons/ClockIcon';
 import { cn } from 'src/utils/cn';
+import { getNodeText } from 'src/utils/getNodeText';
 
 export const TimeInput = forwardRef<HTMLInputElement, FloatLabelInputProps>(
   (
@@ -47,7 +48,7 @@ export const TimeInput = forwardRef<HTMLInputElement, FloatLabelInputProps>(
       >
         <FloatLabelInput
           ref={mergedRef}
-          aria-label={label}
+          aria-label={getNodeText(label)}
           autoFocus={autoFocus}
           disabled={disabled}
           error={error}

--- a/src/components/select/CountryMultiSelect.tsx
+++ b/src/components/select/CountryMultiSelect.tsx
@@ -82,7 +82,7 @@ export type CountryMultiSelectProps<
    * Label for the select field
    * @default 'Select countries'
    */
-  label?: string;
+  label?: ReactNode;
   /**
    * Handler called when selection changes
    * @param countryCodes Array of country codes that are selected

--- a/src/components/select/CountrySelect.tsx
+++ b/src/components/select/CountrySelect.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react';
+
 import { Select, type SelectProps } from 'src/components/select/Select';
 import { type Flag, FlagIcon } from 'src/icons/flag-icon/FlagIcon';
 import type { BaseProps } from 'src/types/BaseProps';
@@ -22,7 +24,7 @@ type CountrySelectType<T extends string> = {
   /**
    * Label displayed above the select input
    */
-  label?: string;
+  label?: ReactNode;
   /**
    * Handler called when selection changes
    * @param value The selected country value or null if cleared

--- a/src/components/select/MultiSelect.tsx
+++ b/src/components/select/MultiSelect.tsx
@@ -28,7 +28,7 @@ export type MultiSelectProps<
   components?: SelectComponentsConfig<Option, IsMulti, Group>;
   hasGroups?: boolean;
   icon?: ReactNode;
-  label?: string;
+  label?: ReactNode;
   styles?: StylesConfig<Option, IsMulti, Group>;
   /**
    * @example

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -12,6 +12,7 @@ import { StyledReactSelect } from 'src/components/select/_StyledReactSelect';
 import type { BaseProps } from 'src/types/BaseProps';
 import type { SelectOption, SelectValue } from 'src/types/SelectOption';
 import type { Size } from 'src/types/Size';
+import { getNodeText } from 'src/utils/getNodeText';
 
 type RequiredProps = 'options' | 'value';
 
@@ -30,7 +31,7 @@ export type SelectProps<
   customOption?: (value: V) => ReactNode;
   hasGroups?: boolean;
   icon?: ReactNode;
-  label?: string;
+  label?: ReactNode;
   /**
    * @example
    * onChange={changed => setExampleValue(changed?.value || null)}
@@ -154,7 +155,9 @@ export const Select = <
 }: SelectProps<V, Option, false, Group>) => {
   if (Array.isArray(value) && value.length > 1) {
     throw Error(
-      `Only one selection allowed for '${label}' select (${value.length}) selected.`,
+      // A markup label would stringify to '[object Object]' here, so read its
+      // text — the whole point of this message is naming which select threw.
+      `Only one selection allowed for '${getNodeText(label) ?? ''}' select (${value.length}) selected.`,
     );
   }
   return (

--- a/src/components/select/_StyledReactSelect.tsx
+++ b/src/components/select/_StyledReactSelect.tsx
@@ -30,6 +30,7 @@ import type { BaseProps } from 'src/types/BaseProps';
 import type { SelectOption, SelectValue } from 'src/types/SelectOption';
 import type { Size } from 'src/types/Size';
 import { cn } from 'src/utils/cn';
+import { getNodeText } from 'src/utils/getNodeText';
 import { getTestId } from 'src/utils/getTestId';
 
 const sizeHeight: Record<Size, string> = {
@@ -57,7 +58,7 @@ type AdditionalProps<Value> = {
   customOption?: (value: Value) => ReactNode;
   hasGroups?: boolean;
   icon?: ReactNode;
-  label?: string;
+  label?: ReactNode;
   size?: Size;
 };
 
@@ -447,7 +448,7 @@ export const StyledReactSelect = <
     size,
   };
   const testId = useMemo(
-    () => getTestId({ componentName: 'select', name: label }),
+    () => getTestId({ componentName: 'select', name: getNodeText(label) }),
     [label],
   );
 

--- a/src/components/select/__stories__/CountryMultiSelect.stories.tsx
+++ b/src/components/select/__stories__/CountryMultiSelect.stories.tsx
@@ -6,6 +6,8 @@ import {
   CountryMultiSelect,
   type CountryMultiSelectProps,
 } from 'src/components/select/CountryMultiSelect';
+import { Tooltip } from 'src/components/tooltip/Tooltip';
+import { InfoIcon } from 'src/icons/InfoIcon';
 import { getCountryUrls } from 'src/utils/getCountryUrls';
 import type { CountryOption } from 'src/utils/hooks/useCountryOptions';
 import { useCountryOptions } from 'src/utils/hooks/useCountryOptions';
@@ -66,3 +68,25 @@ const CountryMultiSelectTemplate: StoryFn<CountryMultiSelectProps> = (
 };
 
 export const BasicCountryMultiSelect = CountryMultiSelectTemplate.bind({});
+
+export const LabelWithTooltip: StoryFn<CountryMultiSelectProps> = () => {
+  const [value, setValue] = useState<string[]>([]);
+  const dashboardUrl = getCountryUrls();
+  const countryOptions = useCountryOptions({ dashboardUrl });
+  return (
+    <CountryMultiSelect
+      countryOptions={countryOptions}
+      label={
+        <span className="inline-flex items-center gap-1 align-middle">
+          Ship-to countries
+          <Tooltip title="Choose every destination country you want to enable at checkout.">
+            <InfoIcon color="gray600" inlineBlock size={14} />
+          </Tooltip>
+        </span>
+      }
+      onChange={setValue}
+      unavailableCountries={[{ code: 'DZ', message: '(restricted)' }]}
+      value={value}
+    />
+  );
+};

--- a/src/components/select/__stories__/CountrySelect.stories.tsx
+++ b/src/components/select/__stories__/CountrySelect.stories.tsx
@@ -6,6 +6,8 @@ import {
   CountrySelect,
   type CountrySelectProps,
 } from 'src/components/select/CountrySelect';
+import { Tooltip } from 'src/components/tooltip/Tooltip';
+import { InfoIcon } from 'src/icons/InfoIcon';
 import { getCountryUrls } from 'src/utils/getCountryUrls';
 import {
   type CountryOption,
@@ -68,4 +70,27 @@ BasicCountrySelect.parameters = {
     type: 'figma',
     url: 'https://www.figma.com/file/dKbMcUDxYQ8INw5cUdvXLI/amino-tokens-2021?node-id=79%3A135',
   },
+};
+
+export const LabelWithTooltip: StoryFn<CountrySelectProps> = props => {
+  const [value, setValue] = useState<string | null>(null);
+  const dashboardUrl = getCountryUrls();
+  const countryOptions = useCountryOptions({ dashboardUrl });
+  return (
+    <CountrySelect
+      {...props}
+      countryOptions={countryOptions}
+      label={
+        <span className="inline-flex items-center gap-1 align-middle">
+          Country of origin
+          <Tooltip title="Where the item was manufactured or produced.">
+            <InfoIcon color="gray600" inlineBlock size={14} />
+          </Tooltip>
+        </span>
+      }
+      onChange={option => setValue(option?.value || null)}
+      placeholder="Select a country"
+      value={value}
+    />
+  );
 };

--- a/src/components/select/__stories__/MultiSelect.stories.tsx
+++ b/src/components/select/__stories__/MultiSelect.stories.tsx
@@ -6,6 +6,8 @@ import {
   MultiSelect,
   type MultiSelectProps,
 } from 'src/components/select/MultiSelect';
+import { Tooltip } from 'src/components/tooltip/Tooltip';
+import { InfoIcon } from 'src/icons/InfoIcon';
 import { PlayCircleIcon } from 'src/icons/PlayCircleIcon';
 
 const SelectMeta: Meta = {
@@ -138,6 +140,25 @@ ActiveMultiSelectWithCutoff.args = {
       value: 'NZD',
     },
   ],
+};
+
+export const LabelWithTooltip = MultiSelectTemplate.bind({});
+LabelWithTooltip.args = {
+  label: (
+    <span className="inline-flex items-center gap-1 align-middle">
+      Currencies
+      <Tooltip title="Select every currency you want to display prices in.">
+        <InfoIcon color="gray600" inlineBlock size={14} />
+      </Tooltip>
+    </span>
+  ),
+  options: [
+    { label: 'US Dollar (USD)', value: 'USD' },
+    { label: 'European Euro (EUR)', value: 'EUR' },
+    { label: 'Japanese Yen (JPY)', value: 'JPY' },
+    { label: 'British Pound (GBP)', value: 'GBP' },
+  ],
+  value: [{ label: 'US Dollar (USD)', value: 'USD' }],
 };
 
 export const ActiveMultiSelectWithCutoffWithIcon = MultiSelectTemplate.bind({});

--- a/src/components/select/__stories__/Select.stories.tsx
+++ b/src/components/select/__stories__/Select.stories.tsx
@@ -8,8 +8,10 @@ import { Dialog } from 'src/components/dialog/Dialog';
 import { Select, type SelectProps } from 'src/components/select/Select';
 import { VStack } from 'src/components/stack/VStack';
 import { Text } from 'src/components/text/Text';
+import { Tooltip } from 'src/components/tooltip/Tooltip';
 import { FileIcon } from 'src/icons/FileIcon';
 import { FlagIcon } from 'src/icons/flag-icon/FlagIcon';
+import { InfoIcon } from 'src/icons/InfoIcon';
 import { MoneyIcon } from 'src/icons/MoneyIcon';
 import { theme } from 'src/styles/constants/theme';
 import type { SelectOption } from 'src/types/SelectOption';
@@ -255,6 +257,25 @@ export const ScrollableDialogSelect = () => {
       </Dialog>
     </div>
   );
+};
+
+export const LabelWithTooltip: StoryObj<SelectProps> = {
+  args: {
+    label: (
+      <span className="inline-flex items-center gap-1 align-middle">
+        Currency
+        <Tooltip title="Prices, taxes, and duties will be displayed in this currency.">
+          <InfoIcon color="gray600" inlineBlock size={14} />
+        </Tooltip>
+      </span>
+    ),
+    options: currencyOptions,
+    placeholder: 'Select a currency',
+    value: {
+      label: 'US Dollar (USD)',
+      value: 'USD',
+    },
+  },
 };
 
 export const SelectWithNumberOptions = () => {

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react';
+
 import { Text } from 'src/components/text/Text';
 import { theme } from 'src/styles/constants/theme';
 import type { BaseProps } from 'src/types/BaseProps';
@@ -11,7 +13,7 @@ export type TabsProps = BaseProps & {
    * @default 'start'
    */
   align?: 'start' | 'center' | 'end';
-  items: string[];
+  items: ReactNode[];
   onChange: (selectedTab: number) => void;
   selected: number;
   /**
@@ -121,9 +123,11 @@ export const Tabs = ({
           '--amino-tabs-color': getTabColor(),
         }}
       >
-        {items.map(item => (
+        {items.map((item, index) => (
           <button
-            key={item}
+            // Tabs are a positional list — `onChange` reports an index and
+            // `selected` is an index — so position *is* the identity here.
+            key={index}
             className={cn(
               `relative cursor-pointer py-3 text-center transition-all
               select-none`,
@@ -133,21 +137,21 @@ export const Tabs = ({
               after:transition-all after:content-['']`,
               `focus:outline-none focus-visible:shadow-[var(--amino-glow-blue)]
               focus-visible:outline-none active:outline-none`,
-              selected === items.indexOf(item) && [
+              selected === index && [
                 'text-[var(--amino-tabs-color)]',
                 '[&>span]:text-[var(--amino-tabs-color)]',
                 'after:scale-x-100 after:bg-[var(--amino-tabs-color)]',
                 // Used for external styling
                 'is-selected',
               ],
-              selected !== items.indexOf(item) && [
+              selected !== index && [
                 'hover:text-gray-1000 hover:after:scale-x-100',
                 'focus:text-gray-1000 focus:after:scale-x-100',
                 `active:text-gray-1000 active:after:scale-x-100
                 active:after:bg-gray-300`,
               ],
             )}
-            onClick={() => onChange(items.indexOf(item))}
+            onClick={() => onChange(index)}
             type="button"
           >
             <Text type="label">{item}</Text>
@@ -168,9 +172,10 @@ export const Tabs = ({
         '--amino-tabs-color': getTabColor(),
       }}
     >
-      {items.map(item => (
+      {items.map((item, index) => (
         <button
-          key={item}
+          // Positional identity — see the subtle branch above.
+          key={index}
           className={cn(
             `relative flex-1 cursor-pointer py-3 text-center font-medium
             transition-all select-none`,
@@ -182,13 +187,13 @@ export const Tabs = ({
             '[&+button]:border-amino [&+button]:border-l',
             `focus:outline-none focus-visible:shadow-[var(--amino-glow-blue)]
             focus-visible:outline-none active:outline-none`,
-            selected === items.indexOf(item) && [
+            selected === index && [
               'text-[var(--amino-tabs-color)]',
               'after:scale-x-100 after:bg-[var(--amino-tabs-color)]',
               // Used for external styling
               'is-selected',
             ],
-            selected !== items.indexOf(item) && [
+            selected !== index && [
               'hover:bg-[rgba(0,0,0,0.03)]',
               'hover:text-gray-1000 hover:after:scale-x-100',
               'focus:text-gray-1000 focus:after:scale-x-100',
@@ -197,7 +202,7 @@ export const Tabs = ({
               active:after:bg-gray-300`,
             ],
           )}
-          onClick={() => onChange(items.indexOf(item))}
+          onClick={() => onChange(index)}
           type="button"
         >
           {item}

--- a/src/components/tabs/__stories__/Tabs.stories.tsx
+++ b/src/components/tabs/__stories__/Tabs.stories.tsx
@@ -1,10 +1,12 @@
-import { useState } from 'react';
+import { type ReactNode, useState } from 'react';
 
 import type { Meta, StoryFn } from '@storybook/react';
 
 import { VStack } from 'src/components/stack/VStack';
 import { Tabs, type TabsProps } from 'src/components/tabs/Tabs';
 import { Text } from 'src/components/text/Text';
+import { Tooltip } from 'src/components/tooltip/Tooltip';
+import { InfoIcon } from 'src/icons/InfoIcon';
 
 const TabsMeta: Meta = {
   component: Tabs,
@@ -34,6 +36,45 @@ export const BasicTabs = Template.bind({});
 
 export const Subtle = Template.bind({});
 Subtle.args = {
+  align: 'center',
+  subtle: true,
+  variant: 'primary',
+};
+
+const withTooltip = ({ label, tip }: { label: string; tip: string }) => (
+  <span className="inline-flex items-center gap-1 align-middle">
+    {label}
+    <Tooltip title={tip}>
+      <InfoIcon color="gray600" inlineBlock size={14} />
+    </Tooltip>
+  </span>
+);
+
+const itemsWithTooltip: ReactNode[] = [
+  withTooltip({ label: 'Overview', tip: 'High-level summary of this section' }),
+  withTooltip({ label: 'Activity', tip: 'Recent activity and events' }),
+  withTooltip({ label: 'Settings', tip: 'Configuration options' }),
+];
+
+const ItemsWithTooltipTemplate: StoryFn<TabsProps> = props => {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  return (
+    <VStack>
+      <Tabs
+        {...props}
+        items={itemsWithTooltip}
+        onChange={setSelectedIndex}
+        selected={selectedIndex}
+      />
+      <Text type="bold-label">Selected index: {selectedIndex}</Text>
+    </VStack>
+  );
+};
+
+export const ItemsWithTooltip = ItemsWithTooltipTemplate.bind({});
+
+export const ItemsWithTooltipSubtle = ItemsWithTooltipTemplate.bind({});
+ItemsWithTooltipSubtle.args = {
   align: 'center',
   subtle: true,
   variant: 'primary',

--- a/src/components/textarea/Textarea.tsx
+++ b/src/components/textarea/Textarea.tsx
@@ -258,13 +258,11 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
                   ease-in-out`,
                   // pointer-events-none lets clicks on the label text pass
                   // through to the textarea beneath (so the cursor lands where
-                  // the user clicked). Interactive descendants — links,
-                  // buttons, and our Tooltip trigger — opt back in so a
+                  // the user clicked). Our Tooltip trigger opts back in so a
                   // ReactNode label like `<>Label <Tooltip>?</Tooltip></>`
-                  // still works.
-                  `[&_.tooltip-wrapper]:pointer-events-auto
-                  [&_a]:pointer-events-auto [&_button]:pointer-events-auto
-                  **:[[role=button]]:pointer-events-auto`,
+                  // can still be hovered — Tooltip is the only interactive
+                  // content we put in labels.
+                  '[&_.tooltip-wrapper]:pointer-events-auto',
                   (hasValue || isFocused) && 'top-[11px] scale-[0.8]',
                 )}
                 style={{ color: theme.gray800 }}
@@ -273,8 +271,12 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
               </span>
             )}
             <div
-              className="after:absolute after:inset-0 after:rounded-[12px]
-                after:content-['']"
+              // The ::after overlay is a full-cover decorative box; make it
+              // click-through so it doesn't sit above the label span and
+              // swallow hover/click on a Tooltip trigger inside a ReactNode
+              // label.
+              className="after:pointer-events-none after:absolute after:inset-0
+                after:rounded-[12px] after:content-['']"
             />
           </label>
 

--- a/src/components/textarea/Textarea.tsx
+++ b/src/components/textarea/Textarea.tsx
@@ -256,6 +256,15 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
                   top-[calc(var(--amino-font-size-base)+6px)] left-4
                   origin-top-left leading-none transition-all duration-300
                   ease-in-out`,
+                  // pointer-events-none lets clicks on the label text pass
+                  // through to the textarea beneath (so the cursor lands where
+                  // the user clicked). Interactive descendants — links,
+                  // buttons, and our Tooltip trigger — opt back in so a
+                  // ReactNode label like `<>Label <Tooltip>?</Tooltip></>`
+                  // still works.
+                  `[&_.tooltip-wrapper]:pointer-events-auto
+                  [&_a]:pointer-events-auto [&_button]:pointer-events-auto
+                  **:[[role=button]]:pointer-events-auto`,
                   (hasValue || isFocused) && 'top-[11px] scale-[0.8]',
                 )}
                 style={{ color: theme.gray800 }}

--- a/src/components/textarea/Textarea.tsx
+++ b/src/components/textarea/Textarea.tsx
@@ -43,7 +43,7 @@ type TextareaType = {
   /**
    * Label text to be displayed above the textarea
    */
-  label?: string;
+  label?: ReactNode;
   /**
    * A value (in px) that will determine how wide the input is
    * @default 100%

--- a/src/components/textarea/Textarea.tsx
+++ b/src/components/textarea/Textarea.tsx
@@ -262,7 +262,8 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
                   // ReactNode label like `<>Label <Tooltip>?</Tooltip></>`
                   // can still be hovered — Tooltip is the only interactive
                   // content we put in labels.
-                  '[&_.tooltip-wrapper]:pointer-events-auto',
+                  `[&_.tooltip-wrapper]:pointer-events-auto
+                  [&_.tooltip-wrapper]:cursor-help`,
                   (hasValue || isFocused) && 'top-[11px] scale-[0.8]',
                 )}
                 style={{ color: theme.gray800 }}

--- a/src/components/textarea/__stories__/Textarea.stories.tsx
+++ b/src/components/textarea/__stories__/Textarea.stories.tsx
@@ -7,6 +7,8 @@ import { Flex } from 'src/components/flex/Flex';
 import { Input } from 'src/components/input/Input';
 import { Text } from 'src/components/text/Text';
 import { Textarea, type TextareaProps } from 'src/components/textarea/Textarea';
+import { Tooltip } from 'src/components/tooltip/Tooltip';
+import { InfoIcon } from 'src/icons/InfoIcon';
 
 const TextAreaMeta: Meta = {
   component: Textarea,
@@ -306,4 +308,24 @@ ErrorState.args = {
   label: 'Description',
   placeholder: 'Please fill out the description',
   value: 'HS code for Brazil',
+};
+
+export const LabelWithTooltip: StoryFn<TextareaProps> = props => {
+  const [value, setValue] = useState('');
+  return (
+    <Textarea
+      {...props}
+      label={
+        <span className="inline-flex items-center gap-1 align-middle">
+          Description
+          <Tooltip title="Explain the item's purpose and any special handling.">
+            <InfoIcon color="gray600" inlineBlock size={14} />
+          </Tooltip>
+        </span>
+      }
+      onChange={e => setValue(e.target.value)}
+      placeholder="Please fill out the description"
+      value={value}
+    />
+  );
 };

--- a/src/components/textarea/__stories__/Textarea.stories.tsx
+++ b/src/components/textarea/__stories__/Textarea.stories.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 
 import type { Meta, StoryFn } from '@storybook/react';
+import { expect, userEvent, within } from '@storybook/test';
 
 import { Button } from 'src/components/button/Button';
 import { Flex } from 'src/components/flex/Flex';
@@ -308,6 +309,45 @@ ErrorState.args = {
   label: 'Description',
   placeholder: 'Please fill out the description',
   value: 'HS code for Brazil',
+};
+
+export const ClickPlacesCaret: StoryFn<TextareaProps> = props => {
+  const [value, setValue] = useState('HS code for Brazil');
+  return (
+    <Textarea
+      {...props}
+      label="Description"
+      onChange={e => setValue(e.target.value)}
+      value={value}
+    />
+  );
+};
+ClickPlacesCaret.tags = ['tested'];
+ClickPlacesCaret.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  const textarea = canvas.getByRole<HTMLTextAreaElement>('textbox');
+
+  // The decorative ::after overlay must be click-through: if it covers the
+  // field it becomes the click target, and the label's click handler then
+  // yanks the caret to the end of the value instead of leaving it where the
+  // user clicked.
+  const rect = textarea.getBoundingClientRect();
+  const hit = document.elementFromPoint(
+    rect.left + rect.width / 2,
+    rect.top + rect.height / 2,
+  );
+  expect(hit).toBe(textarea);
+
+  // Click what a real pointer would hit, then place the caret mid-text. If
+  // the overlay had captured the click, the label handler's deferred
+  // "move caret to end" would override this position on the next tick.
+  await userEvent.click(hit as HTMLElement);
+  textarea.setSelectionRange(7, 7);
+  await new Promise(resolve => {
+    setTimeout(resolve, 50);
+  });
+  expect(textarea.selectionStart).toBe(7);
+  expect(textarea.selectionStart).not.toBe(textarea.value.length);
 };
 
 export const LabelWithTooltip: StoryFn<TextareaProps> = props => {

--- a/src/utils/__tests__/getNodeText.test.ts
+++ b/src/utils/__tests__/getNodeText.test.ts
@@ -1,9 +1,9 @@
-import { createElement } from 'react';
+import { createElement, type ReactNode } from 'react';
 
 import { getNodeText } from 'src/utils/getNodeText';
 
 /** JSX is unavailable here — the suite only picks up `.test.ts` files. */
-const element = (type: string, ...children: unknown[]) =>
+const element = ({ type, children }: { type: string; children: ReactNode[] }) =>
   createElement(type, null, ...children);
 
 describe('getNodeText', () => {
@@ -19,12 +19,22 @@ describe('getNodeText', () => {
     expect(getNodeText(null)).toBeUndefined();
     expect(getNodeText(undefined)).toBeUndefined();
     expect(getNodeText(false)).toBeUndefined();
-    expect(getNodeText(element('span'))).toBeUndefined();
+    expect(
+      getNodeText(element({ type: 'span', children: [] })),
+    ).toBeUndefined();
   });
 
   it('recurses into element children so wrapped labels keep their text', () => {
     expect(
-      getNodeText(element('span', 'Genus ', element('em', '(required)'))),
+      getNodeText(
+        element({
+          type: 'span',
+          children: [
+            'Genus ',
+            element({ type: 'em', children: ['(required)'] }),
+          ],
+        }),
+      ),
     ).toBe('Genus (required)');
   });
 
@@ -39,16 +49,20 @@ describe('getNodeText', () => {
   it('distinguishes sibling controls whose labels differ deep in the tree', () => {
     // The property test ids depend on: two richly-labeled selects must not
     // collapse onto the same extracted string.
-    const industry = element(
-      'div',
-      element('strong', 'Industry'),
-      element('button', '?'),
-    );
-    const productGroup = element(
-      'div',
-      element('strong', 'Product group'),
-      element('button', '?'),
-    );
+    const industry = element({
+      type: 'div',
+      children: [
+        element({ type: 'strong', children: ['Industry'] }),
+        element({ type: 'button', children: ['?'] }),
+      ],
+    });
+    const productGroup = element({
+      type: 'div',
+      children: [
+        element({ type: 'strong', children: ['Product group'] }),
+        element({ type: 'button', children: ['?'] }),
+      ],
+    });
     expect(getNodeText(industry)).toBe('Industry ?');
     expect(getNodeText(productGroup)).toBe('Product group ?');
     expect(getNodeText(industry)).not.toBe(getNodeText(productGroup));

--- a/src/utils/__tests__/getNodeText.test.ts
+++ b/src/utils/__tests__/getNodeText.test.ts
@@ -1,0 +1,56 @@
+import { createElement } from 'react';
+
+import { getNodeText } from 'src/utils/getNodeText';
+
+/** JSX is unavailable here — the suite only picks up `.test.ts` files. */
+const element = (type: string, ...children: unknown[]) =>
+  createElement(type, null, ...children);
+
+describe('getNodeText', () => {
+  it('reads plain strings and numbers', () => {
+    expect(getNodeText('Country of origin')).toBe('Country of origin');
+    expect(getNodeText(0)).toBe('0');
+  });
+
+  it('treats nodes that render nothing as having no text', () => {
+    // An empty string must not extract as '' — callers rely on undefined to
+    // fall back to the component name.
+    expect(getNodeText('')).toBeUndefined();
+    expect(getNodeText(null)).toBeUndefined();
+    expect(getNodeText(undefined)).toBeUndefined();
+    expect(getNodeText(false)).toBeUndefined();
+    expect(getNodeText(element('span'))).toBeUndefined();
+  });
+
+  it('recurses into element children so wrapped labels keep their text', () => {
+    expect(
+      getNodeText(element('span', 'Genus ', element('em', '(required)'))),
+    ).toBe('Genus (required)');
+  });
+
+  it('skips non-rendering siblings instead of padding the text with gaps', () => {
+    // A conditional label part (`{isRequired && '*'}`) leaves `false` in the
+    // children array; naively joining would yield 'Genus  species'.
+    expect(getNodeText(['Genus', false, null, 'species'])).toBe(
+      'Genus species',
+    );
+  });
+
+  it('distinguishes sibling controls whose labels differ deep in the tree', () => {
+    // The property test ids depend on: two richly-labeled selects must not
+    // collapse onto the same extracted string.
+    const industry = element(
+      'div',
+      element('strong', 'Industry'),
+      element('button', '?'),
+    );
+    const productGroup = element(
+      'div',
+      element('strong', 'Product group'),
+      element('button', '?'),
+    );
+    expect(getNodeText(industry)).toBe('Industry ?');
+    expect(getNodeText(productGroup)).toBe('Product group ?');
+    expect(getNodeText(industry)).not.toBe(getNodeText(productGroup));
+  });
+});

--- a/src/utils/__tests__/getNodeText.test.ts
+++ b/src/utils/__tests__/getNodeText.test.ts
@@ -3,7 +3,7 @@ import { createElement, type ReactNode } from 'react';
 import { getNodeText } from 'src/utils/getNodeText';
 
 /** JSX is unavailable here — the suite only picks up `.test.ts` files. */
-const element = ({ type, children }: { type: string; children: ReactNode[] }) =>
+const element = ({ children, type }: { children: ReactNode[]; type: string }) =>
   createElement(type, null, ...children);
 
 describe('getNodeText', () => {
@@ -20,7 +20,7 @@ describe('getNodeText', () => {
     expect(getNodeText(undefined)).toBeUndefined();
     expect(getNodeText(false)).toBeUndefined();
     expect(
-      getNodeText(element({ type: 'span', children: [] })),
+      getNodeText(element({ children: [], type: 'span' })),
     ).toBeUndefined();
   });
 
@@ -28,11 +28,11 @@ describe('getNodeText', () => {
     expect(
       getNodeText(
         element({
-          type: 'span',
           children: [
             'Genus ',
-            element({ type: 'em', children: ['(required)'] }),
+            element({ children: ['(required)'], type: 'em' }),
           ],
+          type: 'span',
         }),
       ),
     ).toBe('Genus (required)');
@@ -50,18 +50,18 @@ describe('getNodeText', () => {
     // The property test ids depend on: two richly-labeled selects must not
     // collapse onto the same extracted string.
     const industry = element({
-      type: 'div',
       children: [
-        element({ type: 'strong', children: ['Industry'] }),
-        element({ type: 'button', children: ['?'] }),
+        element({ children: ['Industry'], type: 'strong' }),
+        element({ children: ['?'], type: 'button' }),
       ],
+      type: 'div',
     });
     const productGroup = element({
-      type: 'div',
       children: [
-        element({ type: 'strong', children: ['Product group'] }),
-        element({ type: 'button', children: ['?'] }),
+        element({ children: ['Product group'], type: 'strong' }),
+        element({ children: ['?'], type: 'button' }),
       ],
+      type: 'div',
     });
     expect(getNodeText(industry)).toBe('Industry ?');
     expect(getNodeText(productGroup)).toBe('Product group ?');

--- a/src/utils/__tests__/getNodeText.test.ts
+++ b/src/utils/__tests__/getNodeText.test.ts
@@ -22,6 +22,44 @@ describe('getNodeText', () => {
     expect(
       getNodeText(element({ children: [], type: 'span' })),
     ).toBeUndefined();
+    // Whitespace-only strings read as no text, not as '   '.
+    expect(getNodeText('   ')).toBeUndefined();
+  });
+
+  it('normalizes whitespace regardless of nesting', () => {
+    expect(getNodeText('  HS  code  ')).toBe('HS code');
+    expect(
+      getNodeText(element({ children: ['  HS  code  '], type: 'span' })),
+    ).toBe('HS code');
+  });
+
+  it('reads non-array iterables the same way React renders them', () => {
+    expect(getNodeText(new Set(['Genus', 'species']))).toBe('Genus species');
+  });
+
+  it('cannot read text a component renders from props', () => {
+    // `<Translate text="HS code" />` keeps its text in a prop, which is
+    // unreachable without rendering. Callers must not rely on extraction for
+    // component labels: test ids fall back to the component name, and
+    // accessible names come from the <label> association rather than an
+    // extracted aria-label.
+    const TranslateLike = ({ text }: { text: string }) => text;
+    expect(
+      getNodeText(createElement(TranslateLike, { text: 'HS code' })),
+    ).toBeUndefined();
+    // A component nested in markup contributes nothing — only the host text
+    // around it survives.
+    expect(
+      getNodeText(
+        element({
+          children: [
+            'HS code ',
+            createElement(TranslateLike, { text: '(optional)' }),
+          ],
+          type: 'span',
+        }),
+      ),
+    ).toBe('HS code');
   });
 
   it('recurses into element children so wrapped labels keep their text', () => {

--- a/src/utils/getNodeText.ts
+++ b/src/utils/getNodeText.ts
@@ -1,0 +1,36 @@
+import { isValidElement, type ReactNode } from 'react';
+
+/**
+ * Best-effort plain-text reading of a `ReactNode`.
+ *
+ * Label props accept arbitrary markup (an icon beside the text, a tooltip
+ * trigger, a translated fragment), but test ids and other string-only consumers
+ * still need something readable. Recursing into children keeps those ids
+ * meaningful — and distinct between sibling controls — instead of collapsing
+ * every richly-labeled control onto the same component-name fallback.
+ *
+ * Returns `undefined` when the node carries no readable text, which lets callers
+ * fall back the same way they do for an absent label.
+ */
+export const getNodeText = (node: unknown): string | undefined => {
+  if (typeof node === 'string') {
+    return node || undefined;
+  }
+  if (typeof node === 'number') {
+    return String(node);
+  }
+  if (Array.isArray(node)) {
+    const text = node
+      .map(getNodeText)
+      .filter(Boolean)
+      .join(' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+    return text || undefined;
+  }
+  // Booleans, null and undefined render nothing, so they read as no text.
+  if (isValidElement<{ children?: ReactNode }>(node)) {
+    return getNodeText(node.props.children);
+  }
+  return undefined;
+};

--- a/src/utils/getNodeText.ts
+++ b/src/utils/getNodeText.ts
@@ -1,5 +1,29 @@
 import { isValidElement, type ReactNode } from 'react';
 
+const extractText = (node: unknown): string => {
+  if (typeof node === 'string') {
+    return node;
+  }
+  if (typeof node === 'number') {
+    return String(node);
+  }
+  // Text living in other props (`<Translate text="…" />`) is unreachable
+  // without rendering the component, so a component element with no children
+  // reads as no text and callers fall back as if the label were absent.
+  if (isValidElement<{ children?: ReactNode }>(node)) {
+    return extractText(node.props.children);
+  }
+  // Arrays and other iterables (React renders both).
+  if (typeof node === 'object' && node !== null && Symbol.iterator in node) {
+    return Array.from(node as Iterable<unknown>)
+      .map(extractText)
+      .filter(Boolean)
+      .join(' ');
+  }
+  // Booleans, null and undefined render nothing, so they read as no text.
+  return '';
+};
+
 /**
  * Best-effort plain-text reading of a `ReactNode`.
  *
@@ -9,28 +33,13 @@ import { isValidElement, type ReactNode } from 'react';
  * meaningful — and distinct between sibling controls — instead of collapsing
  * every richly-labeled control onto the same component-name fallback.
  *
- * Returns `undefined` when the node carries no readable text, which lets callers
- * fall back the same way they do for an absent label.
+ * Only host content is readable: a component element that renders its text
+ * from props (`<Translate text="…" />`) reads as no text here.
+ *
+ * Returns `undefined` when the node carries no readable text, which lets
+ * callers fall back the same way they do for an absent label.
  */
 export const getNodeText = (node: unknown): string | undefined => {
-  if (typeof node === 'string') {
-    return node || undefined;
-  }
-  if (typeof node === 'number') {
-    return String(node);
-  }
-  if (Array.isArray(node)) {
-    const text = node
-      .map(getNodeText)
-      .filter(Boolean)
-      .join(' ')
-      .replace(/\s+/g, ' ')
-      .trim();
-    return text || undefined;
-  }
-  // Booleans, null and undefined render nothing, so they read as no text.
-  if (isValidElement<{ children?: ReactNode }>(node)) {
-    return getNodeText(node.props.children);
-  }
-  return undefined;
+  const text = extractText(node).replace(/\s+/g, ' ').trim();
+  return text || undefined;
 };

--- a/svgReact/build-utils/__tests__/transformSvgContent.test.ts
+++ b/svgReact/build-utils/__tests__/transformSvgContent.test.ts
@@ -2,6 +2,14 @@ import { formatTS } from 'build-utils/css/utils/formatTS';
 import { generateComponentContent } from 'svgReact/flags/createReactFlagSvgs';
 
 describe('Transforming SVG content', () => {
+  // Prettier's TypeScript parser + config resolution are lazy — the first
+  // `formatTS` call runs ~5s cold, subsequent calls run in <1s. Warm it up
+  // here so the first snapshot test doesn't race the 5s testTimeout; the
+  // cost lives in the (much larger) hookTimeout instead.
+  beforeAll(async () => {
+    await formatTS('');
+  }, 20000);
+
   test('CN.svg (mask xlink:href)', async () => {
     const componentName = 'CN';
     const fileContent = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 640 480"><defs><path id="a" fill="#ffde00" d="M-.6.8 0-1 .6.8-1-.3h2z"/></defs><path fill="#de2910" d="M0 0h640v480H0z"/><use xlink:href="#a" width="30" height="20" transform="matrix(71.9991 0 0 72 120 120)"/><use xlink:href="#a" width="30" height="20" transform="matrix(-12.33562 -20.5871 20.58684 -12.33577 240.3 48)"/><use xlink:href="#a" width="30" height="20" transform="matrix(-3.38573 -23.75998 23.75968 -3.38578 288 95.8)"/><use xlink:href="#a" width="30" height="20" transform="matrix(6.5991 -23.0749 23.0746 6.59919 288 168)"/><use xlink:href="#a" width="30" height="20" transform="matrix(14.9991 -18.73557 18.73533 14.99929 240 216)"/></svg>`;


### PR DESCRIPTION
Label props were typed `string`, so a label could only ever be plain text. Anything richer — an info-tooltip trigger beside the prompt, a translated fragment, a required marker — had to bypass the prop entirely and be rendered by the consumer above the control, which loses the label/input association the component sets up and forces a wrapper component per call site.

Widen `label` to `ReactNode` on the form controls (Input, InputSimple, Textarea, Checkbox, Select, MultiSelect, CountrySelect, CountryMultiSelect) and `Tabs.items` to `ReactNode[]`. Widening is backward compatible: every existing string label still type-checks.

Two internal consumers needed a string and drove the shape of this change:

- Nine input variants passed `label` straight into `aria-label`, which only accepts a string.
- `getTestId({ name: label })` builds test ids from the label text.

For accessible names, extraction turned out to be the wrong tool (thanks @Gamerweazel): `aria-label` overrides the `<label>` association, so an extracted name could silently truncate the visible one, and a component label that renders its text from props (`<Translate text="…" />`) extracts as nothing at all. Instead, `aria-label` is now only set when the label is a plain string (identical to pre-widening behavior), and markup or component labels get their name from the `<label>` element's rendered text. The InputSimple family's `<label>` gains an `htmlFor` association to support this — previously `aria-label` was its only name source.

Test ids still go through `getNodeText`, which recursively reads the host text out of a node — this keeps ids distinct between sibling controls labeled with markup (`<span>HS code <Tooltip>?</Tooltip></span>` → `amino--hs-code--`). Known limitation, documented and tested: a component label's text lives in props and can't be extracted without rendering, so those fall back to the component name (`amino--input`). Where distinct test ids matter, pass a string label; an explicit `testId` prop (as on Button) is the escape hatch to add if that constraint bites.

Tabs additionally had to stop identifying items by value. It used `items.indexOf(item)` for selection and `key={item}`, so two tabs sharing a label both rendered as selected and both reported the first tab's index on click. Tabs are positional — `selected` and `onChange` are indexes — so the map index is the correct identity, and ReactNode items made the old approach untypeable anyway.

A follow-up pass fixes three interaction bugs the widening surfaced. Input's floating-label wrapper, Textarea's floating-label span, and Checkbox's visual row all set `pointer-events-none` (with a `[&_*]:pointer-events-none` wildcard in Checkbox's case) so clicks pass through to the underlying control. Hover events are pointer events too, so a Tooltip trigger inside a `ReactNode` label never received `mouseenter` and the tooltip never opened. Input and Textarea additionally have a full-cover `::after` overlay on a sibling div that sits above the label span in stacking order and captures hover before it reaches the trigger. Fixed by narrowly opting `.tooltip-wrapper` back into pointer events on the three affected wrappers (with `cursor: help` so the trigger doesn't read as part of the control), and by making the decorative overlays click-through by default. Tooltip is the only interactive content we put in a label, so no broader `a` / `button` / `[role=button]` opt-in is needed.

Disabled Input's not-allowed cursor now lives on the label wrapper rather than the overlay's `::after`. The previous `.disabled_&:after:*` classes used a non-compiling Tailwind form and never emitted CSS, and the literal syntax fix would have re-broken tooltip hover in the disabled state — a click-through pseudo is never hit-tested, so its cursor never shows anyway. The wrapper already re-enables pointer events when disabled, so it's the element the cursor can actually land on.

Making Textarea's overlay click-through also changes click behavior for **every labelled Textarea**, not just tooltip labels: the overlay used to be the click target for any click inside the field, so the label's click handler moved the caret to the end of the value no matter where you clicked, and drag-to-select was swallowed. Clicks now reach the textarea and the caret stays where the user clicked — which is what that handler's own comment says it intends. The `ClickPlacesCaret` play test pins both the hit-test (the overlay must not be the element under the pointer) and the caret staying put.

Clicking a tooltip trigger inside a `Checkbox` label still toggles the box — the whole row is a `<label htmlFor>`, and a non-interactive trigger doesn't stop label activation. That's now documented on the `label` prop; making the trigger focusable/`aria-describedby`-wired (it's currently mouse-only) and making open tooltip content click-through are Tooltip-level follow-ups.

## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->

## Description

Every widened control gets a new `LabelWithTooltip` story (or `ItemsWithTooltip` on Tabs) so the label + tooltip alignment can be reviewed visually across the different label rendering styles (static labels, floating labels, positional tab items). Storybook preview:

https://amino-git-feat-reactnode-labels-zonos.vercel.app/?path=/story/amino-checkbox--checkbox-with-tooltip-label

## Todo

- [ ] Bump version and add tag

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared form primitives (a11y naming, pointer events, tab selection) across many components; behavior changes for all labelled Textareas (caret on click), not only tooltip labels.
> 
> **Overview**
> **Form controls can now take rich `ReactNode` labels** (e.g. text plus a `Tooltip` info icon) on Checkbox, Input / InputSimple / Textarea, Select family, and `Tabs.items`, while existing string labels stay valid. Package version goes to **6.0.5**.
> 
> **Accessibility:** Markup labels no longer get a copied `aria-label` from the label prop; names come from the associated `<label>` (and `InputBase` gains `htmlFor` / `id`). `aria-label` is only set when the label is still a plain string.
> 
> **`getNodeText`** is added and wired into `getTestId` (and Select’s multi-value error message) so extracted host text drives stable test ids instead of `[object Object]`.
> 
> **Interaction fixes** for tooltip-in-label: decorative overlays and label wrappers use click-through `pointer-events`, with `.tooltip-wrapper` opted back in on Checkbox, float-label Input, and Textarea; **Tabs** selection uses map index instead of `indexOf` on item content. Storybook adds `LabelWithTooltip` / `ItemsWithTooltip` examples; Textarea gets a play test for caret placement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aef3d237aa1739d327030e996a0e40798dd41c89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


