### PR TITLE
fix(ci): pin publish workflow to npm 11

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,8 +21,10 @@ jobs:
           node-version: 22.22.1
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
-      # Ensure npm 11.5.1 or later for trusted publishing
-      - run: npm install -g npm@latest
+      # Trusted publishing needs npm >= 11.5.1, but stay on the npm 11 line:
+      # npm 12 requires node >= 22.22.2, whose bundled npm is broken (see the
+      # node-version pin above), so `npm@latest` can no longer install here.
+      - run: npm install -g npm@11
       - run: pnpm install
       - run: pnpm build:ci
       - run: cd dist && npm publish --access public


### PR DESCRIPTION
The 6.0.5 publish failed on `npm install -g npm@latest`:

```
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.9.4","node":"v22.22.1"}
```

npm@latest became npm 12, which requires node >= 22.22.2 — but the workflow deliberately pins node 22.22.1 because 22.22.2's bundled npm is broken (missing promise-retry). So `latest` can never install on the pinned node again.

Trusted publishing only needs npm >= 11.5.1, and the npm 11 line supports node 22.22.1, so pin to `npm@11`. Merging this re-triggers the publish workflow on main, which will publish the pending 6.0.5.

Once node ships a 22.x/24.x with a working bundled npm, the node pin and this npm pin can both be revisited together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to the npm global install step; no application or runtime behavior changes.
> 
> **Overview**
> Fixes the **main publish workflow** by replacing `npm install -g npm@latest` with **`npm install -g npm@11`**, with comments explaining why.
> 
> **npm@latest** is now npm 12, which requires Node **≥ 22.22.2**, but the job stays on **22.22.1** because 22.22.2’s bundled npm is broken. Trusted publishing still only needs npm **≥ 11.5.1**, which the npm 11 line satisfies on the pinned Node version—so publish (e.g. pending **6.0.5**) can run again after merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09db0e2412a73541cfbfba4af24a8b2a4d9967bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->